### PR TITLE
desktop cra 1.0

### DIFF
--- a/common/changes/@itwin/cra-template-desktop-viewer/feat-desktop-cra-1.0_2021-06-30-19-11.json
+++ b/common/changes/@itwin/cra-template-desktop-viewer/feat-desktop-cra-1.0_2021-06-30-19-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/cra-template-desktop-viewer",
+      "comment": "update deps and browserlist, bump to 1.0",
+      "type": "major"
+    }
+  ],
+  "packageName": "@itwin/cra-template-desktop-viewer",
+  "email": "6283674+kckst8@users.noreply.github.com"
+}

--- a/packages/apps/desktop-viewer-test/package.json
+++ b/packages/apps/desktop-viewer-test/package.json
@@ -29,7 +29,7 @@
     "pseudolocalize": "betools pseudolocalize --englishDir ./public/locales/en --out ./public/locales/en-PSEUDO"
   },
   "browserslist": [
-    "electron 10.0.0"
+    "electron 8.0.0"
   ],
   "dependencies": {
     "@bentley/backend-itwin-client": "^2.14.0",

--- a/packages/modules/cra-template-desktop-viewer/README.md
+++ b/packages/modules/cra-template-desktop-viewer/README.md
@@ -1,7 +1,5 @@
 # iTwin Viewer Create React App Template for Desktop
 
-Consider this package as unstable until 1.0 release.
-
 This is a template for desktop applications that are based on [Electron](https://www.electronjs.org/) and the [iTwin Viewer](https://github.com/itwin/viewer/tree/main/packages/modules/desktop-viewer-react) for [Create React App](https://github.com/facebook/create-react-app).
 
 To use this template, add `--template @itwin/desktop-viewer` when creating a new app. You should also use the @bentley/react-scripts scripts version to compile your application.

--- a/packages/modules/cra-template-desktop-viewer/template.json
+++ b/packages/modules/cra-template-desktop-viewer/template.json
@@ -35,7 +35,7 @@
       "@bentley/ui-framework": "^2.14.0",
       "@bentley/ui-ninezone": "^2.14.0",
       "@bentley/webgl-compatibility": "^2.14.0",
-      "@itwin/desktop-viewer-react": "^1.0.0",
+      "@itwin/desktop-viewer-react": "^1.0.1",
       "@reduxjs/toolkit": "^1.6.0",
       "@types/electron-devtools-installer": "^2.2.0",
       "@types/minimist": "^1.2.0",
@@ -65,7 +65,7 @@
       "pseudolocalize": "betools pseudolocalize --englishDir ./public/locales/en --out ./public/locales/en-PSEUDO"
     },
     "browserslist": [
-      "electron 10.0.0"
+      "electron 8.0.0"
     ]
   }
 }


### PR DESCRIPTION
- Fix browserslist. 8.0.0 is the highest electron goes (its what core uses)
- upgrade desktop viewer to 1.0.1
- Remove prerelease text