### PR TITLE
Code split the test apps

### DIFF
--- a/packages/apps/web-viewer-test/src/App.tsx
+++ b/packages/apps/web-viewer-test/src/App.tsx
@@ -10,9 +10,11 @@ import { history, Routes } from "./components/routing";
 
 function App() {
   return (
-    <Router history={history}>
-      <Routes />
-    </Router>
+    <React.Suspense fallback={<></>}>
+      <Router history={history}>
+        <Routes />
+      </Router>
+    </React.Suspense>
   );
 }
 

--- a/packages/apps/web-viewer-test/src/components/auth/LoginRedirect.tsx
+++ b/packages/apps/web-viewer-test/src/components/auth/LoginRedirect.tsx
@@ -8,7 +8,7 @@ import { Redirect } from "react-router-dom";
 
 import { AuthorizationClient, RedirectKey } from "../../services/auth";
 
-export const LoginRedirect = () => {
+const LoginRedirect = () => {
   const [isAuthVerified, setIsAuthVerified] = useState(false);
   const [redirectPath, setRedirectPath] = useState("/");
 
@@ -42,3 +42,5 @@ export const LoginRedirect = () => {
     </div>
   );
 };
+
+export default LoginRedirect;

--- a/packages/apps/web-viewer-test/src/components/auth/LogoutRedirect.tsx
+++ b/packages/apps/web-viewer-test/src/components/auth/LogoutRedirect.tsx
@@ -8,7 +8,7 @@ import { Redirect } from "react-router-dom";
 
 import { RedirectKey } from "../../services/auth";
 
-export const LogoutRedirect = () => {
+const LogoutRedirect = () => {
   const redirectPath = sessionStorage.getItem(RedirectKey) ?? "/";
   return (
     <div>
@@ -16,3 +16,5 @@ export const LogoutRedirect = () => {
     </div>
   );
 };
+
+export default LogoutRedirect;

--- a/packages/apps/web-viewer-test/src/components/home/BlankConnectionHome.tsx
+++ b/packages/apps/web-viewer-test/src/components/home/BlankConnectionHome.tsx
@@ -17,7 +17,7 @@ import { TestUiProvider2 } from "../../providers";
  * Test blank connection viewer
  * @returns
  */
-export const BlankConnectionHome: React.FC = () => {
+const BlankConnectionHome: React.FC = () => {
   const authClient = useMemo(
     () =>
       new BrowserAuthorizationClient({
@@ -81,3 +81,5 @@ export const BlankConnectionHome: React.FC = () => {
     </div>
   );
 };
+
+export default BlankConnectionHome;

--- a/packages/apps/web-viewer-test/src/components/home/Home.tsx
+++ b/packages/apps/web-viewer-test/src/components/home/Home.tsx
@@ -11,7 +11,7 @@ import type { RouteComponentProps } from "react-router";
 import { ReactComponent as Itwin } from "../../images/itwin.svg";
 import styles from "./Home.module.scss";
 
-export const Home = ({ history }: RouteComponentProps) => {
+const Home = ({ history }: RouteComponentProps) => {
   return (
     <div className={styles.container}>
       <div className={styles.content}>
@@ -52,3 +52,5 @@ export const Home = ({ history }: RouteComponentProps) => {
     </div>
   );
 };
+
+export default Home;

--- a/packages/apps/web-viewer-test/src/components/home/IModelBankHome.tsx
+++ b/packages/apps/web-viewer-test/src/components/home/IModelBankHome.tsx
@@ -18,7 +18,7 @@ import { history } from "../routing";
  * Test a viewer that is connected to an iModelBank
  * @returns
  */
-export const IModelBankHome: React.FC = () => {
+const IModelBankHome: React.FC = () => {
   const [iModelId, setIModelId] = useState(
     process.env.IMJS_AUTH_CLIENT_IMODEL_ID
   );
@@ -117,3 +117,5 @@ export const IModelBankHome: React.FC = () => {
     </div>
   );
 };
+
+export default IModelBankHome;

--- a/packages/apps/web-viewer-test/src/components/home/ViewerHome.tsx
+++ b/packages/apps/web-viewer-test/src/components/home/ViewerHome.tsx
@@ -32,7 +32,7 @@ import { history } from "../routing";
  * Test a viewer that uses auth configuration provided at startup
  * @returns
  */
-export const ViewerHome: React.FC = () => {
+const ViewerHome: React.FC = () => {
   const [iModelId, setIModelId] = useState(
     process.env.IMJS_AUTH_CLIENT_IMODEL_ID
   );
@@ -139,3 +139,5 @@ export const ViewerHome: React.FC = () => {
     </div>
   );
 };
+
+export default ViewerHome;

--- a/packages/apps/web-viewer-test/src/components/routing/Routes.tsx
+++ b/packages/apps/web-viewer-test/src/components/routing/Routes.tsx
@@ -6,9 +6,54 @@
 import React from "react";
 import { Route, Switch } from "react-router-dom";
 
-import { LoginRedirect, LogoutRedirect } from "../auth";
-import { BlankConnectionHome, Home, ViewerHome } from "../home";
-import { IModelBankHome } from "../home/IModelBankHome";
+async function loadHomeRoute() {
+  return import(
+    /* webpackChunkName: "route--home" */
+    "../home/Home"
+  );
+}
+
+async function loadLogoutRoute() {
+  return import(
+    /* webpackChunkName: "route--logout" */
+    "../auth/LogoutRedirect"
+  );
+}
+
+async function loadLoginRoute() {
+  return import(
+    /* webpackChunkName: "route--login" */
+    "../auth/LoginRedirect"
+  );
+}
+
+async function loadViewerRoute() {
+  return import(
+    /* webpackPrefetch: true, webpackChunkName: "route--viewer" */
+    "../home/ViewerHome"
+  );
+}
+
+async function loadBlankConnectionRoute() {
+  return import(
+    /* webpackChunkName: "route--blankconnection" */
+    "../home/BlankConnectionHome"
+  );
+}
+
+async function loadIModelBankRoute() {
+  return import(
+    /* webpackChunkName: "route--imodelbank" */
+    "../home/IModelBankHome"
+  );
+}
+
+const Home = React.lazy(loadHomeRoute);
+const LoginRedirect = React.lazy(loadLoginRoute);
+const LogoutRedirect = React.lazy(loadLogoutRoute);
+const IModelBankHome = React.lazy(loadIModelBankRoute);
+const BlankConnectionHome = React.lazy(loadBlankConnectionRoute);
+const ViewerHome = React.lazy(loadViewerRoute);
 
 export const Routes = () => {
   return (

--- a/packages/modules/test-extension/package.json
+++ b/packages/modules/test-extension/package.json
@@ -28,7 +28,8 @@
     "build:esbuild": "node esbuild.js",
     "start": "run-p \"build:** -- --watch\"",
     "debug": "serve .",
-    "clean": "rimraf lib dist"
+    "clean": "rimraf lib dist",
+    "test": ""
   },
   "activationEvents": [
     "onStartup"


### PR DESCRIPTION
Split the web viewer app into bundles according to Routes. /Login, /Logout, and the /Home page load faster (assuming nothing is cached) because the bundle size is only a fraction of the bundle size required to load the Viewport (all those itwinjs core dependencies). And thanks to Webpack pre-fetch, the Viewport bundle is loading in the background.
* Note the Lighthouse comparison below is only for the first load of the /Home page. The /Viewer page performance is hardly any different.
## Before 
![before-code-splitting](https://user-images.githubusercontent.com/19596966/167192617-14b48f8a-b880-46d9-a074-13977dfb9c9d.png)
## After
![after-code-splitting](https://user-images.githubusercontent.com/19596966/167192629-d8bc94aa-7e16-461f-a151-38a81736ca45.png)
 