### PR TITLE
proxy ipc calls to make it easier to add new ones

### DIFF
--- a/common/changes/@itwin/cra-template-desktop-viewer/proxy-ipc_2021-08-16-14-59.json
+++ b/common/changes/@itwin/cra-template-desktop-viewer/proxy-ipc_2021-08-16-14-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/cra-template-desktop-viewer",
+      "comment": "proxy frontend ipc calls to remove some boilerplate for defining new ipc calls",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@itwin/cra-template-desktop-viewer",
+  "email": "MichaelBelousov@users.noreply.github.com"
+}

--- a/common/scripts/.eslintrc.ts.base.json
+++ b/common/scripts/.eslintrc.ts.base.json
@@ -32,6 +32,7 @@
     "react/display-name": "off",
     "react/prop-types": "off",
     "@typescript-eslint/interface-name-prefix": "off",
-    "no-unused-vars": [1, { "ignoreRestSiblings": true }]
+    "no-unused-vars": 0,
+    "@typescript-eslint/no-unused-vars": [1, { "ignoreRestSiblings": true }]
   }
 }

--- a/packages/apps/desktop-viewer-test/src/common/ViewerConfig.ts
+++ b/packages/apps/desktop-viewer-test/src/common/ViewerConfig.ts
@@ -10,13 +10,15 @@ import {
   SnapshotIModelRpcInterface,
 } from "@bentley/imodeljs-common";
 import { PresentationRpcInterface } from "@bentley/presentation-common";
-import { OpenDialogReturnValue } from "electron";
+import type Electron from "electron";
 
 export const channelName = iTwinChannel("desktop-viewer");
 
 export interface ViewerIpc {
   getConfig: () => Promise<ViewerConfig>;
-  openFile: (options: any) => Promise<OpenDialogReturnValue>;
+  openFile: (
+    options: Electron.OpenDialogOptions
+  ) => Promise<Electron.OpenDialogReturnValue>;
 }
 
 export interface ViewerConfig {

--- a/packages/apps/desktop-viewer-test/src/common/ViewerConfig.ts
+++ b/packages/apps/desktop-viewer-test/src/common/ViewerConfig.ts
@@ -10,15 +10,13 @@ import {
   SnapshotIModelRpcInterface,
 } from "@bentley/imodeljs-common";
 import { PresentationRpcInterface } from "@bentley/presentation-common";
-import type Electron from "electron";
+import type { OpenDialogOptions, OpenDialogReturnValue } from "electron";
 
 export const channelName = iTwinChannel("desktop-viewer");
 
 export interface ViewerIpc {
   getConfig: () => Promise<ViewerConfig>;
-  openFile: (
-    options: Electron.OpenDialogOptions
-  ) => Promise<Electron.OpenDialogReturnValue>;
+  openFile: (options: OpenDialogOptions) => Promise<OpenDialogReturnValue>;
 }
 
 export interface ViewerConfig {

--- a/packages/apps/desktop-viewer-test/src/frontend/app/ITwinViewerApp.ts
+++ b/packages/apps/desktop-viewer-test/src/frontend/app/ITwinViewerApp.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import {
-  AsyncMethodsOf,
+  AsyncFunction,
   IModelApp,
   IpcApp,
   PromiseReturnType,
@@ -16,27 +16,40 @@ import {
   ViewerIpc,
 } from "../../common/ViewerConfig";
 
-// this is a singleton - all methods are static and no instances may be created
+export declare type PickAsyncMethods<T> = {
+  [P in keyof T]: T[P] extends AsyncFunction ? T[P] : never;
+};
+
+type IpcMethods = PickAsyncMethods<ViewerIpc>;
+
 export class ITwinViewerApp {
-  public static config: ViewerConfig;
+  // this is a singleton - all methods are static and no instances may be created
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  private constructor() {}
+
+  private static config: ViewerConfig;
 
   public static translate(key: string | string[], options?: any): string {
     return IModelApp.i18n.translate(`iTwinViewer:${key}`, options);
   }
-  public static async callBackend<T extends AsyncMethodsOf<ViewerIpc>>(
-    methodName: T,
-    ...args: Parameters<ViewerIpc[T]>
-  ) {
-    return IpcApp.callIpcChannel(
-      channelName,
-      methodName,
-      ...args
-    ) as PromiseReturnType<ViewerIpc[T]>;
-  }
-  public static async getConfig(): Promise<ViewerConfig> {
-    if (!this.config) {
-      this.config = await this.callBackend("getConfig");
-    }
-    return this.config;
-  }
+
+  public static ipcCall = new Proxy({} as IpcMethods, {
+    async get(_target, key: keyof IpcMethods) {
+      const makeIpcCall =
+        <T extends keyof IpcMethods>(methodName: T) =>
+        async (...args: Parameters<IpcMethods[T]>) =>
+          IpcApp.callIpcChannel(
+            channelName,
+            methodName,
+            ...args
+          ) as PromiseReturnType<ViewerIpc[T]>;
+
+      switch (key) {
+        case "getConfig": // cache getConfig results
+          return (ITwinViewerApp.config ??= await makeIpcCall("getConfig")());
+        default:
+          return makeIpcCall(key);
+      }
+    },
+  });
 }

--- a/packages/apps/desktop-viewer-test/src/frontend/app/ITwinViewerApp.ts
+++ b/packages/apps/desktop-viewer-test/src/frontend/app/ITwinViewerApp.ts
@@ -34,7 +34,7 @@ export class ITwinViewerApp {
   }
 
   public static ipcCall = new Proxy({} as IpcMethods, {
-    async get(_target, key: keyof IpcMethods) {
+    get(_target, key: keyof IpcMethods): AsyncFunction {
       const makeIpcCall =
         <T extends keyof IpcMethods>(methodName: T) =>
         async (...args: Parameters<IpcMethods[T]>) =>
@@ -45,8 +45,12 @@ export class ITwinViewerApp {
           ) as PromiseReturnType<ViewerIpc[T]>;
 
       switch (key) {
-        case "getConfig": // cache getConfig results
-          return (ITwinViewerApp.config ??= await makeIpcCall("getConfig")());
+        case "getConfig":
+          return async () =>
+            // if we already cached getConfig results, just resolve to that
+            Promise.resolve(
+              (ITwinViewerApp.config ??= await makeIpcCall("getConfig")())
+            );
         default:
           return makeIpcCall(key);
       }

--- a/packages/apps/desktop-viewer-test/src/frontend/components/AppComponent.tsx
+++ b/packages/apps/desktop-viewer-test/src/frontend/components/AppComponent.tsx
@@ -75,7 +75,7 @@ export const AppComponent = () => {
   const onIModelAppInitialized = async () => {
     await IModelSelect.initialize(IModelApp.i18n);
 
-    const config = await ITwinViewerApp.getConfig();
+    const config = await ITwinViewerApp.ipcCall.getConfig();
     if (config?.snapshotName) {
       dispatch({
         type: "OPEN_SNAPSHOT",

--- a/packages/apps/desktop-viewer-test/src/frontend/components/frontstages/SnapshotSelectFrontstage.tsx
+++ b/packages/apps/desktop-viewer-test/src/frontend/components/frontstages/SnapshotSelectFrontstage.tsx
@@ -25,7 +25,7 @@ import {
   Widget,
   Zone,
 } from "@bentley/ui-framework";
-import { OpenDialogOptions, OpenDialogReturnValue } from "electron";
+import { OpenDialogOptions } from "electron";
 import * as React from "react";
 
 import { AppLoggerCategory } from "../../../common/LoggerCategory";
@@ -96,10 +96,7 @@ class LocalFilePage extends React.Component {
       filters: [{ name: "iModels", extensions: ["ibim", "bim"] }],
     };
 
-    const val = (await ITwinViewerApp.callBackend(
-      "openFile",
-      options
-    )) as OpenDialogReturnValue;
+    const val = await ITwinViewerApp.ipcCall.openFile(options);
     const file = val.canceled ? undefined : val.filePaths[0];
     if (file) {
       try {

--- a/packages/modules/cra-template-desktop-viewer/template/src/common/ViewerConfig.ts
+++ b/packages/modules/cra-template-desktop-viewer/template/src/common/ViewerConfig.ts
@@ -10,13 +10,15 @@ import {
   SnapshotIModelRpcInterface,
 } from "@bentley/imodeljs-common";
 import { PresentationRpcInterface } from "@bentley/presentation-common";
-import { OpenDialogReturnValue } from "electron";
+import type Electron from "electron";
 
 export const channelName = iTwinChannel("desktop-viewer");
 
 export interface ViewerIpc {
   getConfig: () => Promise<ViewerConfig>;
-  openFile: (options: any) => Promise<OpenDialogReturnValue>;
+  openFile: (
+    options: Electron.OpenDialogOptions
+  ) => Promise<Electron.OpenDialogReturnValue>;
 }
 
 export interface ViewerConfig {

--- a/packages/modules/cra-template-desktop-viewer/template/src/common/ViewerConfig.ts
+++ b/packages/modules/cra-template-desktop-viewer/template/src/common/ViewerConfig.ts
@@ -10,15 +10,13 @@ import {
   SnapshotIModelRpcInterface,
 } from "@bentley/imodeljs-common";
 import { PresentationRpcInterface } from "@bentley/presentation-common";
-import type Electron from "electron";
+import type { OpenDialogOptions, OpenDialogReturnValue } from "electron";
 
 export const channelName = iTwinChannel("desktop-viewer");
 
 export interface ViewerIpc {
   getConfig: () => Promise<ViewerConfig>;
-  openFile: (
-    options: Electron.OpenDialogOptions
-  ) => Promise<Electron.OpenDialogReturnValue>;
+  openFile: (options: OpenDialogOptions) => Promise<OpenDialogReturnValue>;
 }
 
 export interface ViewerConfig {

--- a/packages/modules/cra-template-desktop-viewer/template/src/frontend/app/ITwinViewerApp.ts
+++ b/packages/modules/cra-template-desktop-viewer/template/src/frontend/app/ITwinViewerApp.ts
@@ -33,6 +33,9 @@ export class ITwinViewerApp {
     return IModelApp.i18n.translate(`iTwinViewer:${key}`, options);
   }
 
+  // This proxy object forwards any method calls to the backend over IPC.
+  // This way, you can call all ipc methods like `ITwinViewerApp.ipcCall.openFile(args)`
+  // Any new backend/ipc methods you need should be added to the ViewerIpc interface, and then implemented in the ViewerHandler
   public static ipcCall = new Proxy({} as IpcMethods, {
     get(_target, key: keyof IpcMethods): AsyncFunction {
       const makeIpcCall =

--- a/packages/modules/cra-template-desktop-viewer/template/src/frontend/app/ITwinViewerApp.ts
+++ b/packages/modules/cra-template-desktop-viewer/template/src/frontend/app/ITwinViewerApp.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import {
-  AsyncMethodsOf,
+  AsyncFunction,
   IModelApp,
   IpcApp,
   PromiseReturnType,
@@ -16,27 +16,40 @@ import {
   ViewerIpc,
 } from "../../common/ViewerConfig";
 
-// this is a singleton - all methods are static and no instances may be created
+export declare type PickAsyncMethods<T> = {
+  [P in keyof T]: T[P] extends AsyncFunction ? T[P] : never;
+};
+
+type IpcMethods = PickAsyncMethods<ViewerIpc>;
+
 export class ITwinViewerApp {
-  public static config: ViewerConfig;
+  // this is a singleton - all methods are static and no instances may be created
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  private constructor() {}
+
+  private static config: ViewerConfig;
 
   public static translate(key: string | string[], options?: any): string {
     return IModelApp.i18n.translate(`iTwinViewer:${key}`, options);
   }
-  public static async callBackend<T extends AsyncMethodsOf<ViewerIpc>>(
-    methodName: T,
-    ...args: Parameters<ViewerIpc[T]>
-  ) {
-    return IpcApp.callIpcChannel(
-      channelName,
-      methodName,
-      ...args
-    ) as PromiseReturnType<ViewerIpc[T]>;
-  }
-  public static async getConfig(): Promise<ViewerConfig> {
-    if (!this.config) {
-      this.config = await this.callBackend("getConfig");
-    }
-    return this.config;
-  }
+
+  public static ipcCall = new Proxy({} as IpcMethods, {
+    async get(_target, key: keyof IpcMethods) {
+      const makeIpcCall =
+        <T extends keyof IpcMethods>(methodName: T) =>
+        async (...args: Parameters<IpcMethods[T]>) =>
+          IpcApp.callIpcChannel(
+            channelName,
+            methodName,
+            ...args
+          ) as PromiseReturnType<ViewerIpc[T]>;
+
+      switch (key) {
+        case "getConfig": // cache getConfig results
+          return (ITwinViewerApp.config ??= await makeIpcCall("getConfig")());
+        default:
+          return makeIpcCall(key);
+      }
+    },
+  });
 }

--- a/packages/modules/cra-template-desktop-viewer/template/src/frontend/app/ITwinViewerApp.ts
+++ b/packages/modules/cra-template-desktop-viewer/template/src/frontend/app/ITwinViewerApp.ts
@@ -34,7 +34,7 @@ export class ITwinViewerApp {
   }
 
   public static ipcCall = new Proxy({} as IpcMethods, {
-    async get(_target, key: keyof IpcMethods) {
+    get(_target, key: keyof IpcMethods): AsyncFunction {
       const makeIpcCall =
         <T extends keyof IpcMethods>(methodName: T) =>
         async (...args: Parameters<IpcMethods[T]>) =>
@@ -45,8 +45,12 @@ export class ITwinViewerApp {
           ) as PromiseReturnType<ViewerIpc[T]>;
 
       switch (key) {
-        case "getConfig": // cache getConfig results
-          return (ITwinViewerApp.config ??= await makeIpcCall("getConfig")());
+        case "getConfig":
+          return async () =>
+            // if we already cached getConfig results, just resolve to that
+            Promise.resolve(
+              (ITwinViewerApp.config ??= await makeIpcCall("getConfig")())
+            );
         default:
           return makeIpcCall(key);
       }

--- a/packages/modules/cra-template-desktop-viewer/template/src/frontend/components/AppComponent.tsx
+++ b/packages/modules/cra-template-desktop-viewer/template/src/frontend/components/AppComponent.tsx
@@ -75,7 +75,7 @@ export const AppComponent = () => {
   const onIModelAppInitialized = async () => {
     await IModelSelect.initialize(IModelApp.i18n);
 
-    const config = await ITwinViewerApp.getConfig();
+    const config = await ITwinViewerApp.ipcCall.getConfig();
     if (config?.snapshotName) {
       dispatch({
         type: "OPEN_SNAPSHOT",

--- a/packages/modules/cra-template-desktop-viewer/template/src/frontend/components/frontstages/SnapshotSelectFrontstage.tsx
+++ b/packages/modules/cra-template-desktop-viewer/template/src/frontend/components/frontstages/SnapshotSelectFrontstage.tsx
@@ -25,7 +25,7 @@ import {
   Widget,
   Zone,
 } from "@bentley/ui-framework";
-import { OpenDialogOptions, OpenDialogReturnValue } from "electron";
+import { OpenDialogOptions } from "electron";
 import * as React from "react";
 
 import { AppLoggerCategory } from "../../../common/LoggerCategory";
@@ -96,10 +96,7 @@ class LocalFilePage extends React.Component {
       filters: [{ name: "iModels", extensions: ["ibim", "bim"] }],
     };
 
-    const val = (await ITwinViewerApp.callBackend(
-      "openFile",
-      options
-    )) as OpenDialogReturnValue;
+    const val = await ITwinViewerApp.ipcCall.openFile(options);
     const file = val.canceled ? undefined : val.filePaths[0];
     if (file) {
       try {


### PR DESCRIPTION
I found it easier to add new calls ipc calls with this proxy, and figured I would share to see if it makes sense to upstream.
My application requires adding ipc calls such as, for instance, opening a save file dialog, and a few others, this change made it more manageable to add several.

I also found that using the `no-unused-vars` linter rule causes a false positive on arrow function type notation in typescript, so I turned it off and instead enabled the @typescript-eslint version of it. 