### PR TITLE
Update links in the template. Remove unnecessary copyright headers

### DIFF
--- a/common/changes/@itwin/cra-template-web-viewer/update-web-template_2023-01-27-03-34.json
+++ b/common/changes/@itwin/cra-template-web-viewer/update-web-template_2023-01-27-03-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/cra-template-web-viewer",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/cra-template-web-viewer"
+}

--- a/packages/modules/cra-template-web-viewer/package.json
+++ b/packages/modules/cra-template-web-viewer/package.json
@@ -7,7 +7,7 @@
     "template",
     "typescript",
     "iModel",
-    "iModelJs",
+    "iTwinJs",
     "iTwin",
     "iTwin Viewer"
   ],

--- a/packages/modules/cra-template-web-viewer/template/.env
+++ b/packages/modules/cra-template-web-viewer/template/.env
@@ -12,7 +12,7 @@ IMJS_IMODEL_ID = ""
 # Advanced CRA Config: https://create-react-app.dev/docs/advanced-configuration/
 SKIP_PREFLIGHT_CHECK=true
 
-# Advanced iModel.js CRA Config: https://github.com/imodeljs/create-react-app/blob/imodeljs/packages/react-scripts/README-imodeljs.md
+# Advanced iTwin.js CRA Config: https://github.com/imodeljs/create-react-app/blob/imodeljs/packages/react-scripts/README-imodeljs.md
 USE_FAST_SASS=true
 USE_FULL_SOURCEMAP=true
 TRANSPILE_DEPS=false

--- a/packages/modules/cra-template-web-viewer/template/README.md
+++ b/packages/modules/cra-template-web-viewer/template/README.md
@@ -14,7 +14,7 @@ IMJS_AUTH_CLIENT_LOGOUT_URI=""
 IMJS_AUTH_CLIENT_SCOPES =""
 ```
 
-- You can generate a [test client](https://developer.bentley.com/tutorials/web-application-quick-start/#2-register-an-application) to get started.
+- You can generate a [test client](https://developer.bentley.com/tutorials/web-application-quick-start/#3-register-an-application) to get started.
 
 - Scopes expected by the viewer are:
 
@@ -34,11 +34,11 @@ IMJS_ITWIN_ID = ""
 IMJS_IMODEL_ID = ""
 ```
 
-- For the IMJS_ITWIN_ID variable, you can use the id of one of your existing Projects or Assets. You can obtain their ids via the [Administration REST APIs](https://developer.bentley.com/api-groups/administration/api-reference/).
+- For the IMJS_ITWIN_ID variable, you can use the id of one of your existing iTwins. You can obtain their ids via the [iTwin REST APIs](https://developer.bentley.com/apis/itwins/operations/get-itwin/).
 
-- For the IMJS_IMODEL_ID variable, use the id of an iModel that belongs to the iTwin that you specified in the IMJS_ITWIN_ID variable. You can obtain iModel ids via the [Data Management REST APIs](https://developer.bentley.com/api-groups/data-management/apis/imodels/operations/get-project-or-asset-imodels/).
+- For the IMJS_IMODEL_ID variable, use the id of an iModel that belongs to the iTwin that you specified in the IMJS_ITWIN_ID variable. You can obtain iModel ids via the [iModel REST APIs](https://developer.bentley.com/apis/imodels-v2/operations/get-imodel-details/).
 
-- Alternatively, you can [generate a test iModel](https://developer.bentley.com/tutorials/web-application-quick-start/#3-create-an-imodel) to get started without an existing iModel.
+- Alternatively, you can [generate a test iModel](https://developer.bentley.com/tutorials/web-application-quick-start/#4-create-an-imodel) to get started without an existing iModel.
 
 - If at any time you wish to change the iModel that you are viewing, you can change the values of the iTwinId or iModelId query parameters in the url (i.e. localhost:3000?iTwinId=myNewITwinId&iModelId=myNewIModelId)
 
@@ -83,7 +83,7 @@ You don’t have to ever use `eject`. The curated feature set is suitable for sm
 
 - [iTwin Viewer options](https://www.npmjs.com/package/@itwin/web-viewer-react)
 
-- [Extending the iTwin Viewer](https://www.itwinjs.org/learning/tutorials/hello-world-viewer/)
+- [Extending the iTwin Viewer](https://developer.bentley.com/tutorials/itwin-viewer-hello-world/)
 
 - [Using the iTwin Platform](https://developer.bentley.com/)
 

--- a/packages/modules/cra-template-web-viewer/template/src/App.tsx
+++ b/packages/modules/cra-template-web-viewer/template/src/App.tsx
@@ -1,8 +1,3 @@
-/*---------------------------------------------------------------------------------------------
- * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
- * See LICENSE.md in the project root for license terms and full copyright notice.
- *--------------------------------------------------------------------------------------------*/
-
 import "./App.scss";
 
 import { BrowserAuthorizationClient } from "@itwin/browser-authorization";

--- a/packages/modules/cra-template-web-viewer/template/src/history.ts
+++ b/packages/modules/cra-template-web-viewer/template/src/history.ts
@@ -1,8 +1,3 @@
-/*---------------------------------------------------------------------------------------------
- * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
- * See LICENSE.md in the project root for license terms and full copyright notice.
- *--------------------------------------------------------------------------------------------*/
-
 import { createBrowserHistory } from "history";
 
 export const history = createBrowserHistory();

--- a/packages/modules/cra-template-web-viewer/template/src/index.scss
+++ b/packages/modules/cra-template-web-viewer/template/src/index.scss
@@ -1,7 +1,3 @@
-/*---------------------------------------------------------------------------------------------
-* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
-* See LICENSE.md in the project root for license terms and full copyright notice.
-*--------------------------------------------------------------------------------------------*/
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",

--- a/packages/modules/cra-template-web-viewer/template/src/index.tsx
+++ b/packages/modules/cra-template-web-viewer/template/src/index.tsx
@@ -1,8 +1,3 @@
-/*---------------------------------------------------------------------------------------------
- * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
- * See LICENSE.md in the project root for license terms and full copyright notice.
- *--------------------------------------------------------------------------------------------*/
-
 import "./index.scss";
 
 import { BrowserAuthorizationCallbackHandler } from "@itwin/browser-authorization";

--- a/packages/modules/cra-template-web-viewer/template/src/serviceWorker.ts
+++ b/packages/modules/cra-template-web-viewer/template/src/serviceWorker.ts
@@ -1,7 +1,3 @@
-/*---------------------------------------------------------------------------------------------
- * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
- * See LICENSE.md in the project root for license terms and full copyright notice.
- *--------------------------------------------------------------------------------------------*/
 /* eslint-disable */
 // This optional code is used to register a service worker.
 // register() is not called by default.


### PR DESCRIPTION
The links are not pointing to the correct part of the tutorials.

The copyright headers on the template files should not be there as we do not need to copyright the template code that we're giving out to everyone to use.