### PR TITLE
multiple rpc interfaces multiple backends

### DIFF
--- a/common/changes/@itwin/viewer-react/benp-multiple-rpc-interfaces-multiple-backends_2023-01-31-22-27.json
+++ b/common/changes/@itwin/viewer-react/benp-multiple-rpc-interfaces-multiple-backends_2023-01-31-22-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/viewer-react",
+      "comment": "Add two utility types: RequireOne and RequireOneOf",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/viewer-react"
+}

--- a/common/changes/@itwin/web-viewer-react/benp-multiple-rpc-interfaces-multiple-backends_2023-01-31-22-27.json
+++ b/common/changes/@itwin/web-viewer-react/benp-multiple-rpc-interfaces-multiple-backends_2023-01-31-22-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/web-viewer-react",
+      "comment": "Allow multiple backends to be registered, each with a collection of RPC interfaces.",
+      "type": "major"
+    }
+  ],
+  "packageName": "@itwin/web-viewer-react"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -102,7 +102,7 @@ importers:
       '@itwin/presentation-components': 3.5.1_1b221fcc2b30368689980e9e5f563472
       '@itwin/presentation-frontend': 3.5.1_d6b565b7d56b61228f60b1dbd5440e67
       '@itwin/property-grid-react': 0.8.1_54e781232dae349830d83d638abea982
-      '@itwin/tree-widget-react': 0.6.0_692cbfd68e4a80be74a248afca8368b4
+      '@itwin/tree-widget-react': 0.6.1_692cbfd68e4a80be74a248afca8368b4
       '@itwin/webgl-compatibility': 3.5.1
       dotenv-flow: 3.2.0
       electron: 14.2.9
@@ -202,7 +202,7 @@ importers:
       '@itwin/property-grid-react': 0.8.1_54e781232dae349830d83d638abea982
       '@itwin/reality-data-client': 0.9.0_@itwin+core-bentley@3.5.1
       '@itwin/test-local-extension': link:../../modules/test-local-extension
-      '@itwin/tree-widget-react': 0.6.0_692cbfd68e4a80be74a248afca8368b4
+      '@itwin/tree-widget-react': 0.6.1_692cbfd68e4a80be74a248afca8368b4
       '@itwin/web-viewer-react': link:../../modules/web-viewer-react
       '@itwin/webgl-compatibility': 3.5.1
       history: 5.3.0
@@ -3430,8 +3430,8 @@ packages:
       - debug
     dev: false
 
-  /@itwin/tree-widget-react/0.6.0_692cbfd68e4a80be74a248afca8368b4:
-    resolution: {integrity: sha512-nwF5g3ytnoOy9auv9H9LficclKJIOnPliGB6ICeqHfra+7yZCcnhCGzfsBjrx3dcP9+F6N6uvaLOQLi/mRrC3g==}
+  /@itwin/tree-widget-react/0.6.1_692cbfd68e4a80be74a248afca8368b4:
+    resolution: {integrity: sha512-S7gjmskNbUoJR68i4Ht1kpkKdeEYvXxU44Vj1RNOdcjRZWmYnnNhdzPPUDD7KJ5CKqE74L0otzM+HDJ+4/9RRQ==}
     peerDependencies:
       '@itwin/appui-abstract': ^3.5.0
       '@itwin/appui-react': ^3.5.0
@@ -6751,7 +6751,7 @@ packages:
     dev: true
 
   /classnames/2.3.2:
-    resolution: {integrity: sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==}
+    resolution: {integrity: sha1-NR2BO/ATf8xqdqFriCCNJWCg2SQ=}
 
   /clean-css/5.3.1:
     resolution: {integrity: sha512-lCr8OHhiWCTw4v8POJovCoh4T7I9U11yVsPjMWWnnMmp9ZowCxyad1Pathle/9HjaDp+fdQKjO9fQydE6RHTZg==}
@@ -9447,7 +9447,7 @@ packages:
     dev: true
 
   /flatbuffers/1.12.0:
-    resolution: {integrity: sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==}
+    resolution: {integrity: sha1-cuh9FybLGyFug57wJliqh9zvaKo=}
 
   /flatted/3.2.7:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
@@ -15526,7 +15526,7 @@ packages:
     dev: true
 
   /rxjs/6.6.7:
-    resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==}
+    resolution: {integrity: sha1-kKwBisq/SRv2UEQjXVhjxNq4BMk=}
     engines: {npm: '>=2.0.0'}
     dependencies:
       tslib: 1.14.1
@@ -18013,7 +18013,7 @@ packages:
     dev: true
 
   /workerpool/6.2.1:
-    resolution: {integrity: sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==}
+    resolution: {integrity: sha1-RvwVDBfYJrhqAI5aRQhlZ3fpw0M=}
     dev: true
 
   /wrap-ansi/5.1.0:

--- a/common/scripts/.eslintrc.ts.json
+++ b/common/scripts/.eslintrc.ts.json
@@ -4,6 +4,7 @@
     "@typescript-eslint/no-floating-promises": "error",
     "@typescript-eslint/prefer-optional-chain": "warn",
     "@typescript-eslint/prefer-nullish-coalescing": "warn",
-    "react-hooks/exhaustive-deps": "warn"
+    "react-hooks/exhaustive-deps": "warn",
+    "prefer-rest-params": "warn"
   }
 }

--- a/common/scripts/.eslintrc.ts.json
+++ b/common/scripts/.eslintrc.ts.json
@@ -4,7 +4,6 @@
     "@typescript-eslint/no-floating-promises": "error",
     "@typescript-eslint/prefer-optional-chain": "warn",
     "@typescript-eslint/prefer-nullish-coalescing": "warn",
-    "react-hooks/exhaustive-deps": "warn",
-    "prefer-rest-params": "warn"
+    "react-hooks/exhaustive-deps": "warn"
   }
 }

--- a/packages/modules/viewer-react/src/types.ts
+++ b/packages/modules/viewer-react/src/types.ts
@@ -42,6 +42,26 @@ export type XOR<T1, T2> = T1 | T2 extends Record<string, unknown>
   : T1 | T2;
 
 /**
+ * Makes the property K on type T required
+ */
+export type RequireOne<T, K extends keyof T> = {
+  [X in Exclude<keyof T, K>]?: T[X];
+} & {
+  [P in K]-?: T[P];
+};
+
+/**
+ * Requires that _at least one_ of the Keys in type T be required
+ */
+export type RequireOneOf<T, Keys extends keyof T = keyof T> = Pick<
+  T,
+  Exclude<keyof T, Keys>
+> &
+  {
+    [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>;
+  }[Keys];
+
+/**
  * Converts the following optional arg foo of type T
  * foo?: T
  * to a required arg with union of type T and undefined

--- a/packages/modules/web-viewer-react/README.md
+++ b/packages/modules/web-viewer-react/README.md
@@ -4,13 +4,13 @@ The iTwin Web Viewer is a configurable iTwin.js viewer that offers basic configu
 
 ## Installation
 
-```
+```bash
 yarn add @itwin/web-viewer-react
 ```
 
 or
 
-```
+```bash
 npm install @itwin/web-viewer-react
 ```
 
@@ -18,7 +18,7 @@ npm install @itwin/web-viewer-react
 
 If you are creating a new application and are using React, it is advised that you use create-react-app with `@bentley/react-scripts`. There is also a predefined template that includes the iTwin Viewer package:
 
-```
+```bash
 npx create-react-app@latest my-app --scripts-version @bentley/react-scripts --template @itwin/web-viewer
 ```
 
@@ -80,9 +80,7 @@ export const MyViewerComponent = () => {
 
 - `changeSetId` - Changeset id to view if combined with the iTwinId and iModelId props
 - `blankConnectionViewState` - Override options for the ViewState that is generated for the BlankConnection
-
-- `backend` - Backend connection info (defaults to the iTwin Platform's iModel Access Service)
-
+- `backendConfiguration` - Manage backend(s) connection info and RPC Interfaces. [See below](#backend-configuration)
 - `theme` - Override the default theme
 - `defaultUiConfig` - hide parts of the default frontstage
   - `hideNavigationAid` - hide the navigation aid cube
@@ -94,7 +92,6 @@ export const MyViewerComponent = () => {
 - `uiProviders` - Extend the viewer's default ui
 - `viewCreatorOptions` - Options for creating the default viewState
 - `loadingComponent` - provide a custom React component to override the spinner when an iModel is loading
-
 - `productId` - application's GPRID
 - `i18nUrlTemplate` - Override the default url template where i18n resource files are queried
 - `onIModelAppInit` - Callback function that executes after IModelApp.startup completes
@@ -183,10 +180,95 @@ export const MyBlankViewerComponent = () => {
 };
 ```
 
-# Development
+## Backend Configuration
+
+If no `backendConfiguration` is specified, the backend defaults to the iTwin Platform's iModel Access Service. You can modify or override this default backend, add additional RpcInterfaces to it, and/or add additional backends. The below examples are not mutually exclusive.
+
+### Default Backend
+
+#### Change default backend details
+
+```javascript
+    // ... rest of code omitted
+    <Viewer
+      // ...other props omitted
+      backendConfiguration={{
+        defaultBackend: {
+          config: {
+            info: {
+              title: "New Default Backend Title",
+              version: "v5.0"
+            },
+            uriPrefix: "https://new-default-backend-uri"
+          }
+        }
+      }}
+    />
+```
+
+#### Add additional RPC Interfaces to Default Backend
+
+```javascript
+    // ... rest of code omitted
+    <Viewer
+      // ...other props omitted
+      backendConfiguration={{
+        defaultBackend: {
+          rpcInterfaces: [
+            MyRpcInterface,
+            AnotherRpcInterface
+          ]
+        }
+      }}
+    />
+```
+
+### Custom Backends
+
+Add one or more custom backends with any number of RPC Interfaces registered against each.
+
+#### Example
+
+```javascript
+    // ... rest of code omitted
+    <Viewer
+      // ...other props omitted
+      backendConfiguration={{
+        customBackends: [
+          { 
+            config: {
+              info: {
+                title: "Custom Backend One",
+                version: "v3.0"
+              },
+              uriPrefix: "https://custom-backend-uri"
+            },
+            rpcInterfaces: [
+              BackendOneRpcInterface,
+              BackendOneRpcInterfaceTwo
+            ]
+          },
+          { 
+            config: {
+              info: {
+                title: "Custom Backend Two",
+                version: "v4.0"
+              },
+              uriPrefix: "https://custom-backend-two-uri"
+            },
+            rpcInterfaces: [
+              BackendTwoRpcInterface
+            ]
+          }
+        ]
+      }}
+    />
+```
+
+## Development
 
 When making changes to the src, run `npm start` in the package's root folder to enable source watching and rebuild, so the dev-server will have access to updated code on successful code compilation.
 
-# Next Steps
+## Next Steps
 
 [Extending the iTwin Viewer](https://www.itwinjs.org/learning/tutorials/hello-world-viewer/)

--- a/packages/modules/web-viewer-react/src/services/RpcInitializer.ts
+++ b/packages/modules/web-viewer-react/src/services/RpcInitializer.ts
@@ -1,0 +1,81 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { BentleyCloudRpcManager } from "@itwin/core-common";
+
+import type { RegisterClientOptions } from "../types";
+
+/**
+ * The RpcInitializer handles registration of backends/instantiates RpcInterface clients.
+ */
+export class RpcInitializer {
+  static readonly orchestratorUrl = `https://${globalThis.IMJS_URL_PREFIX}api.bentley.com`;
+
+  /**
+   * Instantiates a `DefaultBackend` and optional `CustomBackend`s. The `DefaultBackend`
+   * must have at least one Rpc Interface in the `DefaultBackend.rpcInterfaces` array.
+   * @param options: RegisterClientOptions
+   * @returns void
+   */
+  public static registerClients(options: RegisterClientOptions) {
+    const formattedOptions = this.formatDefaultBackendOptions(options);
+
+    BentleyCloudRpcManager.initializeClient(
+      formattedOptions,
+      options.defaultBackend.rpcInterfaces
+    );
+
+    if (!options?.customBackends) {
+      return;
+    }
+
+    for (const { config, rpcInterfaces } of options.customBackends) {
+      BentleyCloudRpcManager.initializeClient(config, rpcInterfaces);
+    }
+  }
+
+  private static formatDefaultBackendOptions(options: RegisterClientOptions) {
+    if (options.defaultBackend.config?.uriPrefix) {
+      return {
+        info: {
+          title:
+            options.defaultBackend.config.info?.title ??
+            this.getDefaultInfo().info.title,
+          version:
+            options.defaultBackend.config.info?.version ??
+            this.getDefaultInfo().info.version,
+        },
+        uriPrefix: options.defaultBackend.config.uriPrefix,
+      };
+    }
+
+    if (options.defaultBackend.config?.info) {
+      if (!options.defaultBackend.config?.info?.title) {
+        throw new Error("Please provide the title for the iTwin.js backend");
+      }
+
+      if (!options.defaultBackend.config?.info.version) {
+        throw new Error("Please provide the version for the iTwin.js backend");
+      }
+
+      return {
+        uriPrefix: this.getDefaultInfo().uriPrefix,
+        info: {
+          title: options.defaultBackend.config.info.title,
+          version: options.defaultBackend.config.info.version,
+        },
+      };
+    }
+
+    return this.getDefaultInfo();
+  }
+
+  private static getDefaultInfo() {
+    return {
+      info: { title: "imodel/rpc", version: "" },
+      uriPrefix: this.orchestratorUrl,
+    };
+  }
+}

--- a/packages/modules/web-viewer-react/src/tests/components/Viewer.test.tsx
+++ b/packages/modules/web-viewer-react/src/tests/components/Viewer.test.tsx
@@ -18,7 +18,7 @@ import React from "react";
 
 import { Viewer } from "../../components/Viewer";
 import { WebInitializer } from "../../services/Initializer";
-import type { IModelBackendOptions } from "../../types";
+import type { BackendConfiguration } from "../../types";
 import MockAuthorizationClient from "../mocks/MockAuthorizationClient";
 
 jest.mock("@itwin/viewer-react", () => {
@@ -156,13 +156,14 @@ describe("Viewer", () => {
   it("initializes the Viewer with the provided backend configuration", async () => {
     jest.spyOn(WebInitializer, "startWebViewer");
 
-    const backendConfig: IModelBackendOptions = {
-      customBackend: {
-        rpcParams: {
+    const backendConfig: BackendConfiguration = {
+      defaultBackend: {
+        config: {
           info: {
-            title: "myBackend",
-            version: "v1.0",
+            title: "default Title",
+            version: "23.0",
           },
+          uriPrefix: "https://customBackendUrl",
         },
       },
     };
@@ -172,7 +173,7 @@ describe("Viewer", () => {
         authClient={authClient}
         iTwinId={mockITwinId}
         iModelId={mockIModelId}
-        backend={backendConfig}
+        backendConfiguration={backendConfig}
         enablePerformanceMonitors={false}
       />
     );
@@ -181,7 +182,7 @@ describe("Viewer", () => {
 
     expect(WebInitializer.startWebViewer).toHaveBeenCalledWith({
       authClient: authClient,
-      backend: backendConfig,
+      backendConfiguration: backendConfig,
       iTwinId: mockITwinId,
       iModelId: mockIModelId,
       enablePerformanceMonitors: false,

--- a/packages/modules/web-viewer-react/src/tests/services/Initializer.test.ts
+++ b/packages/modules/web-viewer-react/src/tests/services/Initializer.test.ts
@@ -3,19 +3,19 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import {
-  IModelReadRpcInterface,
-  IModelTileRpcInterface,
-  SnapshotIModelRpcInterface,
-} from "@itwin/core-common";
+import { BentleyCloudRpcManager } from "@itwin/core-common";
 import type { IModelAppOptions } from "@itwin/core-frontend";
 import { IModelApp } from "@itwin/core-frontend";
 import { UiCore } from "@itwin/core-react";
-import { PresentationRpcInterface } from "@itwin/presentation-common";
 import type { ViewerInitializerParams } from "@itwin/viewer-react";
 
 import { WebInitializer } from "../../services/Initializer";
 import MockAuthorizationClient from "../mocks/MockAuthorizationClient";
+import {
+  defaultRpcInterfaces,
+  TestRpcInterface,
+  TestRpcInterface2,
+} from "../test-helpers/rpc";
 
 jest.mock("@itwin/core-frontend", () => {
   const noMock = jest.requireActual("@itwin/core-frontend");
@@ -78,10 +78,7 @@ jest.mock("@itwin/viewer-react", () => {
         notifications: expect.anything(),
         uiAdmin: expect.anything(),
         rpcInterfaces: [
-          IModelReadRpcInterface,
-          IModelTileRpcInterface,
-          PresentationRpcInterface,
-          SnapshotIModelRpcInterface,
+          ...defaultRpcInterfaces,
           ...(options?.additionalRpcInterfaces ?? []),
         ],
         localization: expect.anything(),
@@ -110,6 +107,8 @@ jest.mock("@itwin/viewer-react", () => {
   };
 });
 
+const initClientSpy = jest.spyOn(BentleyCloudRpcManager, "initializeClient");
+
 describe("Initializer", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -125,5 +124,301 @@ describe("Initializer", () => {
     });
     await WebInitializer.initialized;
     expect(IModelApp.startup).toHaveBeenCalled();
+  });
+
+  it("initializes default RPC interfaces", async () => {
+    await WebInitializer.startWebViewer({
+      authClient: new MockAuthorizationClient(),
+      enablePerformanceMonitors: false,
+    });
+    await WebInitializer.initialized;
+    expect(initClientSpy).toHaveBeenCalledTimes(1);
+    expect(initClientSpy).toHaveBeenCalledWith(
+      {
+        info: {
+          title: "imodel/rpc",
+          version: "",
+        },
+        uriPrefix: "https://undefinedapi.bentley.com",
+      },
+      defaultRpcInterfaces
+    );
+  });
+
+  it("initializes default RPC interfaces with altered default backend url", async () => {
+    await WebInitializer.startWebViewer({
+      authClient: new MockAuthorizationClient(),
+      enablePerformanceMonitors: false,
+      backendConfiguration: {
+        defaultBackend: {
+          config: {
+            uriPrefix: "https://alteredBackendUrl.bentley",
+          },
+        },
+      },
+    });
+
+    await WebInitializer.initialized;
+    expect(initClientSpy).toHaveBeenCalledTimes(1);
+    expect(initClientSpy).toHaveBeenCalledWith(
+      {
+        info: {
+          title: "imodel/rpc",
+          version: "",
+        },
+        uriPrefix: "https://alteredBackendUrl.bentley",
+      },
+      defaultRpcInterfaces
+    );
+  });
+
+  it("initializes default RPC interfaces with altered title and version", async () => {
+    await WebInitializer.startWebViewer({
+      authClient: new MockAuthorizationClient(),
+      enablePerformanceMonitors: false,
+      backendConfiguration: {
+        defaultBackend: {
+          config: {
+            info: {
+              title: "Custom title",
+              version: "Custom version",
+            },
+          },
+        },
+      },
+    });
+
+    await WebInitializer.initialized;
+    expect(initClientSpy).toHaveBeenCalledTimes(1);
+    expect(initClientSpy).toHaveBeenCalledWith(
+      {
+        info: {
+          title: "Custom title",
+          version: "Custom version",
+        },
+        uriPrefix: "https://undefinedapi.bentley.com",
+      },
+      defaultRpcInterfaces
+    );
+  });
+
+  it("initializes default RPC interfaces with additional rpcs", async () => {
+    await WebInitializer.startWebViewer({
+      authClient: new MockAuthorizationClient(),
+      enablePerformanceMonitors: false,
+      backendConfiguration: {
+        defaultBackend: {
+          rpcInterfaces: [TestRpcInterface],
+        },
+      },
+    });
+
+    await WebInitializer.initialized;
+    expect(initClientSpy).toHaveBeenCalledTimes(1);
+    expect(initClientSpy).toHaveBeenCalledWith(
+      {
+        info: {
+          title: "imodel/rpc",
+          version: "",
+        },
+        uriPrefix: "https://undefinedapi.bentley.com",
+      },
+      [...defaultRpcInterfaces, TestRpcInterface]
+    );
+  });
+
+  it("default backend throws if config is specified but no version is provided", async () => {
+    await WebInitializer.startWebViewer({
+      authClient: new MockAuthorizationClient(),
+      enablePerformanceMonitors: false,
+      backendConfiguration: {
+        defaultBackend: {
+          config: {
+            info: {
+              title: "specified default backend",
+              version: "",
+            },
+          },
+        },
+      },
+    });
+
+    expect(WebInitializer.initialized).rejects.toThrowError(
+      "Please provide the version for the iTwin.js backend"
+    );
+
+    expect(initClientSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it("default backend throws if config is specified but no version is provided", async () => {
+    await WebInitializer.startWebViewer({
+      authClient: new MockAuthorizationClient(),
+      enablePerformanceMonitors: false,
+      backendConfiguration: {
+        defaultBackend: {
+          config: {
+            info: {
+              title: "specified default backend",
+              version: "",
+            },
+          },
+        },
+      },
+    });
+
+    expect(WebInitializer.initialized).rejects.toThrowError(
+      "Please provide the version for the iTwin.js backend"
+    );
+
+    expect(initClientSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it("initializes multiple backends - specified custom (default included by default)", async () => {
+    await WebInitializer.startWebViewer({
+      authClient: new MockAuthorizationClient(),
+      enablePerformanceMonitors: false,
+      backendConfiguration: {
+        customBackends: [
+          {
+            config: {
+              info: { title: "My Custom Backend", version: "1.0" },
+              uriPrefix: "https://custombackend.bentley",
+            },
+            rpcInterfaces: [TestRpcInterface],
+          },
+        ],
+      },
+    });
+
+    expect(initClientSpy).toHaveBeenNthCalledWith(
+      1,
+      {
+        info: {
+          title: "imodel/rpc",
+          version: "",
+        },
+        uriPrefix: "https://undefinedapi.bentley.com",
+      },
+      defaultRpcInterfaces
+    );
+
+    expect(initClientSpy).toHaveBeenNthCalledWith(
+      2,
+      {
+        info: { title: "My Custom Backend", version: "1.0" },
+        uriPrefix: "https://custombackend.bentley",
+      },
+      [TestRpcInterface]
+    );
+  });
+
+  it("initializes multiple backends - specified custom and specified default", async () => {
+    await WebInitializer.startWebViewer({
+      authClient: new MockAuthorizationClient(),
+      enablePerformanceMonitors: false,
+      backendConfiguration: {
+        customBackends: [
+          {
+            config: {
+              info: { title: "My Custom Backend", version: "3.0" },
+              uriPrefix: "https://custombackend.bentley.specified2",
+            },
+            rpcInterfaces: [TestRpcInterface],
+          },
+        ],
+        defaultBackend: {
+          config: {
+            info: {
+              title: "specified default backend",
+              version: "2.0",
+            },
+          },
+        },
+      },
+    });
+
+    expect(initClientSpy).toHaveBeenNthCalledWith(
+      1,
+      {
+        info: {
+          title: "specified default backend",
+          version: "2.0",
+        },
+        uriPrefix: "https://undefinedapi.bentley.com",
+      },
+      defaultRpcInterfaces
+    );
+
+    expect(initClientSpy).toHaveBeenNthCalledWith(
+      2,
+      {
+        info: { title: "My Custom Backend", version: "3.0" },
+        uriPrefix: "https://custombackend.bentley.specified2",
+      },
+      [TestRpcInterface]
+    );
+  });
+
+  it("initializes many backends - multiple custom and specified default", async () => {
+    await WebInitializer.startWebViewer({
+      authClient: new MockAuthorizationClient(),
+      enablePerformanceMonitors: false,
+      backendConfiguration: {
+        customBackends: [
+          {
+            config: {
+              info: { title: "My Custom Backend", version: "3.0" },
+              uriPrefix: "https://custombackend.bentley.specified2",
+            },
+            rpcInterfaces: [TestRpcInterface],
+          },
+          {
+            config: {
+              info: { title: "My Custom Backend 2", version: "4.0" },
+              uriPrefix: "https://custombackend.bentley.specified3",
+            },
+            rpcInterfaces: [TestRpcInterface2],
+          },
+        ],
+        defaultBackend: {
+          config: {
+            info: {
+              title: "specified default backend",
+              version: "2.0",
+            },
+          },
+        },
+      },
+    });
+
+    expect(initClientSpy).toHaveBeenNthCalledWith(
+      1,
+      {
+        info: {
+          title: "specified default backend",
+          version: "2.0",
+        },
+        uriPrefix: "https://undefinedapi.bentley.com",
+      },
+      defaultRpcInterfaces
+    );
+
+    expect(initClientSpy).toHaveBeenNthCalledWith(
+      2,
+      {
+        info: { title: "My Custom Backend", version: "3.0" },
+        uriPrefix: "https://custombackend.bentley.specified2",
+      },
+      [TestRpcInterface]
+    );
+
+    expect(initClientSpy).toHaveBeenNthCalledWith(
+      3,
+      {
+        info: { title: "My Custom Backend 2", version: "4.0" },
+        uriPrefix: "https://custombackend.bentley.specified3",
+      },
+      [TestRpcInterface2]
+    );
   });
 });

--- a/packages/modules/web-viewer-react/src/tests/test-helpers/rpc.ts
+++ b/packages/modules/web-viewer-react/src/tests/test-helpers/rpc.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+/* eslint-disable prefer-rest-params */
+
+import type { IModelRpcProps } from "@itwin/core-common";
+import {
+  IModelReadRpcInterface,
+  IModelTileRpcInterface,
+  RpcInterface,
+  RpcManager,
+  SnapshotIModelRpcInterface,
+} from "@itwin/core-common";
+import { PresentationRpcInterface } from "@itwin/presentation-common";
+
+export const defaultRpcInterfaces = [
+  IModelReadRpcInterface,
+  IModelTileRpcInterface,
+  PresentationRpcInterface,
+  SnapshotIModelRpcInterface,
+];
+
+export abstract class TestRpcInterface extends RpcInterface {
+  // eslint-disable-line deprecation/deprecation
+  public static readonly interfaceName = "TestRpcInterface";
+  public static interfaceVersion = "1.1.1";
+
+  public static getClient(): TestRpcInterface {
+    return RpcManager.getClientForInterface(TestRpcInterface);
+  }
+  public async restartIModelHost(): Promise<void> {
+    return this.forward(arguments);
+  }
+  public async executeTest(
+    _iModelRpcProps: IModelRpcProps,
+    _testName: string,
+    _params: any
+  ): Promise<any> {
+    return this.forward(arguments);
+  }
+  public async purgeCheckpoints(_iModelId: string): Promise<void> {
+    return this.forward(arguments);
+  }
+  public async purgeStorageCache(): Promise<void> {
+    return this.forward(arguments);
+  }
+  public async beginOfflineScope(): Promise<void> {
+    return this.forward(arguments);
+  }
+  public async endOfflineScope(): Promise<void> {
+    return this.forward(arguments);
+  }
+}
+
+export class TestRpcInterface2 extends TestRpcInterface {
+  public static override readonly interfaceName = "TestRpcInterface";
+  public static override interfaceVersion = "1.1.1";
+  public static override getClient(): TestRpcInterface2 {
+    return RpcManager.getClientForInterface(TestRpcInterface2);
+  }
+}

--- a/packages/modules/web-viewer-react/src/types.ts
+++ b/packages/modules/web-viewer-react/src/types.ts
@@ -3,45 +3,51 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import type { BentleyCloudRpcParams } from "@itwin/core-common";
+import type {
+  BentleyCloudRpcParams,
+  RpcInterface,
+  RpcInterfaceDefinition,
+} from "@itwin/core-common";
 import type {
   BlankViewerProps,
   ConnectedViewerProps,
+  RequireOne,
+  RequireOneOf,
   ViewerAuthorizationClient,
   ViewerCommonProps,
   XOR,
 } from "@itwin/viewer-react";
 
 /**
- * Hosted backend configuration
+ * Custom backend and rpc configuration
  */
-export interface HostedBackendConfig {
-  /* title for rpc config */
-  title: string;
-  /* in the form "vx.x" */
-  version: string;
-}
+export type BackendConfiguration = RequireOneOf<
+  {
+    defaultBackend: RequireOneOf<DefaultBackend, "rpcInterfaces" | "config">;
+    customBackends: CustomBackend[];
+  },
+  "defaultBackend" | "customBackends"
+>;
 
-/**
- * Custom rpc configuration
- */
-export interface CustomBackendConfig {
-  rpcParams: BentleyCloudRpcParams;
-}
+export type RegisterClientOptions = {
+  defaultBackend: RequireOne<DefaultBackend, "rpcInterfaces">;
+  customBackends?: CustomBackend[];
+};
 
-/**
- * Backend configuration
- */
-export interface IModelBackendOptions {
-  hostedBackend?: HostedBackendConfig;
-  customBackend?: CustomBackendConfig;
-}
+export type DefaultBackend = {
+  rpcInterfaces?: RpcInterfaceDefinition<RpcInterface>[]; // will be combined with a set of default interfaces
+  config?: Partial<BentleyCloudRpcParams>;
+};
+
+export type CustomBackend = {
+  rpcInterfaces: RpcInterfaceDefinition<RpcInterface>[]; // will be combined with a set of default interfaces
+  config: BentleyCloudRpcParams;
+};
 
 export type WebInitializerParams = ViewerCommonProps & {
   /** authorization configuration */
   authClient: ViewerAuthorizationClient;
-  /** options to override the default backend from iTwin Platform */
-  backend?: IModelBackendOptions;
+  backendConfiguration?: BackendConfiguration;
 };
 
 export type WebViewerProps = XOR<ConnectedViewerProps, BlankViewerProps> &


### PR DESCRIPTION
Enable the registration of multiple RPC interfaces across multiple backends, retaining the concept and functional of a default backend. 

Since both the `Viewer` `backend` and `additionalRpcInterfaces` props relate to the same functionality, they've been merged as `backendConfiguration`.

This is a breaking change to the `Viewer`'s API. 

fixes: iTwin/itwinjs-core#4725