### PR TITLE
fix blank connections

### DIFF
--- a/common/changes/@itwin/viewer-react/fix-fix-blank-connections_2021-12-10-14-15.json
+++ b/common/changes/@itwin/viewer-react/fix-fix-blank-connections_2021-12-10-14-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/viewer-react",
+      "comment": "Add check for BlankConnections when creating viewState as they are always closed",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/viewer-react",
+  "email": "6283674+kckst8@users.noreply.github.com"
+}

--- a/packages/modules/viewer-react/src/components/iModel/IModelLoader.tsx
+++ b/packages/modules/viewer-react/src/components/iModel/IModelLoader.tsx
@@ -109,7 +109,7 @@ const Loader: React.FC<ModelLoaderProps> = React.memo(
     };
 
     const getViewState = useCallback(async () => {
-      if (!connection || connection.isClosed) {
+      if (!connection || (!connection.isBlank && connection.isClosed)) {
         setViewState(undefined);
         return;
       }


### PR DESCRIPTION
Apparently they are always closed, so added a specific check when creating a viewState