### PR TITLE
[cra-template-web-viewer][cra-template-desktop-viewer] adding .npmrc file to files array in package.json to allow it into npm pack

### DIFF
--- a/packages/templates/cra-template-desktop-viewer/package.json
+++ b/packages/templates/cra-template-desktop-viewer/package.json
@@ -24,7 +24,8 @@
   },
   "files": [
     "template",
-    "template.json"
+    "template.json",
+    "template/.npmrc"
   ],
   "main": "template.json",
   "scripts": {

--- a/packages/templates/cra-template-web-viewer/package.json
+++ b/packages/templates/cra-template-web-viewer/package.json
@@ -23,7 +23,8 @@
   },
   "files": [
     "template",
-    "template.json"
+    "template.json",
+    "template/.npmrc"
   ],
   "main": "template.json",
   "scripts": {


### PR DESCRIPTION
the npm package we publish was excluding the .npmrc file which we are using to fix an issue with building the templates. adding the file to the files array in the package.json fixes this and adds it to the list of files to publish