### PR TITLE
update supported node ver of  monorepo to same as core

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -2,7 +2,7 @@
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush.schema.json",
   "rushVersion": "5.28.0",
   "pnpmVersion": "4.12.5",
-  "nodeSupportedVersionRange": ">=10.13.0 <13.0.0",
+  "nodeSupportedVersionRange": ">=12.17.0 <15.0.0",
   "projectFolderMinDepth": 2,
   "projectFolderMaxDepth": 3,
   "repository": {


### PR DESCRIPTION
As of imjs 2.19, we officially support 14.x. Bump supported node ver in viewer monorepo to match core