### PR TITLE
Refactoring IModelLoader

### DIFF
--- a/common/changes/@itwin/desktop-viewer-react/viewport-issue_2022-02-11-18-21.json
+++ b/common/changes/@itwin/desktop-viewer-react/viewport-issue_2022-02-11-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/desktop-viewer-react",
+      "comment": "Cleanup",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/desktop-viewer-react",
+  "email": "6283674+kckst8@users.noreply.github.com"
+}

--- a/common/changes/@itwin/viewer-react/viewport-issue_2022-02-08-20-28.json
+++ b/common/changes/@itwin/viewer-react/viewport-issue_2022-02-08-20-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/viewer-react",
+      "comment": "Code optimization and refactoring",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/viewer-react",
+  "email": "6283674+kckst8@users.noreply.github.com"
+}

--- a/common/changes/@itwin/web-viewer-react/viewport-issue_2022-02-11-18-21.json
+++ b/common/changes/@itwin/web-viewer-react/viewport-issue_2022-02-11-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/web-viewer-react",
+      "comment": "Cleanup",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/web-viewer-react",
+  "email": "6283674+kckst8@users.noreply.github.com"
+}

--- a/packages/apps/web-viewer-test/src/components/home/ViewerHome.tsx
+++ b/packages/apps/web-viewer-test/src/components/home/ViewerHome.tsx
@@ -8,6 +8,7 @@ import { BrowserAuthorizationClient } from "@itwin/browser-authorization";
 import { Viewer } from "@itwin/web-viewer-react";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 
+import { ViewportWidgetProvider } from "../../providers/ViewportAccessWidget";
 import { history } from "../routing";
 
 /**
@@ -60,6 +61,19 @@ export const ViewerHome: React.FC = () => {
     history.push(`viewer?iTwinId=${iTwinId}&iModelId=${iModelId}`);
   }, [iTwinId, iModelId]);
 
+  const updateModelInfo = (iModelId: string, iTwinId: string) => {
+    console.log(
+      `About to pass iModelId of ${iModelId} into the Viewer Component`
+    );
+    setIModelId(iModelId);
+    setITwinId(iTwinId);
+  };
+
+  const uiProviders = useMemo(
+    () => [new ViewportWidgetProvider(updateModelInfo)],
+    []
+  );
+
   const Loader = () => {
     return <div>Things are happening...</div>;
   };
@@ -80,6 +94,11 @@ export const ViewerHome: React.FC = () => {
           },
         }}
         enablePerformanceMonitors={true}
+        uiProviders={uiProviders}
+        defaultUiConfig={{
+          hideTreeView: true,
+          hidePropertyGrid: true,
+        }}
       />
     </div>
   );

--- a/packages/apps/web-viewer-test/src/components/home/ViewerHome.tsx
+++ b/packages/apps/web-viewer-test/src/components/home/ViewerHome.tsx
@@ -61,12 +61,11 @@ export const ViewerHome: React.FC = () => {
     history.push(`viewer?iTwinId=${iTwinId}&iModelId=${iModelId}`);
   }, [iTwinId, iModelId]);
 
-  const updateModelInfo = (iModelId: string, iTwinId: string) => {
+  const updateModelInfo = (iModelId: string) => {
     console.log(
       `About to pass iModelId of ${iModelId} into the Viewer Component`
     );
     setIModelId(iModelId);
-    setITwinId(iTwinId);
   };
 
   const uiProviders = useMemo(

--- a/packages/apps/web-viewer-test/src/providers/ViewportAccessWidget.tsx
+++ b/packages/apps/web-viewer-test/src/providers/ViewportAccessWidget.tsx
@@ -13,10 +13,8 @@ import { Button } from "@itwin/itwinui-react";
 import React, { useEffect } from "react";
 
 const ViewportOnlyWidget: React.FunctionComponent<{
-  onSampleIModelChange: (iModelId: string, iTwinId: string) => void;
-}> = (props: {
-  onSampleIModelChange: (iModelId: string, iTwinId: string) => void;
-}) => {
+  onSampleIModelChange: (iModelId: string) => void;
+}> = (props: { onSampleIModelChange: (iModelId: string) => void }) => {
   const viewport = useActiveViewport();
 
   /** Load the images on widget startup */
@@ -32,10 +30,15 @@ const ViewportOnlyWidget: React.FunctionComponent<{
   }, [viewport]);
 
   const toggleModel = () => {
-    props.onSampleIModelChange(
-      "435e704b-ae19-418c-a02e-fc75686e213c",
-      "1bff8c44-3196-4231-b8f6-66cf6dacd45b"
-    );
+    const iModelId1 = process.env.IMJS_AUTH_CLIENT_IMODEL_ID;
+    const iModelId2 = process.env.IMJS_AUTH_CLIENT_IMODEL_ID2;
+    let iModelId = iModelId1;
+    if (!iModelId || viewport?.iModel.iModelId === iModelId1) {
+      iModelId = iModelId2;
+    }
+    if (iModelId) {
+      props.onSampleIModelChange(iModelId);
+    }
   };
 
   // Display drawing and sheet options in separate sections.
@@ -48,13 +51,8 @@ const ViewportOnlyWidget: React.FunctionComponent<{
 
 export class ViewportWidgetProvider implements UiItemsProvider {
   public readonly id: string = "ViewportWidgetProvider";
-  private _onSampleiModelInfoChange: (
-    iModelId: string,
-    iTwinId: string
-  ) => void;
-  constructor(
-    onSampleiModelInfoChange: (iModelId: string, iTwinId: string) => void
-  ) {
+  private _onSampleiModelInfoChange: (iModelId: string) => void;
+  constructor(onSampleiModelInfoChange: (iModelId: string) => void) {
     this._onSampleiModelInfoChange = onSampleiModelInfoChange;
   }
 

--- a/packages/apps/web-viewer-test/src/providers/ViewportAccessWidget.tsx
+++ b/packages/apps/web-viewer-test/src/providers/ViewportAccessWidget.tsx
@@ -1,0 +1,82 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import type {
+  AbstractWidgetProps,
+  UiItemsProvider,
+} from "@itwin/appui-abstract";
+import { StagePanelLocation, WidgetState } from "@itwin/appui-abstract";
+import { useActiveViewport } from "@itwin/appui-react";
+import { Button } from "@itwin/itwinui-react";
+import React, { useEffect } from "react";
+
+const ViewportOnlyWidget: React.FunctionComponent<{
+  onSampleIModelChange: (iModelId: string, iTwinId: string) => void;
+}> = (props: {
+  onSampleIModelChange: (iModelId: string, iTwinId: string) => void;
+}) => {
+  const viewport = useActiveViewport();
+
+  /** Load the images on widget startup */
+  useEffect(() => {
+    if (viewport?.iModel.iModelId) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `Setting up sample widget with iModelId: ${viewport.iModel.iModelId}`
+      );
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [viewport]);
+
+  const toggleModel = () => {
+    props.onSampleIModelChange(
+      "435e704b-ae19-418c-a02e-fc75686e213c",
+      "1bff8c44-3196-4231-b8f6-66cf6dacd45b"
+    );
+  };
+
+  // Display drawing and sheet options in separate sections.
+  return (
+    <div className="sample-options">
+      <Button onClick={toggleModel}>Switch iModel</Button>
+    </div>
+  );
+};
+
+export class ViewportWidgetProvider implements UiItemsProvider {
+  public readonly id: string = "ViewportWidgetProvider";
+  private _onSampleiModelInfoChange: (
+    iModelId: string,
+    iTwinId: string
+  ) => void;
+  constructor(
+    onSampleiModelInfoChange: (iModelId: string, iTwinId: string) => void
+  ) {
+    this._onSampleiModelInfoChange = onSampleiModelInfoChange;
+  }
+
+  public provideWidgets(
+    _stageId: string,
+    _stageUsage: string,
+    location: StagePanelLocation
+  ): ReadonlyArray<AbstractWidgetProps> {
+    const widgets: AbstractWidgetProps[] = [];
+    if (location === StagePanelLocation.Right) {
+      widgets.push({
+        id: "ViewportWidgetProvider",
+        label: "Viewport Widget Selector",
+        defaultState: WidgetState.Floating,
+        // eslint-disable-next-line react/display-name
+        getWidgetContent: () => (
+          <ViewportOnlyWidget
+            onSampleIModelChange={this._onSampleiModelInfoChange}
+          />
+        ),
+      });
+    }
+    return widgets;
+  }
+}

--- a/packages/modules/desktop-viewer-react/src/components/Viewer.tsx
+++ b/packages/modules/desktop-viewer-react/src/components/Viewer.tsx
@@ -16,5 +16,5 @@ export const Viewer = (props: DesktopViewerProps) => {
 
   const initialized = useDesktopViewerInitializer(memoizedProps);
 
-  return initialized ? <BaseViewer {...memoizedProps} /> : null; //TODO loader?
+  return initialized ? <BaseViewer {...memoizedProps} /> : null;
 };

--- a/packages/modules/desktop-viewer-react/src/services/Initializer.ts
+++ b/packages/modules/desktop-viewer-react/src/services/Initializer.ts
@@ -65,7 +65,7 @@ export class DesktopInitializer {
           iModelApp: iModelAppOpts,
         };
         // this is a hack to workaround a bug in ITJS 2.x where browser connectivity events are not registered
-        // TODO verify and remove in 3.x
+        // TODO next verify and remove if no longer needed
         window.ononline = () => {
           /* nop */
         };

--- a/packages/modules/viewer-react/public/locales/en/iTwinViewer.json
+++ b/packages/modules/viewer-react/public/locales/en/iTwinViewer.json
@@ -10,7 +10,7 @@
     "synchronizerLink": "Please visit <a href={{bridgePortal}} rel=\"noopener noreferrer\" target=\"_blank\">the Synchronization Portal</a> to review the iModel's data connections and synchronize changes.",
     "iModelLoading": "Your iModel is loading"
   },
-  "missingConnectionProps": "Please provide a valid iTwinId and iModelId or a local snapshotPath",
+  "missingConnectionProps": "Please provide a valid iTwinId and iModelId, a local snapshotPath, or Blank Connection configuration",
   "backstage": {
     "mainFrontstage": "Main Frontstage"
   },

--- a/packages/modules/viewer-react/src/components/BaseViewer.tsx
+++ b/packages/modules/viewer-react/src/components/BaseViewer.tsx
@@ -16,7 +16,7 @@ export interface ViewerProps extends ItwinViewerCommonParams {
   iTwinId?: string;
   iModelId?: string;
   changeSetId?: string;
-  snapshotPath?: string; // TODO 3.0 rename (filePath?) as this can be a briefcase or a snapshot
+  snapshotPath?: string; // TODO next rename (filePath?) as this can be a briefcase or a snapshot
   loadingComponent?: React.ReactNode;
 }
 
@@ -53,7 +53,6 @@ export const BaseViewer: React.FC<ViewerProps> = ({
   });
 
   const accessToken = useAccessToken();
-  // assume authorized when using a local snapshot TODO poor assumption
   return (
     <ErrorBoundary>
       {snapshotPath || accessToken ? (

--- a/packages/modules/viewer-react/src/components/app-ui/frontstages/DefaultFrontstage.tsx
+++ b/packages/modules/viewer-react/src/components/app-ui/frontstages/DefaultFrontstage.tsx
@@ -3,119 +3,27 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { StageUsage, StandardContentLayouts } from "@itwin/appui-abstract";
+import { StageUsage } from "@itwin/appui-abstract";
+import type { ContentGroupProvider } from "@itwin/appui-react";
 import {
-  ContentGroup,
-  ContentGroupProvider,
   CoreTools,
   Frontstage,
   FrontstageProvider,
-  IModelViewportControl,
   StagePanel,
-  UiFramework,
   Widget,
   Zone,
 } from "@itwin/appui-react";
-import type { IModelConnection, ViewState } from "@itwin/core-frontend";
-import { ViewCreator3d } from "@itwin/core-frontend";
 import * as React from "react";
 
-import { createBlankViewState } from "../../../services/iModel/ViewCreatorBlank";
 import type {
   BlankConnectionViewState,
   ItwinViewerUi,
   ViewerViewCreator3dOptions,
   ViewerViewportControlOptions,
 } from "../../../types";
+import { DefaultContentGroupProvider } from "../providers";
 import { AppStatusBarWidget } from "../statusbars/AppStatusBar";
 import { BasicNavigationWidget, BasicToolWidget } from "../widgets";
-
-/**
- * Use a Provider to provide the content group
- */
-class DefaultFrontstageContentGroupProvider extends ContentGroupProvider {
-  private _viewportOptions: ViewerViewportControlOptions | undefined;
-  private _blankConnectionViewState: BlankConnectionViewState | undefined;
-  private _viewCreatorOptions: ViewerViewCreator3dOptions | undefined;
-
-  constructor(
-    viewportOptions?: ViewerViewportControlOptions,
-    viewCreatorOptions?: ViewerViewCreator3dOptions,
-    blankConnectionViewStateOptions?: BlankConnectionViewState
-  ) {
-    super();
-    this._viewportOptions = viewportOptions;
-    this._blankConnectionViewState = blankConnectionViewStateOptions;
-    this._viewCreatorOptions = viewCreatorOptions;
-  }
-
-  async getViewState(
-    connection: IModelConnection | undefined
-  ): Promise<ViewState | undefined> {
-    if (!connection || (!connection.isBlank && connection.isClosed)) {
-      return;
-    }
-    let view: ViewState | undefined;
-    if (this._viewportOptions?.viewState) {
-      if (typeof this._viewportOptions?.viewState === "function") {
-        view = await this._viewportOptions?.viewState(connection);
-      } else {
-        view = this._viewportOptions?.viewState;
-      }
-    }
-    if (
-      !this._viewportOptions?.alwaysUseSuppliedViewState &&
-      (!view ||
-        (view.iModel.iModelId !== connection.iModelId && connection.isOpen))
-    ) {
-      if (connection.isBlankConnection()) {
-        view = createBlankViewState(connection, this._blankConnectionViewState);
-      } else {
-        // attempt to construct a default viewState
-        const viewCreator = new ViewCreator3d(connection);
-
-        const options: ViewerViewCreator3dOptions = this._viewCreatorOptions
-          ? { ...this._viewCreatorOptions }
-          : { useSeedView: true };
-
-        if (options.useSeedView === undefined) {
-          options.useSeedView = true;
-        }
-
-        view = await viewCreator.createDefaultView(options);
-        UiFramework.setActiveSelectionScope("top-assembly");
-      }
-
-      // Should not be undefined
-      if (!view) {
-        throw new Error("No default view state for the imodel!");
-      }
-      // Set default view state
-      UiFramework.setDefaultViewState(view);
-    }
-    return view;
-  }
-
-  public async provideContentGroup(): Promise<ContentGroup> {
-    const iModelConnection = UiFramework.getIModelConnection();
-    const viewState = await this.getViewState(iModelConnection);
-    return new ContentGroup({
-      id: "content-group",
-      layout: StandardContentLayouts.singleView,
-      contents: [
-        {
-          id: "viewport",
-          classId: IModelViewportControl,
-          applicationData: {
-            ...this._viewportOptions,
-            viewState,
-            iModelConnection,
-          },
-        },
-      ],
-    });
-  }
-}
 
 /**
  * Default Frontstage for the iTwinViewer
@@ -147,7 +55,7 @@ export class DefaultFrontstage extends FrontstageProvider {
     this._uiConfig = uiConfig;
 
     // Create the content group.
-    this._contentGroup = new DefaultFrontstageContentGroupProvider(
+    this._contentGroup = new DefaultContentGroupProvider(
       viewportOptions,
       viewCreatorOptions,
       blankConnectionViewState

--- a/packages/modules/viewer-react/src/components/app-ui/providers/BackstageItemsProvider.ts
+++ b/packages/modules/viewer-react/src/components/app-ui/providers/BackstageItemsProvider.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import type { UiItemsProvider } from "@itwin/appui-abstract";
+import type {
+  BackstageActionItem,
+  BackstageStageLauncher,
+} from "@itwin/appui-abstract";
+import { BackstageItemUtilities } from "@itwin/appui-abstract";
+import { UiFramework } from "@itwin/appui-react";
+import { IModelApp } from "@itwin/core-frontend";
+
+import type { ViewerBackstageItem } from "../../../types";
+
+export class BackstageItemsProvider implements UiItemsProvider {
+  public readonly id = "BackstageItemsProvider";
+  private _backstageItems: ViewerBackstageItem[];
+
+  constructor(backstageItems: ViewerBackstageItem[]) {
+    this._backstageItems = backstageItems;
+  }
+
+  public provideBackstageItems() {
+    const allBackstageItems: ViewerBackstageItem[] = [];
+    this._backstageItems.forEach((backstageItem) => {
+      // check for label i18n key and translate if needed
+      if (backstageItem.labeli18nKey) {
+        let newItem;
+        if ((backstageItem as BackstageStageLauncher).stageId) {
+          newItem = BackstageItemUtilities.createStageLauncher(
+            (backstageItem as BackstageStageLauncher).stageId,
+            backstageItem.groupPriority,
+            backstageItem.itemPriority,
+            IModelApp.localization.getLocalizedString(
+              backstageItem.labeli18nKey
+            ),
+            backstageItem.subtitle,
+            backstageItem.icon
+          );
+        } else {
+          newItem = BackstageItemUtilities.createActionItem(
+            backstageItem.id,
+            backstageItem.groupPriority,
+            backstageItem.itemPriority,
+            (backstageItem as BackstageActionItem).execute,
+            IModelApp.localization.getLocalizedString(
+              backstageItem.labeli18nKey
+            ),
+            backstageItem.subtitle,
+            backstageItem.icon
+          );
+        }
+        allBackstageItems.push(newItem);
+      } else {
+        allBackstageItems.push(backstageItem);
+      }
+    });
+
+    // add a launcher item for the built-in frontstage if there is an active connection and other backstage items
+    if (allBackstageItems?.length > 0 && UiFramework.getIModelConnection()) {
+      allBackstageItems.unshift({
+        stageId: "DefaultFrontstage",
+        id: "DefaultFrontstage",
+        groupPriority: 100,
+        itemPriority: 10,
+        label: IModelApp.localization.getLocalizedString(
+          "iTwinViewer:backstage.mainFrontstage"
+        ),
+      });
+    }
+    return allBackstageItems;
+  }
+}

--- a/packages/modules/viewer-react/src/components/app-ui/providers/DefaultContentGroupProvider.ts
+++ b/packages/modules/viewer-react/src/components/app-ui/providers/DefaultContentGroupProvider.ts
@@ -1,0 +1,107 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { StandardContentLayouts } from "@itwin/appui-abstract";
+import {
+  ContentGroup,
+  ContentGroupProvider,
+  IModelViewportControl,
+  UiFramework,
+} from "@itwin/appui-react";
+import type { IModelConnection, ViewState } from "@itwin/core-frontend";
+import { ViewCreator3d } from "@itwin/core-frontend";
+
+import { createBlankViewState } from "../../../services/iModel/ViewCreatorBlank";
+import type {
+  BlankConnectionViewState,
+  ViewerViewCreator3dOptions,
+  ViewerViewportControlOptions,
+} from "../../../types";
+
+/**
+ * Provide a default content group to the default frontstage
+ */
+export class DefaultContentGroupProvider extends ContentGroupProvider {
+  private _viewportOptions: ViewerViewportControlOptions | undefined;
+  private _blankConnectionViewState: BlankConnectionViewState | undefined;
+  private _viewCreatorOptions: ViewerViewCreator3dOptions | undefined;
+
+  constructor(
+    viewportOptions?: ViewerViewportControlOptions,
+    viewCreatorOptions?: ViewerViewCreator3dOptions,
+    blankConnectionViewStateOptions?: BlankConnectionViewState
+  ) {
+    super();
+    this._viewportOptions = viewportOptions;
+    this._blankConnectionViewState = blankConnectionViewStateOptions;
+    this._viewCreatorOptions = viewCreatorOptions;
+  }
+
+  async getViewState(
+    connection: IModelConnection | undefined
+  ): Promise<ViewState | undefined> {
+    if (!connection || (!connection.isBlank && connection.isClosed)) {
+      return;
+    }
+    let view: ViewState | undefined;
+    if (this._viewportOptions?.viewState) {
+      if (typeof this._viewportOptions?.viewState === "function") {
+        view = await this._viewportOptions?.viewState(connection);
+      } else {
+        view = this._viewportOptions?.viewState;
+      }
+    }
+    if (
+      !this._viewportOptions?.alwaysUseSuppliedViewState &&
+      (!view ||
+        (view.iModel.iModelId !== connection.iModelId && connection.isOpen))
+    ) {
+      if (connection.isBlankConnection()) {
+        view = createBlankViewState(connection, this._blankConnectionViewState);
+      } else {
+        // attempt to construct a default viewState
+        const viewCreator = new ViewCreator3d(connection);
+
+        const options: ViewerViewCreator3dOptions = this._viewCreatorOptions
+          ? { ...this._viewCreatorOptions }
+          : { useSeedView: true };
+
+        if (options.useSeedView === undefined) {
+          options.useSeedView = true;
+        }
+
+        view = await viewCreator.createDefaultView(options);
+        UiFramework.setActiveSelectionScope("top-assembly");
+      }
+
+      // Should not be undefined
+      if (!view) {
+        throw new Error("No default view state for the imodel!");
+      }
+      // Set default view state
+      UiFramework.setDefaultViewState(view);
+    }
+    return view;
+  }
+
+  public async provideContentGroup(): Promise<ContentGroup> {
+    const iModelConnection = UiFramework.getIModelConnection();
+    const viewState = await this.getViewState(iModelConnection);
+    return new ContentGroup({
+      id: "content-group",
+      layout: StandardContentLayouts.singleView,
+      contents: [
+        {
+          id: "viewport",
+          classId: IModelViewportControl,
+          applicationData: {
+            ...this._viewportOptions,
+            viewState,
+            iModelConnection,
+          },
+        },
+      ],
+    });
+  }
+}

--- a/packages/modules/viewer-react/src/components/app-ui/providers/DefaultContentGroupProvider.ts
+++ b/packages/modules/viewer-react/src/components/app-ui/providers/DefaultContentGroupProvider.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+
 import { StandardContentLayouts } from "@itwin/appui-abstract";
 import {
   ContentGroup,
@@ -10,9 +11,8 @@ import {
   UiFramework,
 } from "@itwin/appui-react";
 import type { IModelConnection, ViewState } from "@itwin/core-frontend";
-import { ViewCreator3d } from "@itwin/core-frontend";
 
-import { createBlankViewState } from "../../../services/iModel/ViewCreatorBlank";
+import { createBlankViewState, ViewCreator3d } from "../../../services/iModel";
 import type {
   BlankConnectionViewState,
   ViewerViewCreator3dOptions,

--- a/packages/modules/viewer-react/src/components/app-ui/providers/index.ts
+++ b/packages/modules/viewer-react/src/components/app-ui/providers/index.ts
@@ -2,10 +2,5 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-
-export * from "./useTheme";
-export * from "./useUiProviders";
-export * from "./useIsMounted";
-export * from "./useBaseViewerInitializer";
-export * from "./useAccessToken";
-export * from "./useFrontstages";
+export * from "./DefaultContentGroupProvider";
+export * from "./BackstageItemsProvider";

--- a/packages/modules/viewer-react/src/components/app-ui/widgets/BasicToolWidget.tsx
+++ b/packages/modules/viewer-react/src/components/app-ui/widgets/BasicToolWidget.tsx
@@ -6,8 +6,13 @@
 /** Clone of core BasicToolWidget with conditional tooling
  */
 import type { CommonToolbarItem } from "@itwin/appui-abstract";
-import { ToolbarOrientation, ToolbarUsage } from "@itwin/appui-abstract";
+import {
+  BackstageItemsManager,
+  ToolbarOrientation,
+  ToolbarUsage,
+} from "@itwin/appui-abstract";
 import type { UiVisibilityEventArgs } from "@itwin/appui-react";
+import { useUiItemsProviderBackstageItems } from "@itwin/appui-react";
 import {
   BackstageAppButton,
   CoreTools,
@@ -17,15 +22,13 @@ import {
   ToolWidgetComposer,
   UiFramework,
 } from "@itwin/appui-react";
-import * as React from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 
 import type { ContentManipulationTools } from "../../../types";
 
 export function useUiVisibility(): boolean {
-  const [uiIsVisible, setUiIsVisible] = React.useState(
-    UiFramework.getIsUiVisible()
-  );
-  React.useEffect(() => {
+  const [uiIsVisible, setUiIsVisible] = useState(UiFramework.getIsUiVisible());
+  useEffect(() => {
     const handleUiVisibilityChanged = (args: UiVisibilityEventArgs): void =>
       setUiIsVisible(args.visible);
     UiFramework.onUiVisibilityChanged.addListener(handleUiVisibilityChanged);
@@ -46,74 +49,77 @@ interface BasicToolWidgetProps {
  * This definition will also show a overflow button if there is not enough room to display all the toolbar buttons.
  */
 export function BasicToolWidget({ config }: BasicToolWidgetProps): JSX.Element {
-  const getHorizontalToolbarItems =
-    React.useCallback((): CommonToolbarItem[] => {
-      if (config?.hideDefaultHorizontalItems) {
-        return [];
-      }
-      const items: CommonToolbarItem[] = [];
+  const backstageItems = useUiItemsProviderBackstageItems(
+    new BackstageItemsManager()
+  );
 
-      if (
-        config?.horizontalItems?.clearSelection === undefined ||
-        config?.horizontalItems?.clearSelection === true
-      ) {
-        items.push(
-          ToolbarHelper.createToolbarItemFromItemDef(
-            10,
-            CoreTools.clearSelectionItemDef
-          )
-        );
-      }
-      if (
-        config?.horizontalItems?.clearHideIsolateEmphasizeElements ===
-          undefined ||
-        config?.horizontalItems?.clearHideIsolateEmphasizeElements === true
-      ) {
-        items.push(
-          ToolbarHelper.createToolbarItemFromItemDef(
-            20,
-            SelectionContextToolDefinitions.clearHideIsolateEmphasizeElementsItemDef
-          )
-        );
-      }
-      if (
-        config?.horizontalItems?.hideElements === undefined ||
-        config?.horizontalItems?.hideElements === true
-      ) {
-        items.push(
-          ToolbarHelper.createToolbarItemFromItemDef(
-            30,
-            SelectionContextToolDefinitions.hideElementsItemDef
-          )
-        );
-      }
-      if (
-        config?.horizontalItems?.isolateElements === undefined ||
-        config?.horizontalItems?.isolateElements === true
-      ) {
-        items.push(
-          ToolbarHelper.createToolbarItemFromItemDef(
-            40,
-            SelectionContextToolDefinitions.isolateElementsItemDef
-          )
-        );
-      }
-      if (
-        config?.horizontalItems?.emphasizeElements === undefined ||
-        config?.horizontalItems?.emphasizeElements === true
-      ) {
-        items.push(
-          ToolbarHelper.createToolbarItemFromItemDef(
-            50,
-            SelectionContextToolDefinitions.emphasizeElementsItemDef
-          )
-        );
-      }
+  const getHorizontalToolbarItems = useCallback((): CommonToolbarItem[] => {
+    if (config?.hideDefaultHorizontalItems) {
+      return [];
+    }
+    const items: CommonToolbarItem[] = [];
 
-      return items;
-    }, [config]);
+    if (
+      config?.horizontalItems?.clearSelection === undefined ||
+      config?.horizontalItems?.clearSelection === true
+    ) {
+      items.push(
+        ToolbarHelper.createToolbarItemFromItemDef(
+          10,
+          CoreTools.clearSelectionItemDef
+        )
+      );
+    }
+    if (
+      config?.horizontalItems?.clearHideIsolateEmphasizeElements ===
+        undefined ||
+      config?.horizontalItems?.clearHideIsolateEmphasizeElements === true
+    ) {
+      items.push(
+        ToolbarHelper.createToolbarItemFromItemDef(
+          20,
+          SelectionContextToolDefinitions.clearHideIsolateEmphasizeElementsItemDef
+        )
+      );
+    }
+    if (
+      config?.horizontalItems?.hideElements === undefined ||
+      config?.horizontalItems?.hideElements === true
+    ) {
+      items.push(
+        ToolbarHelper.createToolbarItemFromItemDef(
+          30,
+          SelectionContextToolDefinitions.hideElementsItemDef
+        )
+      );
+    }
+    if (
+      config?.horizontalItems?.isolateElements === undefined ||
+      config?.horizontalItems?.isolateElements === true
+    ) {
+      items.push(
+        ToolbarHelper.createToolbarItemFromItemDef(
+          40,
+          SelectionContextToolDefinitions.isolateElementsItemDef
+        )
+      );
+    }
+    if (
+      config?.horizontalItems?.emphasizeElements === undefined ||
+      config?.horizontalItems?.emphasizeElements === true
+    ) {
+      items.push(
+        ToolbarHelper.createToolbarItemFromItemDef(
+          50,
+          SelectionContextToolDefinitions.emphasizeElementsItemDef
+        )
+      );
+    }
 
-  const getVerticalToolbarItems = React.useCallback((): CommonToolbarItem[] => {
+    return items;
+  }, [config]);
+
+  const getVerticalToolbarItems = useCallback((): CommonToolbarItem[] => {
     if (config?.hideDefaultVerticalItems) {
       return [];
     }
@@ -145,15 +151,16 @@ export function BasicToolWidget({ config }: BasicToolWidgetProps): JSX.Element {
     return items;
   }, [config]);
 
-  const [horizontalItems, setHorizontalItems] = React.useState(() =>
+  const [horizontalItems, setHorizontalItems] = useState(() =>
     getHorizontalToolbarItems()
   );
-  const [verticalItems, setVerticalItems] = React.useState(() =>
+  const [verticalItems, setVerticalItems] = useState(() =>
     getVerticalToolbarItems()
   );
 
-  const isInitialMount = React.useRef(true);
-  React.useEffect(() => {
+  const isInitialMount = useRef(true);
+
+  useEffect(() => {
     if (isInitialMount.current) {
       isInitialMount.current = false;
     } else {
@@ -171,7 +178,8 @@ export function BasicToolWidget({ config }: BasicToolWidgetProps): JSX.Element {
       cornerItem={
         config?.cornerItem?.item ? (
           config?.cornerItem?.item
-        ) : config?.cornerItem?.hideDefault ? undefined : (
+        ) : config?.cornerItem?.hideDefault ||
+          backstageItems.length <= 1 ? undefined : (
           <BackstageAppButton />
         )
       }

--- a/packages/modules/viewer-react/src/components/iModel/IModelLoader.tsx
+++ b/packages/modules/viewer-react/src/components/iModel/IModelLoader.tsx
@@ -164,7 +164,7 @@ const Loader: React.FC<ModelLoaderProps> = React.memo(
     useEffect(() => {
       if (customDefaultFrontstage && connection) {
         // there is a custom default frontstage so we need to generate a viewstate for backwards compatibility
-        // TODO revisit/remove in the next major release
+        // TODO next revisit/remove in the next major release
         void getAndSetViewState(
           connection,
           viewportOptions,

--- a/packages/modules/viewer-react/src/components/iModel/IModelLoader.tsx
+++ b/packages/modules/viewer-react/src/components/iModel/IModelLoader.tsx
@@ -234,8 +234,6 @@ const Loader: React.FC<ModelLoaderProps> = React.memo(
           // Tell the SyncUiEventDispatcher and StateManager about the iModelConnection
           UiFramework.setIModelConnection(imodelConnection, true);
 
-          SyncUiEventDispatcher.initializeConnectionEvents(imodelConnection);
-
           if (onIModelConnected) {
             onIModelConnected(imodelConnection);
           }
@@ -256,6 +254,7 @@ const Loader: React.FC<ModelLoaderProps> = React.memo(
           prevConnection = undefined;
         }
         if (mounted) {
+          setViewState(undefined);
           setConnection(undefined);
         }
       };
@@ -329,7 +328,8 @@ const Loader: React.FC<ModelLoaderProps> = React.memo(
         allFrontstages = [...frontstages];
       }
 
-      if (viewState) {
+      // TODO Kevin fix so we don't need this
+      if (isMounted.current && viewState && viewState.iModel.isOpen) {
         // initialize the DefaultFrontstage that contains the views that we want
         const defaultFrontstageProvider = new DefaultFrontstage(
           viewState,
@@ -345,7 +345,7 @@ const Loader: React.FC<ModelLoaderProps> = React.memo(
       }
 
       setFinalFrontstages(allFrontstages);
-    }, [frontstages, viewportOptions, viewState, defaultUiConfig]);
+    }, [frontstages, viewportOptions, viewState, defaultUiConfig, isMounted]);
 
     if (error) {
       throw error;

--- a/packages/modules/viewer-react/src/components/iModel/IModelLoader.tsx
+++ b/packages/modules/viewer-react/src/components/iModel/IModelLoader.tsx
@@ -154,7 +154,7 @@ const Loader: React.FC<ModelLoaderProps> = React.memo(
           setConnection(undefined);
         }
       };
-    }, [getModelConnection, isMounted, errorManager]);
+    }, [getModelConnection, isMounted]);
 
     if (error) {
       throw error;

--- a/packages/modules/viewer-react/src/components/iModel/IModelLoader.tsx
+++ b/packages/modules/viewer-react/src/components/iModel/IModelLoader.tsx
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-
 import "@bentley/icons-generic-webfont/dist/bentley-icons-generic-webfont.css";
 import "./IModelLoader.scss";
 
@@ -124,7 +123,7 @@ const Loader: React.FC<ModelLoaderProps> = React.memo(
         UiFramework.setIModelConnection(imodelConnection, true);
 
         if (onIModelConnected) {
-          onIModelConnected(imodelConnection);
+          await onIModelConnected(imodelConnection);
         }
         setConnection(imodelConnection);
         return imodelConnection;

--- a/packages/modules/viewer-react/src/components/iModel/IModelViewer.tsx
+++ b/packages/modules/viewer-react/src/components/iModel/IModelViewer.tsx
@@ -44,6 +44,7 @@ export const IModelViewer: React.FC<ModelProps> = ({
       );
     }
     return () => {
+      void FrontstageManager.setActiveFrontstageDef(undefined);
       FrontstageManager.clearFrontstageDefs();
       // TODO next replace the above with the below
       // FrontstageManager.clearFrontstageProviders();

--- a/packages/modules/viewer-react/src/components/iModel/IModelViewer.tsx
+++ b/packages/modules/viewer-react/src/components/iModel/IModelViewer.tsx
@@ -46,6 +46,8 @@ export const IModelViewer: React.FC<ModelProps> = ({
     }
     return () => {
       FrontstageManager.clearFrontstageDefs();
+      // TODO replace the above with the below
+      // FrontstageManager.clearFrontstageProviders();
     };
   }, [frontstages]);
 

--- a/packages/modules/viewer-react/src/components/iModel/IModelViewer.tsx
+++ b/packages/modules/viewer-react/src/components/iModel/IModelViewer.tsx
@@ -17,7 +17,7 @@ import React, { useEffect } from "react";
 import type { ViewerFrontstage } from "../../types";
 interface ModelProps {
   frontstages: ViewerFrontstage[];
-  backstageItems: BackstageItem[];
+  backstageItems?: BackstageItem[]; // TODO remove this and just use the UiItemsManager to get the items in the next major version
 }
 
 export const IModelViewer: React.FC<ModelProps> = ({
@@ -52,13 +52,18 @@ export const IModelViewer: React.FC<ModelProps> = ({
   }, [frontstages]);
 
   // there will always be at least one (for the default frontstage). Wait for it to be loaded into the list before rendering the content
-  return backstageItems.length > 0 ? (
+  return (
     <ThemeManager>
       <FrameworkVersion>
         <ConfigurableUiContent
-          appBackstage={<BackstageComposer items={backstageItems} />}
+          appBackstage={
+            backstageItems &&
+            backstageItems.length > 0 && (
+              <BackstageComposer items={backstageItems} />
+            )
+          }
         />
       </FrameworkVersion>
     </ThemeManager>
-  ) : null;
+  );
 };

--- a/packages/modules/viewer-react/src/components/iModel/IModelViewer.tsx
+++ b/packages/modules/viewer-react/src/components/iModel/IModelViewer.tsx
@@ -17,7 +17,7 @@ import React, { useEffect } from "react";
 import type { ViewerFrontstage } from "../../types";
 interface ModelProps {
   frontstages: ViewerFrontstage[];
-  backstageItems?: BackstageItem[]; // TODO remove this and just use the UiItemsManager to get the items in the next major version
+  backstageItems?: BackstageItem[]; // TODO next remove this and just use the UiItemsManager to get the items in the next major version
 }
 
 export const IModelViewer: React.FC<ModelProps> = ({
@@ -39,14 +39,13 @@ export const IModelViewer: React.FC<ModelProps> = ({
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       void FrontstageManager.getFrontstageDef(defaultFrontstage.id).then(
         (frontstageDef) => {
-          //TODO 3.0 test this
           void FrontstageManager.setActiveFrontstageDef(frontstageDef);
         }
       );
     }
     return () => {
       FrontstageManager.clearFrontstageDefs();
-      // TODO replace the above with the below
+      // TODO next replace the above with the below
       // FrontstageManager.clearFrontstageProviders();
     };
   }, [frontstages]);

--- a/packages/modules/viewer-react/src/hooks/useFrontstages.tsx
+++ b/packages/modules/viewer-react/src/hooks/useFrontstages.tsx
@@ -2,6 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+
+import type { IModelConnection } from "@itwin/core-frontend";
 import { useEffect, useState } from "react";
 
 import { DefaultFrontstage } from "../components/app-ui/frontstages/DefaultFrontstage";
@@ -27,12 +29,14 @@ export const useFrontstages = (
 
   useEffect(() => {
     let allFrontstages: ViewerFrontstage[] = [];
+    let defaultExists = false;
     if (frontstages) {
       allFrontstages = [...frontstages];
       const defaultFrontstages = frontstages.filter(
         (frontstage) => frontstage.default
       );
       if (defaultFrontstages.length > 0) {
+        defaultExists = true;
         // there should only be one, but check if any default frontstage requires an iModel connection
         let requiresConnection = false;
         for (let i = 0; i < defaultFrontstages.length; i++) {
@@ -44,24 +48,26 @@ export const useFrontstages = (
         if (!requiresConnection) {
           // allow to continue to render
           setNoConnectionRequired(true);
-          return;
         }
       }
     }
 
-    // initialize the DefaultFrontstage that contains the views that we want
-    const defaultFrontstageProvider = new DefaultFrontstage(
-      defaultUiConfig,
-      viewportOptions,
-      viewCreatorOptions,
-      blankConnectionViewState
-    );
+    //TODO revisit this. what is the proper check here?
+    if (!noConnectionRequired) {
+      // initialize the DefaultFrontstage that contains the views that we want
+      const defaultFrontstageProvider = new DefaultFrontstage(
+        defaultUiConfig,
+        viewportOptions,
+        viewCreatorOptions,
+        blankConnectionViewState
+      );
 
-    // add the default frontstage first so that it's default status can be overridden
-    allFrontstages.unshift({
-      provider: defaultFrontstageProvider,
-      default: true,
-    });
+      // add the default frontstage first so that it's default status can be overridden
+      allFrontstages.unshift({
+        provider: defaultFrontstageProvider,
+        default: !defaultExists,
+      });
+    }
 
     setFinalFrontstages(allFrontstages);
   }, [
@@ -70,6 +76,7 @@ export const useFrontstages = (
     viewCreatorOptions,
     viewportOptions,
     blankConnectionViewState,
+    noConnectionRequired,
   ]);
 
   return { finalFrontstages, noConnectionRequired };

--- a/packages/modules/viewer-react/src/hooks/useFrontstages.tsx
+++ b/packages/modules/viewer-react/src/hooks/useFrontstages.tsx
@@ -42,7 +42,7 @@ export const useFrontstages = (
         defaultExists = true;
         // if there are multiple defaults (there should not be), the last wins to be consistent with the default that is used in IModelViewer
         requiresConnection =
-          !defaultFrontstages[defaultFrontstages.length - 1]
+          !!defaultFrontstages[defaultFrontstages.length - 1]
             .requiresIModelConnection;
 
         if (!requiresConnection) {

--- a/packages/modules/viewer-react/src/hooks/useFrontstages.tsx
+++ b/packages/modules/viewer-react/src/hooks/useFrontstages.tsx
@@ -31,6 +31,7 @@ export const useFrontstages = (
   useEffect(() => {
     let allFrontstages: ViewerFrontstage[] = [];
     let defaultExists = false;
+    let requiresConnection = true;
     if (frontstages) {
       allFrontstages = [...frontstages];
       const defaultFrontstages = frontstages.filter(
@@ -39,14 +40,11 @@ export const useFrontstages = (
       if (defaultFrontstages.length > 0) {
         setCustomDefaultFrontstage(true);
         defaultExists = true;
-        // there should only be one, but check if any default frontstage requires an iModel connection
-        let requiresConnection = false;
-        for (let i = 0; i < defaultFrontstages.length; i++) {
-          if (defaultFrontstages[i].requiresIModelConnection) {
-            requiresConnection = true;
-            break;
-          }
-        }
+        // if there are multiple defaults (there should not be), the last wins to be consistent with the default that is used in IModelViewer
+        requiresConnection =
+          !defaultFrontstages[defaultFrontstages.length - 1]
+            .requiresIModelConnection;
+
         if (!requiresConnection) {
           // allow to continue to render
           setNoConnectionRequired(true);
@@ -54,7 +52,7 @@ export const useFrontstages = (
       }
     }
 
-    if (!noConnectionRequired) {
+    if (requiresConnection) {
       // we require a connection, so initialize the DefaultFrontstage that contains the views that we want
       const defaultFrontstageProvider = new DefaultFrontstage(
         defaultUiConfig,
@@ -77,7 +75,6 @@ export const useFrontstages = (
     viewCreatorOptions,
     viewportOptions,
     blankConnectionViewState,
-    noConnectionRequired,
   ]);
 
   return { finalFrontstages, noConnectionRequired, customDefaultFrontstage };

--- a/packages/modules/viewer-react/src/hooks/useFrontstages.tsx
+++ b/packages/modules/viewer-react/src/hooks/useFrontstages.tsx
@@ -54,9 +54,8 @@ export const useFrontstages = (
       }
     }
 
-    //TODO revisit this. what is the proper check here?
     if (!noConnectionRequired) {
-      // initialize the DefaultFrontstage that contains the views that we want
+      // we require a connection, so initialize the DefaultFrontstage that contains the views that we want
       const defaultFrontstageProvider = new DefaultFrontstage(
         defaultUiConfig,
         viewportOptions,

--- a/packages/modules/viewer-react/src/hooks/useFrontstages.tsx
+++ b/packages/modules/viewer-react/src/hooks/useFrontstages.tsx
@@ -1,0 +1,76 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { useEffect, useState } from "react";
+
+import { DefaultFrontstage } from "../components/app-ui/frontstages/DefaultFrontstage";
+import type {
+  BlankConnectionViewState,
+  ItwinViewerUi,
+  ViewerFrontstage,
+  ViewerViewCreator3dOptions,
+  ViewerViewportControlOptions,
+} from "../types";
+
+export const useFrontstages = (
+  frontstages?: ViewerFrontstage[],
+  defaultUiConfig?: ItwinViewerUi,
+  viewportOptions?: ViewerViewportControlOptions,
+  viewCreatorOptions?: ViewerViewCreator3dOptions,
+  blankConnectionViewState?: BlankConnectionViewState
+) => {
+  const [finalFrontstages, setFinalFrontstages] =
+    useState<ViewerFrontstage[]>();
+  const [noConnectionRequired, setNoConnectionRequired] =
+    useState<boolean>(false);
+
+  useEffect(() => {
+    let allFrontstages: ViewerFrontstage[] = [];
+    if (frontstages) {
+      allFrontstages = [...frontstages];
+      const defaultFrontstages = frontstages.filter(
+        (frontstage) => frontstage.default
+      );
+      if (defaultFrontstages.length > 0) {
+        // there should only be one, but check if any default frontstage requires an iModel connection
+        let requiresConnection = false;
+        for (let i = 0; i < defaultFrontstages.length; i++) {
+          if (defaultFrontstages[i].requiresIModelConnection) {
+            requiresConnection = true;
+            break;
+          }
+        }
+        if (!requiresConnection) {
+          // allow to continue to render
+          setNoConnectionRequired(true);
+          return;
+        }
+      }
+    }
+
+    // initialize the DefaultFrontstage that contains the views that we want
+    const defaultFrontstageProvider = new DefaultFrontstage(
+      defaultUiConfig,
+      viewportOptions,
+      viewCreatorOptions,
+      blankConnectionViewState
+    );
+
+    // add the default frontstage first so that it's default status can be overridden
+    allFrontstages.unshift({
+      provider: defaultFrontstageProvider,
+      default: true,
+    });
+
+    setFinalFrontstages(allFrontstages);
+  }, [
+    frontstages,
+    defaultUiConfig,
+    viewCreatorOptions,
+    viewportOptions,
+    blankConnectionViewState,
+  ]);
+
+  return { finalFrontstages, noConnectionRequired };
+};

--- a/packages/modules/viewer-react/src/hooks/useFrontstages.tsx
+++ b/packages/modules/viewer-react/src/hooks/useFrontstages.tsx
@@ -3,7 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import type { IModelConnection } from "@itwin/core-frontend";
 import { useEffect, useState } from "react";
 
 import { DefaultFrontstage } from "../components/app-ui/frontstages/DefaultFrontstage";
@@ -26,6 +25,8 @@ export const useFrontstages = (
     useState<ViewerFrontstage[]>();
   const [noConnectionRequired, setNoConnectionRequired] =
     useState<boolean>(false);
+  const [customDefaultFrontstage, setCustomDefaultFrontstage] =
+    useState<boolean>(false);
 
   useEffect(() => {
     let allFrontstages: ViewerFrontstage[] = [];
@@ -36,6 +37,7 @@ export const useFrontstages = (
         (frontstage) => frontstage.default
       );
       if (defaultFrontstages.length > 0) {
+        setCustomDefaultFrontstage(true);
         defaultExists = true;
         // there should only be one, but check if any default frontstage requires an iModel connection
         let requiresConnection = false;
@@ -79,5 +81,5 @@ export const useFrontstages = (
     noConnectionRequired,
   ]);
 
-  return { finalFrontstages, noConnectionRequired };
+  return { finalFrontstages, noConnectionRequired, customDefaultFrontstage };
 };

--- a/packages/modules/viewer-react/src/hooks/useUiProviders.tsx
+++ b/packages/modules/viewer-react/src/hooks/useUiProviders.tsx
@@ -10,11 +10,14 @@ import { PropertyGridUiItemsProvider } from "@itwin/property-grid-react";
 import { TreeWidgetUiItemsProvider } from "@itwin/tree-widget-react";
 import { useEffect } from "react";
 
+import { BackstageItemsProvider } from "../components/app-ui/providers";
+import type { ViewerBackstageItem } from "../types";
 import type { ItwinViewerUi } from "../types";
 
 export function useUiProviders(
   customUiProviders?: UiItemsProvider[],
-  defaultUiConfig?: ItwinViewerUi
+  defaultUiConfig?: ItwinViewerUi,
+  backstageItems?: ViewerBackstageItem[]
 ): void {
   useEffect(() => {
     const defaultProviders: UiItemsProvider[] = [];
@@ -39,6 +42,10 @@ export function useUiProviders(
       defaultProviders.push(new MeasureToolsUiItemsProvider());
     }
 
+    if (backstageItems && backstageItems.length > 0) {
+      defaultProviders.push(new BackstageItemsProvider(backstageItems));
+    }
+
     const uiProviders = customUiProviders
       ? customUiProviders.concat(defaultProviders)
       : defaultProviders;
@@ -52,5 +59,5 @@ export function useUiProviders(
         UiItemsManager.unregister(uiProvider.id);
       });
     };
-  }, [customUiProviders, defaultUiConfig]);
+  }, [customUiProviders, defaultUiConfig, backstageItems]);
 }

--- a/packages/modules/viewer-react/src/services/iModel/IModelService.ts
+++ b/packages/modules/viewer-react/src/services/iModel/IModelService.ts
@@ -129,7 +129,7 @@ export const getViewState = async (
   viewCreatorOptions?: ViewerViewCreator3dOptions,
   blankConnectionViewState?: BlankConnectionViewState
 ): Promise<ViewState | undefined> => {
-  if (!connection.isBlank && connection.isClosed) {
+  if (!connection.isBlankConnection() && connection.isClosed) {
     return;
   }
   let view: ViewState | undefined;

--- a/packages/modules/viewer-react/src/tests/components/app-ui/providers/BackstageItemsProvider.test.tsx
+++ b/packages/modules/viewer-react/src/tests/components/app-ui/providers/BackstageItemsProvider.test.tsx
@@ -1,0 +1,147 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { BackstageItemUtilities } from "@itwin/appui-abstract";
+import type { FrontstageProps } from "@itwin/appui-react";
+import { FrontstageProvider } from "@itwin/appui-react";
+import { IModelApp } from "@itwin/core-frontend";
+import React from "react";
+
+import { BackstageItemsProvider } from "../../../../components/app-ui/providers";
+import type { ViewerBackstageItem, ViewerFrontstage } from "../../../../types";
+
+jest.mock("@itwin/core-frontend", () => {
+  return {
+    IModelApp: {
+      startup: jest.fn(),
+      telemetry: {
+        addClient: jest.fn(),
+      },
+      localization: {
+        getLocalizedString: jest.fn(),
+        registerNamespace: jest.fn().mockResolvedValue(true),
+      },
+      uiAdmin: {
+        updateFeatureFlags: jest.fn(),
+      },
+      notifications: {
+        openMessageBox: jest.fn(),
+      },
+      viewManager: {
+        onViewOpen: {
+          addOnce: jest.fn(),
+        },
+      },
+    },
+    SnapMode: {},
+    ActivityMessageDetails: jest.fn(),
+    PrimitiveTool: jest.fn(),
+    NotificationManager: jest.fn(),
+    Tool: jest.fn(),
+    RemoteBriefcaseConnection: {
+      open: jest.fn(),
+    },
+    SnapshotConnection: {
+      openFile: jest.fn(),
+    },
+    MessageBoxType: {
+      Ok: 1,
+    },
+    MessageBoxIconType: {
+      Critical: 1,
+    },
+    BlankConnection: {
+      create: jest.fn().mockReturnValue({
+        isBlankConnection: () => true,
+        isOpen: true,
+      } as any),
+    },
+    ItemField: {},
+    CompassMode: {},
+    RotationMode: {},
+    AccuDraw: class {},
+    ToolAdmin: class {},
+    WebViewerApp: {
+      startup: jest.fn().mockResolvedValue(true),
+    },
+    ViewCreator3d: jest.fn().mockImplementation(() => {
+      return {
+        createDefaultView: jest.fn().mockResolvedValue({}),
+      };
+    }),
+    SpatialViewState: {
+      className: "",
+    },
+    DrawingViewState: {
+      className: "",
+    },
+    SheetViewState: {
+      className: "",
+    },
+  };
+});
+jest.mock("@itwin/appui-abstract");
+
+class Frontstage1Provider extends FrontstageProvider {
+  public id = "Frontstage1";
+  public get frontstage(): React.ReactElement<FrontstageProps> {
+    return <div></div>;
+  }
+}
+
+class Frontstage2Provider extends FrontstageProvider {
+  public id = "Frontstage2";
+  public get frontstage(): React.ReactElement<FrontstageProps> {
+    return <div></div>;
+  }
+}
+
+describe("BackstageItemsProvider", () => {
+  it("adds backstage items and translates their labels", async () => {
+    const fs1 = new Frontstage1Provider();
+    const fs2 = new Frontstage2Provider();
+    const frontstages: ViewerFrontstage[] = [
+      {
+        provider: fs1,
+      },
+      {
+        provider: fs2,
+      },
+    ];
+
+    const actionItem = {
+      id: "bs1",
+      execute: jest.fn(),
+      groupPriority: 100,
+      itemPriority: 1,
+      label: "",
+      labeli18nKey: "bs1Key",
+    };
+
+    const stageLauncher = {
+      id: "bs2",
+      stageId: "bs2",
+      groupPriority: 100,
+      itemPriority: 2,
+      label: "",
+      labeli18nKey: "bs2Key",
+    };
+
+    const backstageItems: ViewerBackstageItem[] = [actionItem, stageLauncher];
+
+    const provider = new BackstageItemsProvider(backstageItems);
+
+    provider.provideBackstageItems();
+
+    // these calls will be doubled. items will be set first without a viewState and reset with one additional translation for the default frontstage once we have a viewState
+    expect(BackstageItemUtilities.createStageLauncher).toHaveBeenCalledTimes(1);
+    expect(BackstageItemUtilities.createActionItem).toHaveBeenCalledTimes(1);
+    expect(IModelApp.localization.getLocalizedString).toHaveBeenCalledWith(
+      actionItem.labeli18nKey
+    );
+    expect(IModelApp.localization.getLocalizedString).toHaveBeenCalledWith(
+      stageLauncher.labeli18nKey
+    );
+  });
+});

--- a/packages/modules/viewer-react/src/tests/components/app-ui/providers/DefaultContentGroupProvider.test.tsx
+++ b/packages/modules/viewer-react/src/tests/components/app-ui/providers/DefaultContentGroupProvider.test.tsx
@@ -1,0 +1,120 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { UiFramework } from "@itwin/appui-react";
+
+import { DefaultContentGroupProvider } from "../../../../components/app-ui/providers";
+import { ViewCreator3d } from "../../../../services/iModel";
+import { createBlankViewState } from "../../../../services/iModel";
+
+jest.mock("@itwin/core-frontend", () => {
+  return {
+    IModelApp: {
+      startup: jest.fn(),
+      telemetry: {
+        addClient: jest.fn(),
+      },
+      localization: {
+        getLocalizedString: jest.fn(),
+        registerNamespace: jest.fn().mockResolvedValue(true),
+      },
+      uiAdmin: {
+        updateFeatureFlags: jest.fn(),
+      },
+      notifications: {
+        openMessageBox: jest.fn(),
+      },
+      viewManager: {
+        onViewOpen: {
+          addOnce: jest.fn(),
+        },
+      },
+    },
+    SnapMode: {},
+    ActivityMessageDetails: jest.fn(),
+    PrimitiveTool: jest.fn(),
+    NotificationManager: jest.fn(),
+    Tool: jest.fn(),
+    RemoteBriefcaseConnection: {
+      open: jest.fn(),
+    },
+    SnapshotConnection: {
+      openFile: jest.fn(),
+    },
+    MessageBoxType: {
+      Ok: 1,
+    },
+    MessageBoxIconType: {
+      Critical: 1,
+    },
+    BlankConnection: {
+      create: jest.fn().mockReturnValue({
+        isBlankConnection: () => true,
+        isOpen: true,
+      } as any),
+    },
+    ItemField: {},
+    CompassMode: {},
+    RotationMode: {},
+    AccuDraw: class {},
+    ToolAdmin: class {},
+    WebViewerApp: {
+      startup: jest.fn().mockResolvedValue(true),
+    },
+    ViewCreator3d: jest.fn().mockImplementation(() => {
+      return {
+        createDefaultView: jest.fn().mockResolvedValue({}),
+      };
+    }),
+    SpatialViewState: {
+      className: "",
+    },
+    DrawingViewState: {
+      className: "",
+    },
+    SheetViewState: {
+      className: "",
+    },
+  };
+});
+
+jest.mock("../../../../services/iModel/ViewCreatorBlank", () => {
+  return {
+    createBlankViewState: jest.fn().mockResolvedValue({}),
+  };
+});
+
+jest.mock("../../../../services/iModel/ViewCreator3d", () => {
+  return {
+    ViewCreator3d: jest.fn().mockImplementation(() => {
+      return {
+        createDefaultView: jest.fn().mockResolvedValue({}),
+      };
+    }),
+  };
+});
+
+describe("DefaultContentGroupProvider", () => {
+  it("creates a default ViewState for a connection", async () => {
+    jest.spyOn(UiFramework, "getIModelConnection").mockReturnValue({
+      isBlankConnection: () => false,
+    } as any);
+    jest.spyOn(UiFramework, "setDefaultViewState").mockReturnValue();
+
+    const contentGroupProvider = new DefaultContentGroupProvider();
+    await contentGroupProvider.provideContentGroup();
+    expect(ViewCreator3d).toHaveBeenCalled();
+  });
+
+  it("creates a blank ViewState for a blank connection", async () => {
+    jest.spyOn(UiFramework, "getIModelConnection").mockReturnValue({
+      isBlankConnection: () => true,
+    } as any);
+    jest.spyOn(UiFramework, "setDefaultViewState").mockReturnValue();
+
+    const contentGroupProvider = new DefaultContentGroupProvider();
+    await contentGroupProvider.provideContentGroup();
+    expect(createBlankViewState).toHaveBeenCalled();
+  });
+});

--- a/packages/modules/viewer-react/src/tests/components/app-ui/widgets/BasicToolWidget.test.tsx
+++ b/packages/modules/viewer-react/src/tests/components/app-ui/widgets/BasicToolWidget.test.tsx
@@ -41,6 +41,7 @@ jest.mock("@itwin/appui-react", () => {
         removeListener: jest.fn(),
       },
     },
+    useUiItemsProviderBackstageItems: () => [],
   };
 });
 

--- a/packages/modules/viewer-react/src/tests/components/iModel/IModelLoader.test.tsx
+++ b/packages/modules/viewer-react/src/tests/components/iModel/IModelLoader.test.tsx
@@ -153,20 +153,6 @@ jest.mock("../../../components/iModel/IModelViewer", () => ({
   IModelViewer: jest.fn(() => <div data-testid="viewer"></div>),
 }));
 
-class Frontstage1Provider extends FrontstageProvider {
-  public id = "Frontstage1";
-  public get frontstage(): React.ReactElement<FrontstageProps> {
-    return <div></div>;
-  }
-}
-
-class Frontstage2Provider extends FrontstageProvider {
-  public id = "Frontstage2";
-  public get frontstage(): React.ReactElement<FrontstageProps> {
-    return <div></div>;
-  }
-}
-
 const mockITwinId = "mockITwinId";
 const mockIModelId = "mockIModelId";
 
@@ -215,61 +201,7 @@ describe("IModelLoader", () => {
     expect(UiItemsManager.unregister).toHaveBeenCalledTimes(4);
   });
 
-  it("adds backstage items and translates their labels", async () => {
-    const fs1 = new Frontstage1Provider();
-    const fs2 = new Frontstage2Provider();
-    const frontstages: ViewerFrontstage[] = [
-      {
-        provider: fs1,
-      },
-      {
-        provider: fs2,
-      },
-    ];
-
-    const actionItem = {
-      id: "bs1",
-      execute: jest.fn(),
-      groupPriority: 100,
-      itemPriority: 1,
-      label: "",
-      labeli18nKey: "bs1Key",
-    };
-
-    const stageLauncher = {
-      id: "bs2",
-      stageId: "bs2",
-      groupPriority: 100,
-      itemPriority: 2,
-      label: "",
-      labeli18nKey: "bs2Key",
-    };
-
-    const backstageItems: ViewerBackstageItem[] = [actionItem, stageLauncher];
-
-    const { getByTestId } = render(
-      <IModelLoader
-        frontstages={frontstages}
-        backstageItems={backstageItems}
-        iTwinId={mockITwinId}
-        iModelId={mockIModelId}
-      />
-    );
-
-    await waitFor(() => getByTestId("loader-wrapper"));
-
-    // these calls will be doubled. items will be set first without a viewState and reset with one additional translation for the default frontstage once we have a viewState
-    expect(BackstageItemUtilities.createStageLauncher).toHaveBeenCalledTimes(2);
-    expect(BackstageItemUtilities.createActionItem).toHaveBeenCalledTimes(2);
-    expect(IModelApp.localization.getLocalizedString).toHaveBeenCalledWith(
-      actionItem.labeli18nKey
-    );
-    expect(IModelApp.localization.getLocalizedString).toHaveBeenCalledWith(
-      stageLauncher.labeli18nKey
-    );
-  });
-
-  it("creates a blank connection and a blank ViewState", async () => {
+  it("creates a blank connection", async () => {
     const blankConnection: BlankConnectionProps = {
       name: "GeometryConnection",
       location: Cartographic.fromDegrees({
@@ -297,10 +229,6 @@ describe("IModelLoader", () => {
     await waitFor(() => getByTestId("viewer"));
 
     expect(BlankConnection.create).toHaveBeenCalledWith(blankConnection);
-    expect(createBlankViewState).toHaveBeenCalledWith(
-      expect.anything(),
-      viewStateOptions
-    );
   });
 
   it("sets the theme to the provided theme", async () => {

--- a/packages/modules/viewer-react/src/tests/components/iModel/IModelLoader.test.tsx
+++ b/packages/modules/viewer-react/src/tests/components/iModel/IModelLoader.test.tsx
@@ -5,23 +5,11 @@
 
 import "@testing-library/jest-dom/extend-expect";
 
-import { BackstageItemUtilities, UiItemsManager } from "@itwin/appui-abstract";
-import type { FrontstageProps } from "@itwin/appui-react";
-import {
-  ColorTheme,
-  FrontstageProvider,
-  UiFramework,
-} from "@itwin/appui-react";
+import { UiItemsManager } from "@itwin/appui-abstract";
+import { ColorTheme, UiFramework } from "@itwin/appui-react";
 import { Cartographic, ColorDef } from "@itwin/core-common";
-import type {
-  BlankConnectionProps,
-  IModelConnection,
-} from "@itwin/core-frontend";
-import {
-  BlankConnection,
-  IModelApp,
-  SnapshotConnection,
-} from "@itwin/core-frontend";
+import type { BlankConnectionProps } from "@itwin/core-frontend";
+import { BlankConnection, SnapshotConnection } from "@itwin/core-frontend";
 import { Range3d } from "@itwin/core-geometry";
 import { render, waitFor } from "@testing-library/react";
 import React from "react";
@@ -29,12 +17,9 @@ import React from "react";
 import { IModelViewer } from "../../../components/iModel";
 import IModelLoader from "../../../components/iModel/IModelLoader";
 import * as IModelServices from "../../../services/iModel/IModelService";
-import { createBlankViewState } from "../../../services/iModel/ViewCreatorBlank";
 import type {
   BlankConnectionViewState,
-  ViewerBackstageItem,
   ViewerFrontstage,
-  ViewerViewportControlOptions,
 } from "../../../types";
 import { TestUiProvider, TestUiProvider2 } from "../../mocks/MockUiProviders";
 
@@ -133,20 +118,6 @@ jest.mock("@itwin/core-frontend", () => {
   };
 });
 jest.mock("../../../services/iModel/IModelService");
-jest.mock("../../../services/iModel/ViewCreatorBlank", () => {
-  return {
-    createBlankViewState: jest.fn().mockResolvedValue({}),
-  };
-});
-jest.mock("../../../services/iModel/ViewCreator3d", () => {
-  return {
-    ViewCreator3d: jest.fn().mockImplementation(() => {
-      return {
-        createDefaultView: jest.fn().mockResolvedValue({}),
-      };
-    }),
-  };
-});
 
 jest.mock("../../../components/iModel/IModelViewer", () => ({
   __esModule: true,
@@ -245,147 +216,6 @@ describe("IModelLoader", () => {
     expect(UiFramework.setColorTheme).toHaveBeenCalledWith(ColorTheme.Dark);
   });
 
-  it("creates a default viewstate", async () => {
-    jest.spyOn(UiFramework, "setDefaultViewState");
-    const result = render(
-      <IModelLoader iTwinId={mockITwinId} iModelId={mockIModelId} />
-    );
-
-    await waitFor(() => result.getByTestId("loader-wrapper"));
-
-    expect(UiFramework.setDefaultViewState).toHaveBeenCalled();
-  });
-
-  it("uses the provided viewstate when connection imodelid matches viewstate imodelid", async () => {
-    jest.spyOn(UiFramework, "setDefaultViewState");
-    const viewportOptions: ViewerViewportControlOptions = {
-      viewState: {
-        iModel: {
-          iModelId: mockIModelId,
-        },
-      } as any,
-    };
-    const result = render(
-      <IModelLoader
-        iTwinId={mockITwinId}
-        iModelId={mockIModelId}
-        viewportOptions={viewportOptions}
-      />
-    );
-
-    await waitFor(() => result.getByTestId("loader-wrapper"));
-
-    expect(UiFramework.setDefaultViewState).not.toHaveBeenCalled();
-  });
-
-  it("calls the provided viewstate method when connection getting viewstate", async () => {
-    jest.spyOn(UiFramework, "setDefaultViewState");
-    const viewportOptions: ViewerViewportControlOptions = {
-      viewState: (connection: IModelConnection) =>
-        ({
-          iModel: connection,
-        } as any),
-    };
-    const result = render(
-      <IModelLoader
-        iTwinId={mockITwinId}
-        iModelId={mockIModelId}
-        viewportOptions={viewportOptions}
-      />
-    );
-
-    await waitFor(() => result.getByTestId("loader-wrapper"));
-
-    expect(UiFramework.setDefaultViewState).not.toHaveBeenCalled();
-  });
-
-  it("awaits the provided viewstate async method when connection getting viewstate", async () => {
-    jest.spyOn(UiFramework, "setDefaultViewState");
-    const viewportOptions: ViewerViewportControlOptions = {
-      viewState: async (connection: IModelConnection) =>
-        new Promise((resolve) =>
-          resolve({
-            iModel: connection,
-          })
-        ) as any,
-    };
-    const result = render(
-      <IModelLoader
-        iTwinId={mockITwinId}
-        iModelId={mockIModelId}
-        viewportOptions={viewportOptions}
-      />
-    );
-
-    await waitFor(() => result.getByTestId("loader-wrapper"));
-
-    expect(UiFramework.setDefaultViewState).not.toHaveBeenCalled();
-  });
-
-  it("waits for indefinitely for viewstate when alwaysUseSuppliedViewState is true", async () => {
-    jest.spyOn(UiFramework, "setDefaultViewState");
-    const viewportOptions: ViewerViewportControlOptions = {
-      alwaysUseSuppliedViewState: true,
-    };
-    const result = render(
-      <IModelLoader
-        iTwinId={mockITwinId}
-        iModelId={mockIModelId}
-        viewportOptions={viewportOptions}
-      />
-    );
-
-    await waitFor(() => result.getByTestId("loader-wrapper"));
-
-    expect(UiFramework.setDefaultViewState).not.toHaveBeenCalled();
-  });
-
-  it("creates a default viewstate alwaysUseSuppliedViewState is false and no viewstate is provided", async () => {
-    jest.spyOn(UiFramework, "setDefaultViewState");
-    const viewportOptions: ViewerViewportControlOptions = {
-      alwaysUseSuppliedViewState: false,
-    };
-    const result = render(
-      <IModelLoader
-        iTwinId={mockITwinId}
-        iModelId={mockIModelId}
-        viewportOptions={viewportOptions}
-      />
-    );
-
-    await waitFor(() => result.getByTestId("loader-wrapper"));
-
-    expect(UiFramework.setDefaultViewState).toHaveBeenCalled();
-  });
-
-  it("creates a default viewstate when connection imodelid does not match viewstate imodelid", async () => {
-    jest.spyOn(IModelServices, "openRemoteIModel").mockResolvedValue({
-      isBlankConnection: () => false,
-      iModelId: undefined,
-      close: jest.fn(),
-      isOpen: true,
-    } as any);
-    jest.spyOn(UiFramework, "setDefaultViewState");
-    const viewportOptions: ViewerViewportControlOptions = {
-      viewState: {
-        iModel: {
-          iModelId: mockIModelId,
-        },
-      } as any,
-    };
-    const result = render(
-      <IModelLoader
-        iTwinId={mockITwinId}
-        iModelId={mockIModelId}
-        viewportOptions={viewportOptions}
-      />
-    );
-
-    await waitFor(() => result.getByTestId("loader-wrapper"));
-
-    expect(UiFramework.setDefaultViewState).toHaveBeenCalled();
-  });
-
   it("renders without a viewState if the default frontstage does not require a connection", async () => {
     const frontstages: ViewerFrontstage[] = [
       {
@@ -402,7 +232,7 @@ describe("IModelLoader", () => {
     );
     await waitFor(() => result.getByTestId("viewer"));
     expect(IModelViewer).toHaveBeenCalledWith(
-      { backstageItems: [], frontstages },
+      { backstageItems: undefined, frontstages },
       {}
     );
   });

--- a/packages/modules/viewer-react/src/tests/components/iModel/IModelViewer.test.tsx
+++ b/packages/modules/viewer-react/src/tests/components/iModel/IModelViewer.test.tsx
@@ -36,6 +36,9 @@ jest.mock("@itwin/appui-react", () => {
       clearFrontstageDefs: jest.fn(),
     },
     FrontstageProvider: jest.fn(),
+    ThemeManager: jest.fn(() => <div></div>),
+    FrameworkVersion: jest.fn(() => <div></div>),
+    ConfigurableUiContent: jest.fn(() => <div></div>),
   };
 });
 jest.mock("@itwin/appui-abstract");

--- a/packages/modules/viewer-react/src/types.ts
+++ b/packages/modules/viewer-react/src/types.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-
 import type { BackstageItem, UiItemsProvider } from "@itwin/appui-abstract";
 import type {
   ColorTheme,
@@ -64,7 +63,9 @@ export interface IModelLoaderParams {
   /** Default UI configuration */
   defaultUiConfig?: ItwinViewerUi;
   /** Optional callback function when iModel is connected */
-  onIModelConnected?: (iModel: IModelConnection) => void;
+  onIModelConnected?:
+    | ((iModel: IModelConnection) => void)
+    | ((iModel: IModelConnection) => Promise<void>);
   /** additional frontstages to register */
   frontstages?: ViewerFrontstage[];
   /** menu items for the backstage */

--- a/packages/modules/viewer-react/tsconfig.json
+++ b/packages/modules/viewer-react/tsconfig.json
@@ -6,5 +6,5 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false
   },
-  "include": ["./src/**/*.ts"]
+  "include": ["./src/**/*.ts*"]
 }

--- a/packages/modules/web-viewer-react/src/components/BlankViewer.tsx
+++ b/packages/modules/web-viewer-react/src/components/BlankViewer.tsx
@@ -24,5 +24,5 @@ export const BlankViewer = (props: WebBlankViewerProps) => {
     return WebInitializer.cancel;
   }, [memoizedProps]);
 
-  return initialized ? <BaseBlankViewer {...props} /> : null; //TODO loader?
+  return initialized ? <BaseBlankViewer {...props} /> : null;
 };

--- a/packages/modules/web-viewer-react/src/components/Viewer.tsx
+++ b/packages/modules/web-viewer-react/src/components/Viewer.tsx
@@ -16,5 +16,5 @@ export const Viewer = (props: WebViewerProps) => {
 
   const initialized = useWebViewerInitializer(memoizedProps);
 
-  return initialized ? <BaseViewer {...props} /> : null; //TODO loader?
+  return initialized ? <BaseViewer {...props} /> : null;
 };

--- a/packages/modules/web-viewer-react/src/types.ts
+++ b/packages/modules/web-viewer-react/src/types.ts
@@ -43,7 +43,6 @@ export interface WebViewerPropsFull extends ViewerProps {
   backend?: IModelBackendOptions;
 }
 
-// TODO remove this once we support opening snapshots remotely
 export type WebViewerProps = Omit<WebViewerPropsFull, "snapshotPath">;
 
 export interface WebBlankViewerProps extends BlankViewerProps {


### PR DESCRIPTION
What began as looking into the issue of stale viewports (which will be resolved in the next 3.0 core patch) turned into some refactoring. The changes made should help to avoid unwanted side effects and at the least separate concerns a bit more for future refactoring, without breaking any APIs. There is a "breaking" UI change in that the corner item will no longer be visible if there are no additional frontstages or backstage items. This has been requested by multiple users in the past and I can't think of a reason why this would not be a desired change. That said, it is technically new behavior so I'm ok delaying if need be. 

Still need to write/fix tests but I wanted to start getting some comments. 

NOTE: The ViewportAccessWidget was provided by the Sandbox team to help diagnose the stale Viewport bug. I left it in the test app as is to help test model switching in the future. It should be considered test only