### PR TITLE
Do not use the ViewCreator seed by default

### DIFF
--- a/common/changes/@itwin/viewer-react/viewcreator-seed-default_2022-03-02-18-21.json
+++ b/common/changes/@itwin/viewer-react/viewcreator-seed-default_2022-03-02-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/viewer-react",
+      "comment": "No longer uses the ViewCreator seed by default",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/viewer-react",
+  "email": "19596966+johnnyd710@users.noreply.github.com"
+}

--- a/packages/modules/viewer-react/src/services/iModel/IModelService.ts
+++ b/packages/modules/viewer-react/src/services/iModel/IModelService.ts
@@ -150,16 +150,7 @@ export const getViewState = async (
     } else {
       // attempt to construct a default viewState
       const viewCreator = new ViewCreator3d(connection);
-
-      const options: ViewerViewCreator3dOptions = viewCreatorOptions
-        ? { ...viewCreatorOptions }
-        : { useSeedView: true };
-
-      if (options.useSeedView === undefined) {
-        options.useSeedView = true;
-      }
-
-      view = await viewCreator.createDefaultView(options);
+      view = await viewCreator.createDefaultView(viewCreatorOptions);
       UiFramework.setActiveSelectionScope("top-assembly");
     }
   }


### PR DESCRIPTION
Removed the code that defaults the useSeedView option to "true", but still allows it as an option. Since we are no longer creating a new object with useSeedView set to true, we can directly pass viewCreatorOptions to the createDefaultView function.
