### PR TITLE
rename main branch to master

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
         echo 'Publishing...'
         git config user.name "iTwinViewerWorkflow"
         git config user.email "itwinviewer@users.noreply.github.com"
-        node common/scripts/install-run-rush.js version --bump --target-branch main
-        node common/scripts/install-run-rush.js publish --include-all --set-access-level public --apply --publish --npm-auth-token $NPM_TOKEN --target-branch main --suffix alpha
+        node common/scripts/install-run-rush.js version --bump --target-branch master
+        node common/scripts/install-run-rush.js publish --include-all --set-access-level public --apply --publish --npm-auth-token $NPM_TOKEN --target-branch master --suffix alpha
       env:
         NPM_TOKEN: ${{ secrets.NPMJS_PUBLISH_ITWIN }}


### PR DESCRIPTION
most rush commands hardcode origin/master as the default name. This should help us to avoid having to add additional args to rush change, for example