### PR TITLE
Remove unnecessary Webpack plugin sections from all Viewer READMEs

### DIFF
--- a/common/changes/@itwin/desktop-viewer-react/update-docs_2022-03-01-21-21.json
+++ b/common/changes/@itwin/desktop-viewer-react/update-docs_2022-03-01-21-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/desktop-viewer-react",
+      "comment": "Removed unnecessary webpack plugin section from README",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/desktop-viewer-react",
+  "email": "19596966+johnnyd710@users.noreply.github.com"
+}

--- a/common/changes/@itwin/web-viewer-react/update-docs_2022-03-01-21-21.json
+++ b/common/changes/@itwin/web-viewer-react/update-docs_2022-03-01-21-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/web-viewer-react",
+      "comment": "Removed unnecessary webpack plugin section from README",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/web-viewer-react",
+  "email": "19596966+johnnyd710@users.noreply.github.com"
+}

--- a/packages/modules/desktop-viewer-react/README.md
+++ b/packages/modules/desktop-viewer-react/README.md
@@ -16,16 +16,6 @@ npm install @itwin/desktop-viewer-react
 
 ## Dependencies
 
-Currently, in order to use the iTwin Viewer, the consuming application would need to be compiled using Webpack with the IModeljsLibraryExportsPlugin that is in the [@bentley/webpack-tools-core](https://www.npmjs.com/package/@bentley/webpack-tools-core) package:
-
-In your webpack.config file:
-
-```javascript
-    plugins: [
-      // NOTE: iTwin.js specific plugin to allow exposing iTwin.js shared libraries into the global scope.
-      new IModeljsLibraryExportsPlugin(),
-```
-
 If you are creating a new application and are using React, it is advised that you use create-react-app with @bentley/react-scripts, which already include this plugin, as well as some other optimizations. There is also a predefined template that includes the iTwin Viewer package:
 
 ```

--- a/packages/modules/desktop-viewer-react/README.md
+++ b/packages/modules/desktop-viewer-react/README.md
@@ -16,7 +16,7 @@ npm install @itwin/desktop-viewer-react
 
 ## Dependencies
 
-If you are creating a new application and are using React, it is advised that you use create-react-app with @bentley/react-scripts, which already include this plugin, as well as some other optimizations. There is also a predefined template that includes the iTwin Viewer package:
+If you are creating a new application and are using React, it is advised that you use create-react-app with @bentley/react-scripts. There is also a predefined template that includes the iTwin Viewer package:
 
 ```
 npx create-react-app my-app --scripts-version @bentley/react-scripts --template @itwin/desktop-viewer

--- a/packages/modules/web-viewer-react/README.md
+++ b/packages/modules/web-viewer-react/README.md
@@ -16,7 +16,7 @@ npm install @itwin/web-viewer-react
 
 ## Dependencies
 
-If you are creating a new application and are using React, it is advised that you use create-react-app with @bentley/react-scripts, which already include this plugin, as well as some other optimizations. There is also a predefined template that includes the iTwin Viewer package:
+If you are creating a new application and are using React, it is advised that you use create-react-app with @bentley/react-scripts. There is also a predefined template that includes the iTwin Viewer package:
 
 ```
 npx create-react-app my-app --scripts-version @bentley/react-scripts --template @itwin/web-viewer

--- a/packages/modules/web-viewer-react/README.md
+++ b/packages/modules/web-viewer-react/README.md
@@ -16,16 +16,6 @@ npm install @itwin/web-viewer-react
 
 ## Dependencies
 
-Currently, in order to use the iTwin Viewer, the consuming application would need to be compiled using Webpack with the IModeljsLibraryExportsPlugin that is in the [@bentley/webpack-tools-core](https://www.npmjs.com/package/@bentley/webpack-tools-core) package:
-
-In your webpack.config file:
-
-```javascript
-    plugins: [
-      // NOTE: iTwin.js specific plugin to allow exposing iTwin.js shared libraries into the global scope.
-      new IModeljsLibraryExportsPlugin(),
-```
-
 If you are creating a new application and are using React, it is advised that you use create-react-app with @bentley/react-scripts, which already include this plugin, as well as some other optimizations. There is also a predefined template that includes the iTwin Viewer package:
 
 ```


### PR DESCRIPTION
Removed the Webpack plugin details in the "Dependencies" section of the *web-viewer-react* and *desktop-viewer-react* READMEs as they were no longer necessary.