### PR TITLE
tsconfig target es2020

### DIFF
--- a/packages/apps/cdn-viewer/tsconfig.json
+++ b/packages/apps/cdn-viewer/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2017",
+    "target": "es2020",
     "lib": [
       "dom",
       "dom.iterable",

--- a/packages/apps/desktop-viewer-test/tsconfig.json
+++ b/packages/apps/desktop-viewer-test/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2019",
+    "target": "es2020",
     "lib": [
       "dom",
       "dom.iterable",

--- a/packages/modules/cra-template-desktop-viewer/template/tsconfig.json
+++ b/packages/modules/cra-template-desktop-viewer/template/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target":  "es2020",
     "lib": [
       "dom",
       "dom.iterable",

--- a/packages/modules/cra-template-web-viewer/template/tsconfig.json
+++ b/packages/modules/cra-template-web-viewer/template/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2017",
+    "target":  "es2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/packages/modules/error-handling-react/tsconfig.json
+++ b/packages/modules/error-handling-react/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2017",
+    "target":  "es2020",
     "lib": [
       // Required for async iterators/generators:
       "esnext.asynciterable",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2017",
+    "target":  "es2020",
     "lib": [
       // Required for async iterators/generators:
       "esnext.asynciterable",


### PR DESCRIPTION
- init next branch
- Add extensions back (#129)
- rm default ui providers (#125)
- consolidate Viewer & BlankViewer & types (#149)
- use StandardFrontstageProvider from core instead of custom one (#148)
- create default ui providers for the viewer to match existing look (#152)
- don't publish error handling package
- make the package private
- Applying package updates.
- remove version policy for error handling package
- Applying package updates.
- remove version policy from test-extension
- Applying package updates.
- update error-handling package version
- Applying package updates.
- Remove telemetry and dependency on Microsoft's Application Insights (#160)
- Applying package updates.
- Code split the test apps (#161)
- add local and remote test extensions (#150)
- syncronized tsconfig target to es2020
