### PR TITLE
Fix default view configuration

### DIFF
--- a/common/changes/@itwin/viewer-react/maint-view-options_2021-07-15-16-08.json
+++ b/common/changes/@itwin/viewer-react/maint-view-options_2021-07-15-16-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/viewer-react",
+      "comment": "Fix view configuration and add the ability to customize the view",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@itwin/viewer-react",
+  "email": "6283674+kckst8@users.noreply.github.com"
+}

--- a/packages/apps/web-viewer-test/src/components/home/AuthConfigHome.tsx
+++ b/packages/apps/web-viewer-test/src/components/home/AuthConfigHome.tsx
@@ -113,15 +113,10 @@ export const AuthConfigHome: React.FC = () => {
       });
     };
 
-    tileTreesLoaded()
-      .then(() => {
-        IModelApp.tools.run(FitViewTool.toolId, viewPort, true);
-        viewPort.view.setStandardRotation(StandardViewId.Iso);
-      })
-      .catch(() => {
-        IModelApp.tools.run(FitViewTool.toolId, viewPort, true);
-        viewPort.view.setStandardRotation(StandardViewId.Iso);
-      });
+    tileTreesLoaded().finally(() => {
+      IModelApp.tools.run(FitViewTool.toolId, viewPort, true);
+      viewPort.view.setStandardRotation(StandardViewId.Iso);
+    });
   };
 
   return (

--- a/packages/apps/web-viewer-test/src/components/home/AuthConfigHome.tsx
+++ b/packages/apps/web-viewer-test/src/components/home/AuthConfigHome.tsx
@@ -4,7 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { BrowserAuthorizationClientConfiguration } from "@bentley/frontend-authorization-client";
-import { IModelApp } from "@bentley/imodeljs-frontend";
+import {
+  FitViewTool,
+  IModelApp,
+  ScreenViewport,
+  StandardViewId,
+} from "@bentley/imodeljs-frontend";
 import { ColorTheme } from "@bentley/ui-framework";
 import { Viewer } from "@itwin/web-viewer-react";
 import React, { useEffect, useState } from "react";
@@ -89,6 +94,36 @@ export const AuthConfigHome: React.FC = () => {
     }
   };
 
+  const viewConfiguration = (viewPort: ScreenViewport) => {
+    // default execute the fitview tool and use the iso standard view after tile trees are loaded
+    const tileTreesLoaded = () => {
+      return new Promise((resolve, reject) => {
+        const start = new Date();
+        const intvl = setInterval(() => {
+          if (viewPort.areAllTileTreesLoaded) {
+            clearInterval(intvl);
+            resolve(true);
+          }
+          const now = new Date();
+          // after 20 seconds, stop waiting and fit the view
+          if (now.getTime() - start.getTime() > 20000) {
+            reject();
+          }
+        }, 100);
+      });
+    };
+
+    tileTreesLoaded()
+      .then(() => {
+        IModelApp.tools.run(FitViewTool.toolId, viewPort, true);
+        viewPort.view.setStandardRotation(StandardViewId.Iso);
+      })
+      .catch(() => {
+        IModelApp.tools.run(FitViewTool.toolId, viewPort, true);
+        viewPort.view.setStandardRotation(StandardViewId.Iso);
+      });
+  };
+
   return (
     <div className={styles.home}>
       <Header
@@ -103,6 +138,7 @@ export const AuthConfigHome: React.FC = () => {
         appInsightsKey={process.env.IMJS_APPLICATION_INSIGHTS_KEY}
         theme={ColorTheme.Dark}
         onIModelAppInit={onIModelAppInit}
+        viewCreatorOptions={{ viewportConfigurer: viewConfiguration }}
       />
     </div>
   );

--- a/packages/modules/viewer-react/src/components/iModel/IModelLoader.tsx
+++ b/packages/modules/viewer-react/src/components/iModel/IModelLoader.tsx
@@ -12,7 +12,6 @@ import {
   IModelApp,
   IModelConnection,
   SnapshotConnection,
-  ViewCreator3dOptions,
   ViewState,
 } from "@bentley/imodeljs-frontend";
 import {
@@ -37,6 +36,7 @@ import { ai } from "../../services/telemetry/TelemetryService";
 import {
   BlankConnectionViewState,
   IModelLoaderParams,
+  ViewCreator3dOptions,
   ViewerBackstageItem,
   ViewerFrontstage,
 } from "../../types";

--- a/packages/modules/viewer-react/src/services/iModel/ViewCreator3d.ts
+++ b/packages/modules/viewer-react/src/services/iModel/ViewCreator3d.ts
@@ -126,19 +126,12 @@ export class ViewCreator3d {
         });
       };
 
-      tileTreesLoaded()
-        .then(() => {
-          IModelApp.tools.run(FitViewTool.toolId, viewPort, true);
-          viewPort.view.setStandardRotation(
-            options?.standardViewId ?? StandardViewId.Iso
-          );
-        })
-        .catch(() => {
-          IModelApp.tools.run(FitViewTool.toolId, viewPort, true);
-          viewPort.view.setStandardRotation(
-            options?.standardViewId ?? StandardViewId.Iso
-          );
-        });
+      tileTreesLoaded().finally(() => {
+        IModelApp.tools.run(FitViewTool.toolId, viewPort, true);
+        viewPort.view.setStandardRotation(
+          options?.standardViewId ?? StandardViewId.Iso
+        );
+      });
     });
 
     return viewState;
@@ -348,7 +341,7 @@ export class ViewCreator3d {
    */
   private async _getAllModels(): Promise<Id64Array> {
     let query =
-      "SELECT ECInstanceId FROM Bis.GeometricModel3D WHERE IsPrivate = false AND IsTemplate = false AND isNotSpatiallyLocated = false";
+      "SELECT ECInstanceId FROM Bis.GeometricModel3D WHERE IsPrivate = false AND IsTemplate = false AND (isNotSpatiallyLocated = false OR isNotSpatiallyLocated IS NULL)";
     let models = [];
     try {
       models = await this._executeQuery(query);

--- a/packages/modules/viewer-react/src/types.ts
+++ b/packages/modules/viewer-react/src/types.ts
@@ -12,9 +12,10 @@ import {
 } from "@bentley/imodeljs-common";
 import {
   IModelConnection,
+  ScreenViewport,
+  StandardViewId,
   ToolAdmin,
   ViewChangeOptions,
-  ViewCreator3dOptions,
 } from "@bentley/imodeljs-frontend";
 import { BackstageItem, UiItemsProvider } from "@bentley/ui-abstract";
 import {
@@ -23,6 +24,24 @@ import {
   FrontstageProvider,
   IModelViewportControlOptions,
 } from "@bentley/ui-framework";
+
+/**
+ * options for configuration of 3D view
+ */
+export interface ViewCreator3dOptions {
+  /** Turn [[Camera]] on when generating the view. */
+  cameraOn?: boolean;
+  /** Turn [[SkyBox]] on when generating the view. */
+  skyboxOn?: boolean;
+  /** [[StandardViewId]] for the view state. */
+  standardViewId?: StandardViewId;
+  /** Merge in props from the seed view (default spatial view) of the iModel.  */
+  useSeedView?: boolean;
+  /** Aspect ratio of [[Viewport]]. Required to fit contents of the model(s) in the initial state of the view. */
+  vpAspect?: number;
+  /** optional function to configure the viewport on load */
+  viewportConfigurer?: (viewport: ScreenViewport) => void;
+}
 
 export interface ViewerFrontstage {
   /** frontstage provider to register */


### PR DESCRIPTION
1) Allow for a custom function to be executed on the viewPort
2) Failing that, if the model has a default view configured, honor it
3) Failing that, execute the fit to view tool

NOTES:
1) This will diverge our view creator from the core version, but I believe it is needed. I will investigate with the core owners if we should port these changes there.
2) If/when this is merged and published, I will update the CRA templates to use a custom viewportConfigurer function that executes the fitview tool with a comment that it can be removed to honor default views. I think fitview provides the best view of all of the models that I tested, so it should still be the default, but this will allow consumers to easily delete a few lines if they want to honor default views instead