### PR TITLE
Avoid re-initialization of a state manager

### DIFF
--- a/common/changes/@itwin/viewer-react/fix-state-manager_2022-07-20-13-59.json
+++ b/common/changes/@itwin/viewer-react/fix-state-manager_2022-07-20-13-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/viewer-react",
+      "comment": "Avoid StateManager re-initialization.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/viewer-react"
+}

--- a/packages/modules/viewer-react/src/services/BaseInitializer.ts
+++ b/packages/modules/viewer-react/src/services/BaseInitializer.ts
@@ -108,9 +108,11 @@ export class BaseInitializer {
     const cancellable = makeCancellable(function* () {
       // Initialize state manager
       // This will setup a singleton store inside the StoreManager class.
-      new StateManager({
-        frameworkState: FrameworkReducer,
-      });
+      if (!StateManager.isInitialized()) {
+        new StateManager({
+          frameworkState: FrameworkReducer,
+        });
+      }
 
       // execute the iModelApp initialization callback if provided
       if (viewerOptions?.onIModelAppInit) {

--- a/packages/modules/viewer-react/src/tests/services/BaseInitializer.test.ts
+++ b/packages/modules/viewer-react/src/tests/services/BaseInitializer.test.ts
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import { StateManager } from "@itwin/appui-react";
 import {
   DevToolsRpcInterface,
   IModelReadRpcInterface,
@@ -223,5 +224,16 @@ describe("BaseInitializer", () => {
       enablePerformanceMonitors: false,
     });
     expect(appOptions.tileAdmin).toEqual({ cesiumIonKey });
+  });
+  it("initializes StateManager", async () => {
+    await BaseInitializer.initialize();
+    await BaseInitializer.initialized;
+    expect(StateManager).toHaveBeenCalledTimes(1);
+  });
+  it("should not re-initialize StateManager", async () => {
+    jest.spyOn(StateManager, "isInitialized").mockReturnValue(true);
+    await BaseInitializer.initialize();
+    await BaseInitializer.initialized;
+    expect(StateManager).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
This PR fixes an issue where application configured `StateManager` is re-initialized by the `BaseInitializer` (once the Viewer is rendered) preventing the application from configuring a custom Redux store.