### PR TITLE
[viewer-react] Adding @itwin/presentation-components to peer dependency list

### DIFF
--- a/common/changes/@itwin/viewer-react/jake-presentation-add-to-peer_2023-05-25-13-51.json
+++ b/common/changes/@itwin/viewer-react/jake-presentation-add-to-peer_2023-05-25-13-51.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@itwin/viewer-react",
       "comment": "Adding @itwin/presentation-components to peerDependencies in viewer-react",
-      "type": "none"
+      "type": "patch"
     }
   ],
   "packageName": "@itwin/viewer-react"

--- a/common/changes/@itwin/viewer-react/jake-presentation-add-to-peer_2023-05-25-13-51.json
+++ b/common/changes/@itwin/viewer-react/jake-presentation-add-to-peer_2023-05-25-13-51.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/viewer-react",
-      "comment": "Adding @itwin/presentation-components to peerDependencies in viewer-react",
+      "comment": "Adding @itwin/presentation-components to peerDependencies in @itwin/viewer-react",
       "type": "patch"
     }
   ],

--- a/common/changes/@itwin/viewer-react/jake-presentation-add-to-peer_2023-05-25-13-51.json
+++ b/common/changes/@itwin/viewer-react/jake-presentation-add-to-peer_2023-05-25-13-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/viewer-react",
+      "comment": "Adding @itwin/presentation-components to peerDependencies in viewer-react",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/viewer-react"
+}

--- a/packages/modules/viewer-react/package.json
+++ b/packages/modules/viewer-react/package.json
@@ -94,6 +94,7 @@
     "@itwin/imodels-access-frontend": "^4.0.0",
     "@itwin/imodels-client-management": "^4.0.0",
     "@itwin/presentation-common": "^4.0.0",
+    "@itwin/presentation-components": "^4.0.0",
     "@itwin/presentation-frontend": "^4.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",


### PR DESCRIPTION
Adding @itwin/presentation-components to peer dependency list. This is to allow viewer projects to not have to list @itwin/presentation-components in their dependency list unless they actively use it.