### PR TITLE
Replace usage of the error-handling-react package

### DIFF
--- a/packages/modules/viewer-react/package.json
+++ b/packages/modules/viewer-react/package.json
@@ -33,7 +33,6 @@
   ],
   "dependencies": {
     "@bentley/icons-generic-webfont": "^1.0.15",
-    "@itwin/error-handling-react": "2.0.1",
     "@itwin/itwinui-illustrations-react": "^1.2.0",
     "@itwin/itwinui-react": "^1.16.2"
   },

--- a/packages/modules/viewer-react/src/components/BaseViewer.tsx
+++ b/packages/modules/viewer-react/src/components/BaseViewer.tsx
@@ -2,13 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------------------------
- * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
- * See LICENSE.md in the project root for license terms and full copyright notice.
- *--------------------------------------------------------------------------------------------*/
-
 import { FillCentered } from "@itwin/core-react";
-// import { ErrorBoundary } from "@itwin/error-handling-react";
 import React from "react";
 
 import { useAccessToken } from "../hooks/useAccessToken";
@@ -19,6 +13,7 @@ import type {
   FileViewerProps,
   ViewerCommonProps,
 } from "../types";
+import { ErrorBoundary } from "./error/ErrorBoundary";
 import IModelLoader from "./iModel/IModelLoader";
 
 type ViewerProps = (ConnectedViewerProps | FileViewerProps | BlankViewerProps) &
@@ -44,7 +39,7 @@ export const BaseViewer = ({
 
   const accessToken = useAccessToken();
   return (
-    <>
+    <ErrorBoundary>
       {("filePath" in loaderProps && loaderProps.filePath) || accessToken ? (
         viewerInitialized ? (
           <IModelLoader {...loaderProps} />
@@ -54,6 +49,6 @@ export const BaseViewer = ({
       ) : (
         <FillCentered>Please provide a valid access token.</FillCentered>
       )}
-    </>
+    </ErrorBoundary>
   );
 };

--- a/packages/modules/viewer-react/src/components/BaseViewer.tsx
+++ b/packages/modules/viewer-react/src/components/BaseViewer.tsx
@@ -2,9 +2,13 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
 
 import { FillCentered } from "@itwin/core-react";
-import { ErrorBoundary } from "@itwin/error-handling-react";
+// import { ErrorBoundary } from "@itwin/error-handling-react";
 import React from "react";
 
 import { useAccessToken } from "../hooks/useAccessToken";
@@ -40,16 +44,16 @@ export const BaseViewer = ({
 
   const accessToken = useAccessToken();
   return (
-    <ErrorBoundary>
+    <>
       {("filePath" in loaderProps && loaderProps.filePath) || accessToken ? (
         viewerInitialized ? (
           <IModelLoader {...loaderProps} />
         ) : (
-          <FillCentered>initializing...</FillCentered>
+          <FillCentered>Initializing...</FillCentered>
         )
       ) : (
-        <FillCentered>Please sign in.</FillCentered>
+        <FillCentered>Please provide a valid access token.</FillCentered>
       )}
-    </ErrorBoundary>
+    </>
   );
 };

--- a/packages/modules/viewer-react/src/components/BaseViewer.tsx
+++ b/packages/modules/viewer-react/src/components/BaseViewer.tsx
@@ -2,6 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+
 import { FillCentered } from "@itwin/core-react";
 import React from "react";
 

--- a/packages/modules/viewer-react/src/components/error/ErrorBoundary.tsx
+++ b/packages/modules/viewer-react/src/components/error/ErrorBoundary.tsx
@@ -11,6 +11,11 @@ interface Props {
   eventTitle?: string;
 }
 
+interface Error {
+  code?: string;
+  message?: string;
+}
+
 export class ErrorBoundary extends Component<
   Props,
   {
@@ -22,7 +27,7 @@ export class ErrorBoundary extends Component<
     super(props);
     this.state = {
       fallback: false,
-      error: new Error(),
+      error: {},
     };
   }
 
@@ -38,7 +43,7 @@ export class ErrorBoundary extends Component<
 
   override render(): JSX.Element {
     if (this.state.fallback) {
-      let errorType: ErrorPageType = "generic";
+      const errorType: ErrorPageType = "generic";
       let errorMessage: ErrorPageProps["errorMessage"] = (
         <>
           We can't find the iModel that you are looking for or it does not
@@ -47,80 +52,10 @@ export class ErrorBoundary extends Component<
       );
 
       if (this.state.error.message) {
-        switch (this.state.error.message) {
-          case "error401":
-            errorType = "401";
-            errorMessage = (
-              <>
-                You do not have permission to access this server.
-                <br />
-                Unable to fulfill request.
-              </>
-            );
-            break;
-          case "error403":
-          case "ErrorNoEntitlement":
-            errorType = "403";
-            errorMessage = (
-              <>
-                You do not have permission to access this server.
-                <br />
-                Unable to fulfill request.
-              </>
-            );
-            break;
-          case "error404":
-            errorType = "404";
-            errorMessage = (
-              <>
-                We can not find the iModel that you are looking for or it does
-                not exist.
-                <br />
-                Visit the iModelHub or contact our support team.
-              </>
-            );
-            break;
-          case "error500":
-            errorType = "500";
-            errorMessage = (
-              <>
-                Please retry again. If this continues to happen, please contact
-                our support team or visit the iModelHub.
-              </>
-            );
-            break;
-          case "error503":
-          case "ConnectFailed":
-            errorType = "503";
-            errorMessage = (
-              <>
-                This service is being worked on. Please come back in a little
-                bit or visit iModelHub.
-              </>
-            );
-            break;
-          case "MaintenanceMode":
-            errorType = "503";
-            errorMessage = (
-              <>
-                This service is being worked on. Please come back in a little
-                bit or visit iModelHub.
-              </>
-            );
-            break;
-          default:
-            errorType = "generic";
-            errorMessage = (
-              <>
-                We can't find the iModel that you are looking for or it does not
-                exist. Visit the iModelHub or contact our support team.
-              </>
-            );
-            break;
-        }
+        errorMessage = this.state.error.message;
       }
 
-      return <ErrorPage errorMessage={errorMessage} errorType={errorType} />;
+      return <ErrorPage errorType={errorType} errorMessage={errorMessage} />;
     } else {
       return <>{this.props.children}</>;
     }

--- a/packages/modules/viewer-react/src/components/error/ErrorBoundary.tsx
+++ b/packages/modules/viewer-react/src/components/error/ErrorBoundary.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ErrorPage } from "@itwin/itwinui-react";
-import type { PropsWithChildren, ReactNode } from "react";
+import type { PropsWithChildren } from "react";
 import React, { Component } from "react";
 
 interface State {
@@ -13,7 +13,7 @@ interface State {
 }
 
 export class ErrorBoundary extends Component<
-  PropsWithChildren<ReactNode>,
+  PropsWithChildren<Record<string, unknown>>,
   State
 > {
   override state: State = {

--- a/packages/modules/viewer-react/src/components/error/ErrorBoundary.tsx
+++ b/packages/modules/viewer-react/src/components/error/ErrorBoundary.tsx
@@ -2,9 +2,10 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+
 import type { ErrorPageProps, ErrorPageType } from "@itwin/itwinui-react";
 import { ErrorPage } from "@itwin/itwinui-react";
-import React, { Component, Fragment } from "react";
+import React, { Component } from "react";
 
 interface Props {
   eventTitle?: string;
@@ -41,7 +42,7 @@ export class ErrorBoundary extends Component<
       let errorMessage: ErrorPageProps["errorMessage"] = (
         <>
           We can't find the iModel that you are looking for or it does not
-          exist. Visit the iModel HUB or contact our support team.
+          exist. Visit the iModelHub or contact our support team.
         </>
       );
 
@@ -75,7 +76,7 @@ export class ErrorBoundary extends Component<
                 We can not find the iModel that you are looking for or it does
                 not exist.
                 <br />
-                Visit the iModel HUB or contact our support team.
+                Visit the iModelHub or contact our support team.
               </>
             );
             break;
@@ -84,7 +85,7 @@ export class ErrorBoundary extends Component<
             errorMessage = (
               <>
                 Please retry again. If this continues to happen, please contact
-                our support team or visit the iModel HUB.
+                our support team or visit the iModelHub.
               </>
             );
             break;
@@ -94,7 +95,7 @@ export class ErrorBoundary extends Component<
             errorMessage = (
               <>
                 This service is being worked on. Please come back in a little
-                bit or visit iModel HUB.
+                bit or visit iModelHub.
               </>
             );
             break;
@@ -103,7 +104,7 @@ export class ErrorBoundary extends Component<
             errorMessage = (
               <>
                 This service is being worked on. Please come back in a little
-                bit or visit iModel HUB.
+                bit or visit iModelHub.
               </>
             );
             break;
@@ -112,29 +113,16 @@ export class ErrorBoundary extends Component<
             errorMessage = (
               <>
                 We can't find the iModel that you are looking for or it does not
-                exist. Visit the iModel HUB or contact our support team.
+                exist. Visit the iModelHub or contact our support team.
               </>
             );
             break;
         }
       }
 
-      return (
-        <ErrorPage
-          errorMessage={errorMessage}
-          errorType={errorType}
-          primaryButtonHandle={() => {
-            console.log("Close");
-          }}
-          primaryButtonLabel="Close"
-          secondaryButtonHandle={() => {
-            console.log("Cancel");
-          }}
-          secondaryButtonLabel="Cancel"
-        />
-      );
+      return <ErrorPage errorMessage={errorMessage} errorType={errorType} />;
     } else {
-      return <Fragment>{this.props.children}</Fragment>;
+      return <>{this.props.children}</>;
     }
   }
 }

--- a/packages/modules/viewer-react/src/components/error/ErrorBoundary.tsx
+++ b/packages/modules/viewer-react/src/components/error/ErrorBoundary.tsx
@@ -3,33 +3,23 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import type { ErrorPageProps, ErrorPageType } from "@itwin/itwinui-react";
 import { ErrorPage } from "@itwin/itwinui-react";
 import React, { Component } from "react";
 
 interface Props {
-  eventTitle?: string;
+  children: React.ReactNode;
 }
 
-interface Error {
-  code?: string;
-  message?: string;
+interface State {
+  fallback: boolean;
+  error: Error;
 }
 
-export class ErrorBoundary extends Component<
-  Props,
-  {
-    fallback: boolean;
-    error: Error;
-  }
-> {
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      fallback: false,
-      error: {},
-    };
-  }
+export class ErrorBoundary extends Component<Props, State> {
+  override state = {
+    fallback: false,
+    error: new Error(),
+  };
 
   static getDerivedStateFromError(e: Error): {
     fallback: boolean;
@@ -43,19 +33,12 @@ export class ErrorBoundary extends Component<
 
   override render(): JSX.Element {
     if (this.state.fallback) {
-      const errorType: ErrorPageType = "generic";
-      let errorMessage: ErrorPageProps["errorMessage"] = (
-        <>
-          We can't find the iModel that you are looking for or it does not
-          exist. Visit the iModelHub or contact our support team.
-        </>
+      return (
+        <ErrorPage
+          errorType="generic"
+          errorMessage={this.state.error.message}
+        />
       );
-
-      if (this.state.error.message) {
-        errorMessage = this.state.error.message;
-      }
-
-      return <ErrorPage errorType={errorType} errorMessage={errorMessage} />;
     } else {
       return <>{this.props.children}</>;
     }

--- a/packages/modules/viewer-react/src/components/error/ErrorBoundary.tsx
+++ b/packages/modules/viewer-react/src/components/error/ErrorBoundary.tsx
@@ -1,0 +1,140 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import type { ErrorPageProps, ErrorPageType } from "@itwin/itwinui-react";
+import { ErrorPage } from "@itwin/itwinui-react";
+import React, { Component, Fragment } from "react";
+
+interface Props {
+  eventTitle?: string;
+}
+
+export class ErrorBoundary extends Component<
+  Props,
+  {
+    fallback: boolean;
+    error: Error;
+  }
+> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      fallback: false,
+      error: new Error(),
+    };
+  }
+
+  static getDerivedStateFromError(e: Error): {
+    fallback: boolean;
+    error: Error;
+  } {
+    return {
+      fallback: true,
+      error: e,
+    };
+  }
+
+  override render(): JSX.Element {
+    if (this.state.fallback) {
+      let errorType: ErrorPageType = "generic";
+      let errorMessage: ErrorPageProps["errorMessage"] = (
+        <>
+          We can't find the iModel that you are looking for or it does not
+          exist. Visit the iModel HUB or contact our support team.
+        </>
+      );
+
+      if (this.state.error.message) {
+        switch (this.state.error.message) {
+          case "error401":
+            errorType = "401";
+            errorMessage = (
+              <>
+                You do not have permission to access this server.
+                <br />
+                Unable to fulfill request.
+              </>
+            );
+            break;
+          case "error403":
+          case "ErrorNoEntitlement":
+            errorType = "403";
+            errorMessage = (
+              <>
+                You do not have permission to access this server.
+                <br />
+                Unable to fulfill request.
+              </>
+            );
+            break;
+          case "error404":
+            errorType = "404";
+            errorMessage = (
+              <>
+                We can not find the iModel that you are looking for or it does
+                not exist.
+                <br />
+                Visit the iModel HUB or contact our support team.
+              </>
+            );
+            break;
+          case "error500":
+            errorType = "500";
+            errorMessage = (
+              <>
+                Please retry again. If this continues to happen, please contact
+                our support team or visit the iModel HUB.
+              </>
+            );
+            break;
+          case "error503":
+          case "ConnectFailed":
+            errorType = "503";
+            errorMessage = (
+              <>
+                This service is being worked on. Please come back in a little
+                bit or visit iModel HUB.
+              </>
+            );
+            break;
+          case "MaintenanceMode":
+            errorType = "503";
+            errorMessage = (
+              <>
+                This service is being worked on. Please come back in a little
+                bit or visit iModel HUB.
+              </>
+            );
+            break;
+          default:
+            errorType = "generic";
+            errorMessage = (
+              <>
+                We can't find the iModel that you are looking for or it does not
+                exist. Visit the iModel HUB or contact our support team.
+              </>
+            );
+            break;
+        }
+      }
+
+      return (
+        <ErrorPage
+          errorMessage={errorMessage}
+          errorType={errorType}
+          primaryButtonHandle={() => {
+            console.log("Close");
+          }}
+          primaryButtonLabel="Close"
+          secondaryButtonHandle={() => {
+            console.log("Cancel");
+          }}
+          secondaryButtonLabel="Cancel"
+        />
+      );
+    } else {
+      return <Fragment>{this.props.children}</Fragment>;
+    }
+  }
+}

--- a/packages/modules/viewer-react/src/components/error/ErrorBoundary.tsx
+++ b/packages/modules/viewer-react/src/components/error/ErrorBoundary.tsx
@@ -4,27 +4,24 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ErrorPage } from "@itwin/itwinui-react";
+import type { PropsWithChildren, ReactNode } from "react";
 import React, { Component } from "react";
-
-interface Props {
-  children: React.ReactNode;
-}
 
 interface State {
   fallback: boolean;
   error: Error;
 }
 
-export class ErrorBoundary extends Component<Props, State> {
-  override state = {
+export class ErrorBoundary extends Component<
+  PropsWithChildren<ReactNode>,
+  State
+> {
+  override state: State = {
     fallback: false,
     error: new Error(),
   };
 
-  static getDerivedStateFromError(e: Error): {
-    fallback: boolean;
-    error: Error;
-  } {
+  static getDerivedStateFromError(e: Error): State {
     return {
       fallback: true,
       error: e,

--- a/packages/modules/viewer-react/src/components/iModel/IModelLoader.tsx
+++ b/packages/modules/viewer-react/src/components/iModel/IModelLoader.tsx
@@ -2,10 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------------------------
- * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
- * See LICENSE.md in the project root for license terms and full copyright notice.
- *--------------------------------------------------------------------------------------------*/
 
 import "@bentley/icons-generic-webfont/dist/bentley-icons-generic-webfont.css";
 import "./IModelLoader.scss";

--- a/packages/modules/viewer-react/src/components/iModel/IModelLoader.tsx
+++ b/packages/modules/viewer-react/src/components/iModel/IModelLoader.tsx
@@ -2,6 +2,10 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
 
 import "@bentley/icons-generic-webfont/dist/bentley-icons-generic-webfont.css";
 import "./IModelLoader.scss";
@@ -9,7 +13,6 @@ import "./IModelLoader.scss";
 import { StateManager, UiFramework } from "@itwin/appui-react";
 import type { IModelConnection } from "@itwin/core-frontend";
 import { BlankConnection, IModelApp } from "@itwin/core-frontend";
-import { useErrorManager } from "@itwin/error-handling-react";
 import { SvgIModelLoader } from "@itwin/itwinui-illustrations-react";
 import React, { useCallback, useEffect, useState } from "react";
 import { Provider } from "react-redux";
@@ -71,12 +74,6 @@ const IModelLoader = React.memo(
 
     useUiProviders(uiProviders);
     useTheme(theme);
-
-    // trigger error boundary when fatal error is thrown
-    const errorManager = useErrorManager({});
-    useEffect(() => {
-      setError(errorManager.fatalError);
-    }, [errorManager.fatalError]);
 
     const getModelConnection = useCallback(async (): Promise<
       IModelConnection | undefined
@@ -141,9 +138,7 @@ const IModelLoader = React.memo(
 
       void getModelConnection()
         .then((connection) => (prevConnection = connection))
-        .catch((error) => {
-          errorManager.throwFatalError(error);
-        });
+        .catch(setError);
 
       const mounted = isMounted.current;
       return () => {


### PR DESCRIPTION
Removing imports of ErrorBoundary and useErrorManager from the error-handing-react package in viewer-react. Issue https://github.com/iTwin/viewer/issues/135.