### PR TITLE
Add `USING_NPM` env var in templates and default to true. Will be the case if bootstrapped using npx

### DIFF
--- a/common/changes/@itwin/cra-template-desktop-viewer/arun-fix-localization_2023-04-19-13-10.json
+++ b/common/changes/@itwin/cra-template-desktop-viewer/arun-fix-localization_2023-04-19-13-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/cra-template-desktop-viewer",
+      "comment": "Add `USING_NPM` env var and default to true. Will be the case if bootstrapped using npx",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/cra-template-desktop-viewer"
+}

--- a/common/changes/@itwin/cra-template-web-viewer/arun-fix-localization_2023-04-19-13-10.json
+++ b/common/changes/@itwin/cra-template-web-viewer/arun-fix-localization_2023-04-19-13-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/cra-template-web-viewer",
+      "comment": "Add `USING_NPM` env var and default to true. Will be the case if bootstrapped using npx",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/cra-template-web-viewer"
+}

--- a/packages/modules/cra-template-desktop-viewer/README.md
+++ b/packages/modules/cra-template-desktop-viewer/README.md
@@ -8,10 +8,6 @@ For example:
 
 ```sh
 npx create-react-app my-app-name --template @itwin/desktop-viewer --scripts-version @bentley/react-scripts
-
-# or
-
-yarn create react-app my-app-name --template @itwin/desktop-viewer --scripts-version @bentley/react-scripts
 ```
 
 For more information, please refer to:

--- a/packages/modules/cra-template-desktop-viewer/template/.env
+++ b/packages/modules/cra-template-desktop-viewer/template/.env
@@ -15,3 +15,5 @@ DISABLE_NEW_JSX_TRANSFORM=true
 USE_FAST_SASS=true
 USE_FULL_SOURCEMAP=true
 TRANSPILE_DEPS=false
+# Remove the following env var if using a different package manager
+USING_NPM=true

--- a/packages/modules/cra-template-web-viewer/template/.env
+++ b/packages/modules/cra-template-web-viewer/template/.env
@@ -16,3 +16,5 @@ SKIP_PREFLIGHT_CHECK=true
 USE_FAST_SASS=true
 USE_FULL_SOURCEMAP=true
 TRANSPILE_DEPS=false
+# Remove the following env var if using a different package manager
+USING_NPM=true


### PR DESCRIPTION
update template to always default to using npm, which will fix missing static assets