### PR TITLE
[viewer-react] Exposing default frontstage id

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # This workflow will install dependencies, check for dependency version consistency, build all packages in the repo, and run tests
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: iTwin Viewer monorepo CI build
+name: iTwin Viewer monorepo CI
 
 on:
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # This workflow will install dependencies, check for dependency version consistency, build all packages in the repo, and run tests
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: iTwin Viewer monorepo CI
+name: iTwin Viewer monorepo CI build
 
 on:
   pull_request:

--- a/common/changes/@itwin/viewer-react/jake-expose-default-frontstage-id_2023-05-25-18-03.json
+++ b/common/changes/@itwin/viewer-react/jake-expose-default-frontstage-id_2023-05-25-18-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/viewer-react",
+      "comment": "Exposing default frontstage id as a const",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/viewer-react"
+}

--- a/packages/modules/viewer-react/src/hooks/useFrontstages.tsx
+++ b/packages/modules/viewer-react/src/hooks/useFrontstages.tsx
@@ -23,7 +23,8 @@ export interface UseFrontstagesProps {
   blankConnectionViewState?: BlankConnectionViewState;
 }
 
-export const DefaultFrontstageProviderId = "iTwinViewer.DefaultFrontstage";
+export const ViewerDefaultFrontstageProviderId =
+  "iTwinViewer.DefaultFrontstage";
 
 export const useFrontstages = ({
   frontstages,
@@ -71,7 +72,7 @@ export const useFrontstages = ({
       );
 
       const defaultFrontstageProvider = new StandardFrontstageProvider({
-        id: DefaultFrontstageProviderId,
+        id: ViewerDefaultFrontstageProviderId,
         usage: StageUsage.General,
         contentGroupProps: contentGroup,
         ...defaultUiConfig,

--- a/packages/modules/viewer-react/src/hooks/useFrontstages.tsx
+++ b/packages/modules/viewer-react/src/hooks/useFrontstages.tsx
@@ -23,6 +23,8 @@ export interface UseFrontstagesProps {
   blankConnectionViewState?: BlankConnectionViewState;
 }
 
+export const DefaultFrontstageProviderId = "iTwinViewer.DefaultFrontstage";
+
 export const useFrontstages = ({
   frontstages,
   blankConnectionViewState,
@@ -69,7 +71,7 @@ export const useFrontstages = ({
       );
 
       const defaultFrontstageProvider = new StandardFrontstageProvider({
-        id: "iTwinViewer.DefaultFrontstage",
+        id: DefaultFrontstageProviderId,
         usage: StageUsage.General,
         contentGroupProps: contentGroup,
         ...defaultUiConfig,


### PR DESCRIPTION
In response to this [issue](https://github.com/iTwin/viewer/issues/275) raised by @Emi1yZhang

Exposing the default frontstage id by exporting it as a constant.