### PR TITLE
fixed the height of the viewer when app insights are on

### DIFF
--- a/common/changes/@itwin/viewer-react/appInsightsBug_2021-07-30-14-36.json
+++ b/common/changes/@itwin/viewer-react/appInsightsBug_2021-07-30-14-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/viewer-react",
+      "comment": "Fixed bug with the height of the viewer when app insights were on",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/viewer-react",
+  "email": "48142512+spap975@users.noreply.github.com"
+}

--- a/packages/modules/viewer-react/src/components/iModel/IModelLoader.scss
+++ b/packages/modules/viewer-react/src/components/iModel/IModelLoader.scss
@@ -2,6 +2,7 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
+
 .itwin-viewer-container {
   height: 100%;
 }
@@ -11,4 +12,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.tracked-loader {
+  height: 100%;
 }

--- a/packages/modules/viewer-react/src/components/iModel/IModelLoader.tsx
+++ b/packages/modules/viewer-react/src/components/iModel/IModelLoader.tsx
@@ -341,7 +341,12 @@ const Loader: React.FC<ModelLoaderProps> = React.memo(
   }
 );
 
-const TrackedLoader = withAITracking(ai.reactPlugin, Loader, "IModelLoader");
+const TrackedLoader = withAITracking(
+  ai.reactPlugin,
+  Loader,
+  "IModelLoader",
+  "tracked-loader"
+);
 
 const IModelLoader: React.FC<ModelLoaderProps> = (props: ModelLoaderProps) => {
   if (props.appInsightsKey) {


### PR DESCRIPTION
Previously, when including a value for app insights in the .env file, the height of the viewer would shrink.
![image](https://user-images.githubusercontent.com/48142512/127664849-51b7d7f0-a8c2-4c27-8785-7141c8e5dc81.png)
To fix this, I simply added a class name to the div that was giving us trouble and styled it to have a height of 100%.
![image](https://user-images.githubusercontent.com/48142512/127665059-0f8bd9c8-d3d2-457e-a299-5717a9aa6268.png)
