### PR TITLE
Raplemie/additional auth description

### DIFF
--- a/common/changes/@itwin/cra-template-desktop-viewer/raplemie-additionalAuthDescription_2022-06-02-18-51.json
+++ b/common/changes/@itwin/cra-template-desktop-viewer/raplemie-additionalAuthDescription_2022-06-02-18-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/cra-template-desktop-viewer",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/cra-template-desktop-viewer",
+  "email": "1904889+raplemie@users.noreply.github.com"
+}

--- a/common/changes/@itwin/cra-template-desktop-viewer/raplemie-additionalAuthDescription_2022-06-02-19-24.json
+++ b/common/changes/@itwin/cra-template-desktop-viewer/raplemie-additionalAuthDescription_2022-06-02-19-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/cra-template-desktop-viewer",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/cra-template-desktop-viewer",
+  "email": "1904889+raplemie@users.noreply.github.com"
+}

--- a/common/changes/@itwin/cra-template-web-viewer/raplemie-additionalAuthDescription_2022-06-02-17-36.json
+++ b/common/changes/@itwin/cra-template-web-viewer/raplemie-additionalAuthDescription_2022-06-02-17-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/cra-template-web-viewer",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/cra-template-web-viewer",
+  "email": "1904889+raplemie@users.noreply.github.com"
+}

--- a/common/changes/@itwin/cra-template-web-viewer/raplemie-additionalAuthDescription_2022-06-02-19-24.json
+++ b/common/changes/@itwin/cra-template-web-viewer/raplemie-additionalAuthDescription_2022-06-02-19-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/cra-template-web-viewer",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/cra-template-web-viewer",
+  "email": "1904889+raplemie@users.noreply.github.com"
+}

--- a/common/changes/@itwin/desktop-viewer-react/raplemie-additionalAuthDescription_2022-06-02-18-51.json
+++ b/common/changes/@itwin/desktop-viewer-react/raplemie-additionalAuthDescription_2022-06-02-18-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/desktop-viewer-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/desktop-viewer-react",
+  "email": "1904889+raplemie@users.noreply.github.com"
+}

--- a/common/changes/@itwin/desktop-viewer-react/raplemie-additionalAuthDescription_2022-06-02-19-24.json
+++ b/common/changes/@itwin/desktop-viewer-react/raplemie-additionalAuthDescription_2022-06-02-19-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/desktop-viewer-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/desktop-viewer-react",
+  "email": "1904889+raplemie@users.noreply.github.com"
+}

--- a/common/changes/@itwin/web-viewer-react/raplemie-additionalAuthDescription_2022-06-02-17-36.json
+++ b/common/changes/@itwin/web-viewer-react/raplemie-additionalAuthDescription_2022-06-02-17-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/web-viewer-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/web-viewer-react",
+  "email": "1904889+raplemie@users.noreply.github.com"
+}

--- a/common/changes/@itwin/web-viewer-react/raplemie-additionalAuthDescription_2022-06-02-19-24.json
+++ b/common/changes/@itwin/web-viewer-react/raplemie-additionalAuthDescription_2022-06-02-19-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/web-viewer-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/web-viewer-react",
+  "email": "1904889+raplemie@users.noreply.github.com"
+}

--- a/packages/modules/cra-template-desktop-viewer/template/.env
+++ b/packages/modules/cra-template-desktop-viewer/template/.env
@@ -1,5 +1,5 @@
 # ---- Configuration ----
-ITWIN_VIEWER_SCOPE ="imodelaccess:read offline_access imodels:read projects:read realitydata:read"
+ITWIN_VIEWER_SCOPE ="imodelaccess:read imodels:read projects:read realitydata:read"
 ITWIN_VIEWER_CLIENT_ID=""
 ITWIN_VIEWER_REDIRECT_URI=""
 ITWIN_VIEWER_ISSUER_URL="https://ims.bentley.com"

--- a/packages/modules/cra-template-desktop-viewer/template/README.md
+++ b/packages/modules/cra-template-desktop-viewer/template/README.md
@@ -12,15 +12,12 @@ ITWIN_VIEWER_CLIENT_ID="native-xxxxxxxx"
 
 - You should generate a [client](https://developer.bentley.com/register/) to get started. The client that you generate should be for a desktop app and use the following list of apis. You can add the default redirect uri (http://localhost:3000/signin-callback).
 
-- Scopes expected by the viewer are the following:
+- Scopes expected by the viewer are:
 
-  - `imodelaccess:read` is part of Visualization.
-
-  - `imodels:read` is part of iModels API, within Digital Twin Management.
-
-  - `realitydata:read` is part of Reality Data API, within Digital Twin Management.
-
-  - `projects:read` is part of Projects API, within Administration.
+  - **Visualization**: `imodelaccess:read`
+  - **iModels**: `imodels:read`
+  - **Reality Data**: `realitydata:read`
+  - **Projects**: `projects:read`
 
 ## Available Scripts
 

--- a/packages/modules/cra-template-desktop-viewer/template/README.md
+++ b/packages/modules/cra-template-desktop-viewer/template/README.md
@@ -10,7 +10,17 @@ Prior to running the app, you will need to add OIDC client configuration to the 
 ITWIN_VIEWER_CLIENT_ID="native-xxxxxxxx"
 ```
 
-- You should generate a [client](https://developer.bentley.com/register/) to get started. The client that you generate should be for a desktop app and use the Visualization apis. You can add the default redirect uri (http://localhost:3000/signin-callback).
+- You should generate a [client](https://developer.bentley.com/register/) to get started. The client that you generate should be for a desktop app and use the following list of apis. You can add the default redirect uri (http://localhost:3000/signin-callback).
+
+- Scopes expected by the viewer are the following:
+
+  - `imodelaccess:read` is part of Visualization.
+
+  - `imodels:read` is part of iModels API, within Digital Twin Management.
+
+  - `realitydata:read` is part of Reality Data API, within Digital Twin Management.
+
+  - `projects:read` is part of Projects API, within Administration.
 
 ## Available Scripts
 

--- a/packages/modules/cra-template-web-viewer/template/README.md
+++ b/packages/modules/cra-template-web-viewer/template/README.md
@@ -16,6 +16,16 @@ IMJS_AUTH_CLIENT_SCOPES =""
 
 - You can generate a [test client](https://developer.bentley.com/tutorials/web-application-quick-start/#2-register-an-application) to get started.
 
+- Scopes expected by the viewer are `imodelaccess:read`, `imodels:read` and `realitydata:read`.
+
+  - `imodelaccess:read` is part of the Visualization API.
+
+  - `imodels:read` is part of the iModels API.
+
+  - `realitydata:read` is part of the Reality Data API.
+
+- The application will use the path of the redirect URI to handle the redirection, it must simply match what is defined in your client.
+
 - When you are ready to build a production application, [register here](https://developer.bentley.com/register/).
 
 You should also add a valid iTwinId and iModelId for your user in the this file:

--- a/packages/modules/cra-template-web-viewer/template/README.md
+++ b/packages/modules/cra-template-web-viewer/template/README.md
@@ -20,9 +20,9 @@ IMJS_AUTH_CLIENT_SCOPES =""
 
   - `imodelaccess:read` is part of the Visualization API.
 
-  - `imodels:read` is part of the iModels API.
+  - `imodels:read` is part of the iModels API, within Digital Twin Management.
 
-  - `realitydata:read` is part of the Reality Data API.
+  - `realitydata:read` is part of the Reality Data API, within Digital Twin Management.
 
 - The application will use the path of the redirect URI to handle the redirection, it must simply match what is defined in your client.
 

--- a/packages/modules/cra-template-web-viewer/template/README.md
+++ b/packages/modules/cra-template-web-viewer/template/README.md
@@ -16,13 +16,11 @@ IMJS_AUTH_CLIENT_SCOPES =""
 
 - You can generate a [test client](https://developer.bentley.com/tutorials/web-application-quick-start/#2-register-an-application) to get started.
 
-- Scopes expected by the viewer are `imodelaccess:read`, `imodels:read` and `realitydata:read`.
+- Scopes expected by the viewer are:
 
-  - `imodelaccess:read` is part of the Visualization API.
-
-  - `imodels:read` is part of the iModels API, within Digital Twin Management.
-
-  - `realitydata:read` is part of the Reality Data API, within Digital Twin Management.
+  - **Visualization**: `imodelaccess:read`
+  - **iModels**: `imodels:read`
+  - **Reality Data**: `realitydata:read`
 
 - The application will use the path of the redirect URI to handle the redirection, it must simply match what is defined in your client.
 

--- a/packages/modules/desktop-viewer-react/README.md
+++ b/packages/modules/desktop-viewer-react/README.md
@@ -31,7 +31,9 @@ import { Viewer } from "@itwin/desktop-viewer-react";
 export const MyViewerComponent = () => {
   const snapshotPath = "./samples/house_model.bim";
 
-  return <Viewer snapshotPath={snapshotPath} />;
+  return (
+    <Viewer snapshotPath={snapshotPath} enablePerformanceMonitors={true} />
+  );
 };
 ```
 

--- a/packages/modules/web-viewer-react/README.md
+++ b/packages/modules/web-viewer-react/README.md
@@ -47,7 +47,12 @@ export const MyViewerComponent = () => {
   );
 
   return (
-    <Viewer authClient={authClient} iTwinId={iTwinId} iModelId={iModelId} />
+    <Viewer
+      authClient={authClient}
+      iTwinId={iTwinId}
+      iModelId={iModelId}
+      enablePerformanceMonitors={true}
+    />
   );
 };
 ```


### PR DESCRIPTION
Adding scopes information so a user that already have a client registered knows what is required without having to analyse the different .env files provided.

Also added a missing `enablePerformanceMonitors` property in the Viewer react example (This parameter is required but was not in the demo code)