### PR TITLE
Change type of WebAuthorizationOptions.oidcClient to FrontendAuthorizationClient

### DIFF
--- a/common/changes/@itwin/viewer-react/fix-proxy_2021-08-02-18-31.json
+++ b/common/changes/@itwin/viewer-react/fix-proxy_2021-08-02-18-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/viewer-react",
+      "comment": "remove internal ITwinViewerParams interface from base and promote it to the web-viewer pkg",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/viewer-react",
+  "email": "aruniverse@users.noreply.github.com"
+}

--- a/common/changes/@itwin/web-viewer-react/fix-proxy_2021-07-29-23-05.json
+++ b/common/changes/@itwin/web-viewer-react/fix-proxy_2021-07-29-23-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/web-viewer-react",
+      "comment": "change type of WebAuthorizationOptions.oidcClient to FrontendAuthorizationClient",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@itwin/web-viewer-react",
+  "email": "aruniverse@users.noreply.github.com"
+}

--- a/common/changes/@itwin/web-viewer-react/fix-proxy_2021-07-29-23-28.json
+++ b/common/changes/@itwin/web-viewer-react/fix-proxy_2021-07-29-23-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/web-viewer-react",
+      "comment": "export types from web-viewer-react pkg",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@itwin/web-viewer-react",
+  "email": "aruniverse@users.noreply.github.com"
+}

--- a/packages/modules/viewer-react/src/types.ts
+++ b/packages/modules/viewer-react/src/types.ts
@@ -56,14 +56,6 @@ export type ViewerBackstageItem = BackstageItem & {
   labeli18nKey?: string;
 };
 
-/**
- * iTwin Viewer parameter list
- */
-export interface ItwinViewerParams extends ItwinViewerCommonParams {
-  /** id of the html element where the viewer should be rendered */
-  elementId: string;
-}
-
 export interface IModelLoaderParams {
   /** color theme */
   theme?: ColorTheme | string;

--- a/packages/modules/web-viewer-react/src/index.ts
+++ b/packages/modules/web-viewer-react/src/index.ts
@@ -7,3 +7,4 @@ export * from "@itwin/viewer-react";
 export * from "./components/Viewer";
 export * from "./components/BlankViewer";
 export * from "./services/ItwinViewer";
+export * from "./types";

--- a/packages/modules/web-viewer-react/src/services/ItwinViewer.ts
+++ b/packages/modules/web-viewer-react/src/services/ItwinViewer.ts
@@ -17,7 +17,7 @@ import ReactDOM from "react-dom";
 import { ViewerFrontstage } from "..";
 import { Viewer } from "../components/Viewer";
 import {
-  ItwinViewerParams,
+  ItwinWebViewerParams,
   WebAuthorizationOptions,
   WebViewerProps,
 } from "../types";
@@ -42,7 +42,7 @@ export class ItwinViewer {
 
   onIModelConnected: ((iModel: CheckpointConnection) => void) | undefined;
 
-  constructor(options: ItwinViewerParams) {
+  constructor(options: ItwinWebViewerParams) {
     if (!options.elementId) {
       //TODO localize
       throw new Error("Please supply a root elementId as the first parameter"); //TODO localize

--- a/packages/modules/web-viewer-react/src/services/ItwinViewer.ts
+++ b/packages/modules/web-viewer-react/src/services/ItwinViewer.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { CheckpointConnection, IModelApp } from "@bentley/imodeljs-frontend";
+import { CheckpointConnection } from "@bentley/imodeljs-frontend";
 import { UiItemsProvider } from "@bentley/ui-abstract";
 import {
   ColorTheme,

--- a/packages/modules/web-viewer-react/src/services/ItwinViewer.ts
+++ b/packages/modules/web-viewer-react/src/services/ItwinViewer.ts
@@ -17,7 +17,7 @@ import ReactDOM from "react-dom";
 import { ViewerFrontstage } from "..";
 import { Viewer } from "../components/Viewer";
 import {
-  ItwinWebViewerParams,
+  ItwinViewerParams,
   WebAuthorizationOptions,
   WebViewerProps,
 } from "../types";
@@ -42,7 +42,7 @@ export class ItwinViewer {
 
   onIModelConnected: ((iModel: CheckpointConnection) => void) | undefined;
 
-  constructor(options: ItwinWebViewerParams) {
+  constructor(options: ItwinViewerParams) {
     if (!options.elementId) {
       //TODO localize
       throw new Error("Please supply a root elementId as the first parameter"); //TODO localize

--- a/packages/modules/web-viewer-react/src/types.ts
+++ b/packages/modules/web-viewer-react/src/types.ts
@@ -13,7 +13,7 @@ import {
 } from "@bentley/imodeljs-common";
 import {
   BlankViewerProps,
-  ItwinViewerParams,
+  ItwinViewerCommonParams,
   ViewerProps,
 } from "@itwin/viewer-react";
 import { UserManager } from "oidc-client";
@@ -81,7 +81,9 @@ export interface WebBlankViewerProps extends BlankViewerProps {
   authConfig: WebAuthorizationOptions;
 }
 
-export interface ItwinWebViewerParams extends ItwinViewerParams {
+export interface ItwinViewerParams extends ItwinViewerCommonParams {
+  /** id of the html element where the viewer should be rendered */
+  elementId: string;
   /** routing token for rpcs */
   rpcRoutingToken?: RpcRoutingToken;
   /** authorization configuration */

--- a/packages/modules/web-viewer-react/src/types.ts
+++ b/packages/modules/web-viewer-react/src/types.ts
@@ -13,7 +13,7 @@ import {
 } from "@bentley/imodeljs-common";
 import {
   BlankViewerProps,
-  ItwinViewerCommonParams,
+  ItwinViewerParams,
   ViewerProps,
 } from "@itwin/viewer-react";
 import { UserManager } from "oidc-client";
@@ -81,9 +81,7 @@ export interface WebBlankViewerProps extends BlankViewerProps {
   authConfig: WebAuthorizationOptions;
 }
 
-export interface ItwinViewerParams extends ItwinViewerCommonParams {
-  /** id of the html element where the viewer should be rendered */
-  elementId: string;
+export interface ItwinWebViewerParams extends ItwinViewerParams {
   /** routing token for rpcs */
   rpcRoutingToken?: RpcRoutingToken;
   /** authorization configuration */

--- a/packages/modules/web-viewer-react/src/types.ts
+++ b/packages/modules/web-viewer-react/src/types.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import {
-  BrowserAuthorizationClient,
   BrowserAuthorizationClientConfiguration,
+  FrontendAuthorizationClient,
 } from "@bentley/frontend-authorization-client";
 import {
   BentleyCloudRpcParams,
@@ -23,7 +23,7 @@ import { UserManager } from "oidc-client";
  */
 export interface WebAuthorizationOptions {
   /** provide an existing iTwin.js authorization client */
-  oidcClient?: BrowserAuthorizationClient;
+  oidcClient?: FrontendAuthorizationClient;
   /** provide configuration for an oidc client to be managed within the Viewer */
   config?: BrowserAuthorizationClientConfiguration;
   /** reference to a function that returns a pre-configured oidc UserManager */


### PR DESCRIPTION
Change type of WebAuthorizationOptions.oidcClient to [FrontendAuthorizationClient](https://www.itwinjs.org/reference/frontend-authorization-client/authorization/frontendauthorizationclient/). 

A weaker type than the previously used [BrowserAuthorizationClient](https://www.itwinjs.org/reference/frontend-authorization-client/browserauthorization/browserauthorizationclient/) but this is the same type as [IModelApp.authorizationClient](https://www.itwinjs.org/reference/imodeljs-frontend/imodelapp/imodelappoptions/)

This change is being done to accommodate the proxy-viewer use case, but this should also make it much easier for users to switch from the deprecated bentley/itwin-viewer-react package to this one.

A larger discussion needs to be had regarding auth configurations for the viewer; because technically a valid config a user can pass into the viewer is an empty object, but that won't do much and you'll see the newly added "please sign in". For a case like this where you're proxying requests for the visualization apis like gpb then you really shouldn't need an auth client at all on the frontend wrt to the viewer.

Also export types from web-viewer-react pkg.