### PR TITLE
[cra-template-web-viewer][cra-template-desktop-viewer] Adding legacy-peer-deps flag to .npmrc to fix templates

### DIFF
--- a/packages/templates/cra-template-desktop-viewer/template/.npmrc
+++ b/packages/templates/cra-template-desktop-viewer/template/.npmrc
@@ -1,2 +1,3 @@
 @bentley:registry=https://registry.npmjs.org/
 @itwin:registry=https://registry.npmjs.org/
+legacy-peer-deps=true

--- a/packages/templates/cra-template-web-viewer/template/.npmrc
+++ b/packages/templates/cra-template-web-viewer/template/.npmrc
@@ -1,2 +1,3 @@
 @bentley:registry=https://registry.npmjs.org/
 @itwin:registry=https://registry.npmjs.org/
+legacy-peer-deps=true


### PR DESCRIPTION
The create-react-app command is failing to build the templates due to a change introduced in npm v7. Previously , the peer dependency resolution warnings we were recieving did not cause failure and have since been upgraded to errors. To address this, adding legacy-peer-deps flag to .npmrc to fixes this issue for us.