### PR TITLE
Fix intellisense

### DIFF
--- a/packages/apps/web-viewer-test/src/components/home/AuthClientHome.tsx
+++ b/packages/apps/web-viewer-test/src/components/home/AuthClientHome.tsx
@@ -18,8 +18,8 @@ import styles from "./Home.module.scss";
  */
 export const AuthClientHome: React.FC = () => {
   const [loggedIn, setLoggedIn] = useState(
-    (AuthorizationClient.oidcClient.hasSignedIn &&
-      AuthorizationClient.oidcClient.isAuthorized) ||
+    (AuthorizationClient.oidcClient?.hasSignedIn &&
+      AuthorizationClient.oidcClient?.isAuthorized) ||
       false
   );
 
@@ -33,8 +33,8 @@ export const AuthClientHome: React.FC = () => {
         .then(() => {
           setOidcInitialized(true);
           setLoggedIn(
-            (AuthorizationClient.oidcClient.hasSignedIn &&
-              AuthorizationClient.oidcClient.isAuthorized) ||
+            (AuthorizationClient.oidcClient?.hasSignedIn &&
+              AuthorizationClient.oidcClient?.isAuthorized) ||
               false
           );
         })
@@ -44,8 +44,8 @@ export const AuthClientHome: React.FC = () => {
     } else {
       setOidcInitialized(true);
       setLoggedIn(
-        (AuthorizationClient.oidcClient.hasSignedIn &&
-          AuthorizationClient.oidcClient.isAuthorized) ||
+        (AuthorizationClient.oidcClient?.hasSignedIn &&
+          AuthorizationClient.oidcClient?.isAuthorized) ||
           false
       );
     }
@@ -55,8 +55,8 @@ export const AuthClientHome: React.FC = () => {
     if (!loggedIn) {
       await AuthorizationClient.signIn(location.pathname);
       setLoggedIn(
-        AuthorizationClient.oidcClient.hasSignedIn &&
-          AuthorizationClient.oidcClient.isAuthorized
+        AuthorizationClient.oidcClient?.hasSignedIn &&
+          AuthorizationClient.oidcClient?.isAuthorized
       );
     } else {
       await AuthorizationClient.signOut(location.pathname);

--- a/packages/apps/web-viewer-test/src/components/home/IModelBankHome.tsx
+++ b/packages/apps/web-viewer-test/src/components/home/IModelBankHome.tsx
@@ -3,7 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { IModelBankClient } from "@bentley/imodelhub-client";
 import { ColorTheme } from "@itwin/appui-react";
 import { BrowserAuthorizationClientConfiguration } from "@itwin/browser-authorization";
 import {
@@ -19,6 +18,7 @@ import {
 } from "@itwin/web-viewer-react";
 import React, { useEffect, useState } from "react";
 
+import { IModelBankFrontend } from "../../services/IModelBankFrontendHubAccess";
 import { history } from "../routing";
 import { Header } from ".";
 import styles from "./Home.module.scss";
@@ -58,9 +58,8 @@ export const IModelBankHome: React.FC = () => {
     },
   };
 
-  const imodelClient = new IModelBankClient(
-    "https://dev-imodelbank.bentley.com",
-    undefined
+  const imodelBankClient = new IModelBankFrontend(
+    "https://dev-imodelbank.bentley.com"
   );
 
   useEffect(() => {
@@ -154,8 +153,7 @@ export const IModelBankHome: React.FC = () => {
         onIModelAppInit={onIModelAppInit}
         viewCreatorOptions={{ viewportConfigurer: viewConfiguration }}
         backend={backend}
-        // TODO: needs to be updated to use a IModelBankClient that implements the new FrontendHubAccess interface
-        // imodelClient={imodelClient}
+        hubAccess={imodelBankClient}
       />
     </div>
   );

--- a/packages/apps/web-viewer-test/src/components/home/IModelBankHome.tsx
+++ b/packages/apps/web-viewer-test/src/components/home/IModelBankHome.tsx
@@ -154,7 +154,8 @@ export const IModelBankHome: React.FC = () => {
         onIModelAppInit={onIModelAppInit}
         viewCreatorOptions={{ viewportConfigurer: viewConfiguration }}
         backend={backend}
-        imodelClient={imodelClient}
+        // TODO: needs to be updated to use a IModelBankClient that implements the new FrontendHubAccess interface
+        // imodelClient={imodelClient}
       />
     </div>
   );

--- a/packages/apps/web-viewer-test/src/services/IModelBankFrontendHubAccess.ts
+++ b/packages/apps/web-viewer-test/src/services/IModelBankFrontendHubAccess.ts
@@ -1,0 +1,73 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import {
+  ChangeSet,
+  ChangeSetQuery,
+  IModelBankClient,
+  VersionQuery,
+} from "@bentley/imodelhub-client";
+import {
+  BentleyError,
+  BentleyStatus,
+  ChangesetId,
+  IModelVersion,
+} from "@itwin/core-common";
+import { FrontendHubAccess, IModelIdArg } from "@itwin/core-frontend";
+
+export class IModelBankFrontend implements FrontendHubAccess {
+  private _hubClient: IModelBankClient;
+  constructor(orchestratorUrl: string) {
+    this._hubClient = new IModelBankClient(orchestratorUrl, undefined);
+  }
+
+  public async getLatestChangesetId(arg: IModelIdArg): Promise<ChangesetId> {
+    const changeSets: ChangeSet[] = await this._hubClient.changeSets.get(
+      arg.accessToken,
+      arg.iModelId,
+      new ChangeSetQuery().top(1).latest()
+    );
+    return changeSets.length === 0
+      ? ""
+      : changeSets[changeSets.length - 1].wsgId;
+  }
+
+  public async getChangesetIdFromVersion(
+    arg: IModelIdArg & { version: IModelVersion }
+  ): Promise<ChangesetId> {
+    const version = arg.version;
+    if (version.isFirst) {
+      return "";
+    }
+
+    const asOf = version.getAsOfChangeSet();
+    if (asOf) {
+      return asOf;
+    }
+
+    const versionName = version.getName();
+    if (versionName) {
+      return this.getChangesetIdFromNamedVersion({ ...arg, versionName });
+    }
+
+    return this.getLatestChangesetId(arg);
+  }
+
+  public async getChangesetIdFromNamedVersion(
+    arg: IModelIdArg & { versionName: string }
+  ): Promise<ChangesetId> {
+    const versions = await this._hubClient.versions.get(
+      arg.accessToken,
+      arg.iModelId,
+      new VersionQuery().select("ChangeSetId").byName(arg.versionName)
+    );
+    if (!versions[0] || !versions[0].changeSetId) {
+      throw new BentleyError(
+        BentleyStatus.ERROR,
+        `Named version ${arg.versionName} not found`
+      );
+    }
+    return versions[0].changeSetId;
+  }
+}

--- a/packages/apps/web-viewer-test/src/services/IModelBankFrontendHubAccess.ts
+++ b/packages/apps/web-viewer-test/src/services/IModelBankFrontendHubAccess.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+
 import {
   ChangeSet,
   ChangeSetQuery,
@@ -62,7 +63,7 @@ export class IModelBankFrontend implements FrontendHubAccess {
       arg.iModelId,
       new VersionQuery().select("ChangeSetId").byName(arg.versionName)
     );
-    if (!versions[0] || !versions[0].changeSetId) {
+    if (!versions?.length || !versions[0]?.changeSetId) {
       throw new BentleyError(
         BentleyStatus.ERROR,
         `Named version ${arg.versionName} not found`

--- a/packages/modules/desktop-viewer-react/src/hooks/useDesktopViewerInitializer.tsx
+++ b/packages/modules/desktop-viewer-react/src/hooks/useDesktopViewerInitializer.tsx
@@ -6,6 +6,7 @@
 import {
   getInitializationOptions,
   isEqual,
+  ItwinViewerInitializerParams,
   useBaseViewerInitializer,
 } from "@itwin/viewer-react";
 import { useEffect, useMemo, useState } from "react";
@@ -15,7 +16,7 @@ import { DesktopViewerProps } from "../types";
 
 export const useDesktopViewerInitializer = (options?: DesktopViewerProps) => {
   const [desktopViewerInitOptions, setDesktopViewerInitOptions] =
-    useState<DesktopViewerProps>();
+    useState<ItwinViewerInitializerParams>();
   const [desktopViewerInitalized, setDesktopViewerInitalized] = useState(false);
   const baseViewerInitialized = useBaseViewerInitializer(
     options,

--- a/packages/modules/viewer-react/src/components/BaseBlankViewer.tsx
+++ b/packages/modules/viewer-react/src/components/BaseBlankViewer.tsx
@@ -29,7 +29,6 @@ export const BaseBlankViewer: React.FC<BlankViewerProps> = ({
   onIModelConnected,
   frontstages,
   backstageItems,
-  uiFrameworkVersion,
   viewportOptions,
   uiProviders,
   blankConnection,
@@ -55,13 +54,13 @@ export const BaseBlankViewer: React.FC<BlankViewerProps> = ({
     setAuthorized(
       (BaseInitializer.authClient?.hasSignedIn &&
         BaseInitializer.authClient?.isAuthorized) ||
-      false
+        false
     );
     BaseInitializer.authClient?.onAccessTokenChanged.addListener(() => {
       setAuthorized(
         (BaseInitializer.authClient?.hasSignedIn &&
           BaseInitializer.authClient?.isAuthorized) ||
-        false
+          false
       );
     });
   }, []);

--- a/packages/modules/viewer-react/src/components/BaseViewer.tsx
+++ b/packages/modules/viewer-react/src/components/BaseViewer.tsx
@@ -13,7 +13,6 @@ import { ItwinViewerCommonParams } from "../types";
 import IModelLoader from "./iModel/IModelLoader";
 
 export interface ViewerProps extends ItwinViewerCommonParams {
-  [index: string]: any;
   contextId?: string;
   iModelId?: string;
   changeSetId?: string;
@@ -33,7 +32,6 @@ export const BaseViewer: React.FC<ViewerProps> = ({
   snapshotPath,
   frontstages,
   backstageItems,
-  uiFrameworkVersion,
   viewportOptions,
   uiProviders,
   i18nUrlTemplate,
@@ -61,13 +59,13 @@ export const BaseViewer: React.FC<ViewerProps> = ({
       setAuthorized(
         (BaseInitializer.authClient?.hasSignedIn &&
           BaseInitializer.authClient?.isAuthorized) ||
-        false
+          false
       );
       BaseInitializer.authClient?.onAccessTokenChanged.addListener(() => {
         setAuthorized(
           (BaseInitializer.authClient?.hasSignedIn &&
             BaseInitializer.authClient?.isAuthorized) ||
-          false
+            false
         );
       });
     }

--- a/packages/modules/viewer-react/src/tests/components/iModel/IModelLoader.test.tsx
+++ b/packages/modules/viewer-react/src/tests/components/iModel/IModelLoader.test.tsx
@@ -109,8 +109,8 @@ jest.mock("@itwin/core-frontend", () => {
     ItemField: {},
     CompassMode: {},
     RotationMode: {},
-    AccuDraw: class { },
-    ToolAdmin: class { },
+    AccuDraw: class {},
+    ToolAdmin: class {},
     WebViewerApp: {
       startup: jest.fn().mockResolvedValue(true),
     },
@@ -343,9 +343,9 @@ describe("IModelLoader", () => {
     jest.spyOn(UiFramework, "setDefaultViewState");
     const viewportOptions: ViewerViewportControlOptions = {
       viewState: (connection: IModelConnection) =>
-      ({
-        iModel: connection,
-      } as any),
+        ({
+          iModel: connection,
+        } as any),
     };
     const result = render(
       <IModelLoader
@@ -463,7 +463,7 @@ describe("IModelLoader", () => {
     );
     await waitFor(() => result.getByTestId("viewer"));
     expect(IModelViewer).toHaveBeenCalledWith(
-      { backstageItems: [], frontstages, uiFrameworkVersion: undefined },
+      { backstageItems: [], frontstages },
       {}
     );
   });

--- a/packages/modules/viewer-react/src/types.ts
+++ b/packages/modules/viewer-react/src/types.ts
@@ -91,7 +91,6 @@ export interface ItwinViewerCommonParams
     IModelLoaderParams {}
 
 export interface ItwinViewerInitializerParams {
-  [index: string]: any;
   /** optional Azure Application Insights key for telemetry */
   appInsightsKey?: string;
   /** GPRID for the consuming application. Will default to the iTwin Viewer GPRID */
@@ -118,20 +117,19 @@ export interface ItwinViewerInitializerParams {
  * This list MUST match what is in the ItwinViewerInitializerParams interface and should be updated as new properties are added/removed
  */
 const iTwinViewerInitializerParamSample: ItwinViewerInitializerParams = {
-  appInsightKey: undefined,
+  appInsightsKey: undefined,
   productId: undefined,
   i18nUrlTemplate: undefined,
   onIModelAppInit: undefined,
   additionalI18nNamespaces: undefined,
   additionalRpcInterfaces: undefined,
-  iModelDataErrorMessage: undefined,
   toolAdmin: undefined,
   hubAccess: undefined,
-  extensions: undefined,
+  // extensions: undefined,
 };
 export const iTwinViewerInitializerParamList = Object.keys(
   iTwinViewerInitializerParamSample
-) as (keyof ItwinViewerInitializerParams)[];
+);
 
 /**
  * Configure options for the top left corner item

--- a/packages/modules/viewer-react/src/utilities/index.ts
+++ b/packages/modules/viewer-react/src/utilities/index.ts
@@ -65,12 +65,10 @@ export const isEqual = (a?: any, b?: any) => {
  * @returns
  */
 export const getInitializationOptions = (options?: ViewerProps) => {
-  const initOptions = {} as ItwinViewerInitializerParams;
+  const initOptions: ItwinViewerInitializerParams = {};
   if (options) {
-    for (const key in options) {
-      if (iTwinViewerInitializerParamList.indexOf(key) >= 0) {
-        initOptions[key] = options[key];
-      }
+    for (const key in iTwinViewerInitializerParamList) {
+      (initOptions as any)[key] = (options as any)[key];
     }
   }
   return initOptions;

--- a/packages/modules/web-viewer-react/src/hooks/useWebViewerInitializer.tsx
+++ b/packages/modules/web-viewer-react/src/hooks/useWebViewerInitializer.tsx
@@ -6,6 +6,7 @@
 import {
   getInitializationOptions,
   isEqual,
+  ItwinViewerInitializerParams,
   useBaseViewerInitializer,
 } from "@itwin/viewer-react";
 import { useEffect, useMemo, useState } from "react";
@@ -15,7 +16,7 @@ import { WebViewerProps } from "../types";
 
 export const useWebViewerInitializer = (options?: WebViewerProps) => {
   const [webViewerInitOptions, setWebViewerInitOptions] =
-    useState<WebViewerProps>();
+    useState<ItwinViewerInitializerParams>();
   const [webViewerInitalized, setWebViewerInitalized] = useState(false);
   const baseViewerInitialized = useBaseViewerInitializer(
     options,

--- a/packages/modules/web-viewer-react/src/tests/services/ItwinViewer.test.ts
+++ b/packages/modules/web-viewer-react/src/tests/services/ItwinViewer.test.ts
@@ -103,7 +103,6 @@ describe("iTwinViewer", () => {
       appInsightsKey: undefined,
       onIModelConnected: undefined,
       frontstages: undefined,
-      uiFrameworkVersion: undefined,
       viewportOptions: undefined,
       uiProviders: undefined,
       theme: undefined,


### PR DESCRIPTION
Fix intellisense by removing prop on ItwinViewerInitializerParams which allowed for anything to be passed in as a prop
This helped catch quite a few issues throughout the codebase

Added an example of a IModelBankClient that implements the new FrontendHubAccess interface which replaces the IModelClient on IModelApp
