### PR TITLE
Update desktop viewer temaplate's gitignore

### DIFF
--- a/packages/modules/cra-template-desktop-viewer/template.json
+++ b/packages/modules/cra-template-desktop-viewer/template.json
@@ -57,6 +57,7 @@
       "webpack": "4.42.0"
     },
     "scripts": {
+      "build": "npm run build:backend && build:frontend",
       "build:backend": "tsc -p tsconfig.backend.json",
       "build:frontend": "npm run pseudolocalize && react-scripts build",
       "electron": "electron lib/backend/main.js",

--- a/packages/modules/cra-template-desktop-viewer/template/gitignore
+++ b/packages/modules/cra-template-desktop-viewer/template/gitignore
@@ -10,6 +10,8 @@
 
 # production
 /build
+/lib
+/dist
 
 # misc
 .DS_Store

--- a/packages/modules/cra-template-desktop-viewer/template/src/backend/main.ts
+++ b/packages/modules/cra-template-desktop-viewer/template/src/backend/main.ts
@@ -18,8 +18,8 @@ import ViewerHandler from "./ViewerHandler";
 
 require("dotenv-flow").config(); // eslint-disable-line @typescript-eslint/no-var-requires
 
-/** This is the function that gets called when we start iTwinViewer via `electron ViewerMain.js` from the command line.
- * It runs in the Electron main process and hosts the iModeljs backend (IModelHost) code. It starts the render (frontend) process
+/** This is the function that gets called when we start iTwinViewer via `electron main.js` from the command line.
+ * It runs in the Electron main process and hosts the iTwin.js backend (IModelHost) code. It starts the render (frontend) process
  * that starts from the file "index.ts". That launches the viewer frontend (IModelApp).
  */
 const viewerMain = async () => {


### PR DESCRIPTION
The `lib` folder is created by the `npm run build:backend` command and if you use `@bentley/backend-webpack-tools` the `dist` folder is our recommended default.

@aruniverse mind if I add the `npm run build:backend` to the `npm run build` script?