### PR TITLE
Section clear statusbar item

### DIFF
--- a/packages/modules/viewer-react/src/components/app-ui/frontstages/DefaultFrontstage.tsx
+++ b/packages/modules/viewer-react/src/components/app-ui/frontstages/DefaultFrontstage.tsx
@@ -109,7 +109,7 @@ export class DefaultFrontstage extends FrontstageProvider {
     return (
       <Frontstage
         id="DefaultFrontstage"
-        version={1} // this value should be increased when changes are made to Frontstage
+        version={2} // this value should be increased when changes are made to Frontstage
         usage={StageUsage.General}
         defaultTool={CoreTools.selectElementCommand}
         contentGroup={this._contentGroup}

--- a/packages/modules/viewer-react/src/components/app-ui/statusbars/AppStatusBar.tsx
+++ b/packages/modules/viewer-react/src/components/app-ui/statusbars/AppStatusBar.tsx
@@ -6,6 +6,7 @@
 import { StatusBarSection } from "@itwin/appui-abstract";
 import { FooterSeparator } from "@itwin/appui-layout-react";
 import type { ConfigurableCreateInfo, StatusBarItem } from "@itwin/appui-react";
+import { SectionsStatusField } from "@itwin/appui-react";
 import {
   FooterModeField,
   MessageCenterField,
@@ -39,6 +40,7 @@ export class AppStatusBarWidget extends StatusBarWidgetControl {
     const FooterOnlyDisplay = withStatusFieldProps(FooterModeField);
     const SnapMode = withStatusFieldProps(SnapModeField);
     const SelectionInfo = withStatusFieldProps(SelectionInfoField);
+    const Sections = withStatusFieldProps(SectionsStatusField);
 
     this._footerModeOnlySeparator = (): React.ReactNode => {
       return (
@@ -78,6 +80,14 @@ export class AppStatusBarWidget extends StatusBarWidgetControl {
         StatusBarSection.Left,
         25,
         this._footerModeOnlySeparator()
+      )
+    );
+    this._statusBarItems.push(
+      StatusBarItemUtilities.createStatusBarItem(
+        "Sections",
+        StatusBarSection.Left,
+        30,
+        <Sections hideWhenUnused={true} />
       )
     );
 


### PR DESCRIPTION
Not sure why no one had reported this before Travis. Currently, if you make use of the section tools, there is no way to clear/revert your sectioning without refreshing the viewer/pg

https://i.imgur.com/xdYbIY2.gif