### PR TITLE
Add implementation of AccuSnap subclass.

### DIFF
--- a/common/changes/@itwin/viewer-react/task-accusnap-subclass_2022-07-07-17-51.json
+++ b/common/changes/@itwin/viewer-react/task-accusnap-subclass_2022-07-07-17-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/viewer-react",
+      "comment": "Add implementation of AccuSnap that obtains the snap modes off the UiFramework. Fix issues where changing the SnapMode in the UI wouldn't reflect in AccuSnap.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/viewer-react"
+}

--- a/common/changes/@itwin/viewer-react/task-accusnap-subclass_2022-07-07-17-51.json
+++ b/common/changes/@itwin/viewer-react/task-accusnap-subclass_2022-07-07-17-51.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@itwin/viewer-react",
       "comment": "Add implementation of AccuSnap that obtains the snap modes off the UiFramework. Fix issues where changing the SnapMode in the UI wouldn't reflect in AccuSnap.",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@itwin/viewer-react"

--- a/packages/modules/viewer-react/src/services/BaseInitializer.ts
+++ b/packages/modules/viewer-react/src/services/BaseInitializer.ts
@@ -18,6 +18,7 @@ import {
   IModelTileRpcInterface,
 } from "@itwin/core-common";
 import type { IModelAppOptions } from "@itwin/core-frontend";
+import { AccuSnap, SnapMode } from "@itwin/core-frontend";
 import { IModelApp } from "@itwin/core-frontend";
 import { ITwinLocalization } from "@itwin/core-i18n";
 import { UiCore } from "@itwin/core-react";
@@ -235,6 +236,7 @@ export const getIModelAppOptions = (
 
   return {
     applicationId: options?.productId ?? "3098",
+    accuSnap: new ViewerAccuSnap(),
     notifications: new AppNotificationManager(),
     uiAdmin: new FrameworkUiAdmin(),
     rpcInterfaces: getSupportedRpcs(options?.additionalRpcInterfaces ?? []),
@@ -247,3 +249,33 @@ export const getIModelAppOptions = (
     tileAdmin: options?.tileAdmin,
   };
 };
+
+class ViewerAccuSnap extends AccuSnap {
+  public override getActiveSnapModes(): SnapMode[] {
+    // The SnapMode in the UiFramework is a bit mask.
+    const snapMode = UiFramework.getAccudrawSnapMode();
+    const snaps: SnapMode[] = [];
+    if (0 < (snapMode & SnapMode.Bisector)) {
+      snaps.push(SnapMode.Bisector);
+    }
+    if (0 < (snapMode & SnapMode.Center)) {
+      snaps.push(SnapMode.Center);
+    }
+    if (0 < (snapMode & SnapMode.Intersection)) {
+      snaps.push(SnapMode.Intersection);
+    }
+    if (0 < (snapMode & SnapMode.MidPoint)) {
+      snaps.push(SnapMode.MidPoint);
+    }
+    if (0 < (snapMode & SnapMode.Nearest)) {
+      snaps.push(SnapMode.Nearest);
+    }
+    if (0 < (snapMode & SnapMode.NearestKeypoint)) {
+      snaps.push(SnapMode.NearestKeypoint);
+    }
+    if (0 < (snapMode & SnapMode.Origin)) {
+      snaps.push(SnapMode.Origin);
+    }
+    return snaps;
+  }
+}

--- a/packages/modules/viewer-react/src/tests/components/iModel/IModelLoader.test.tsx
+++ b/packages/modules/viewer-react/src/tests/components/iModel/IModelLoader.test.tsx
@@ -88,6 +88,7 @@ jest.mock("@itwin/core-frontend", () => {
     CompassMode: {},
     RotationMode: {},
     AccuDraw: class {},
+    AccuSnap: class {},
     ToolAdmin: class {},
     WebViewerApp: {
       startup: jest.fn().mockResolvedValue(true),

--- a/packages/modules/viewer-react/src/tests/services/BaseInitializer.test.ts
+++ b/packages/modules/viewer-react/src/tests/services/BaseInitializer.test.ts
@@ -87,6 +87,7 @@ jest.mock("@itwin/core-frontend", () => {
     CompassMode: {},
     RotationMode: {},
     AccuDraw: class {},
+    AccuSnap: class {},
     SpatialViewState: {
       className: "",
     },
@@ -118,6 +119,7 @@ describe("BaseInitializer", () => {
     const appOptions = getIModelAppOptions();
     expect(appOptions).toEqual({
       applicationId: "3098",
+      accuSnap: expect.anything(),
       notifications: expect.anything(),
       uiAdmin: expect.anything(),
       rpcInterfaces: [


### PR DESCRIPTION
Issue: viewer-based apps do not take into account the SnapMode set by the user using the SnapModeField in the bottom bar.

Fix: Provide an implementation of AccuSnap that properly returns the expected SnapMode based on the UiFramework state (set by the SnapModeField).