### PR TITLE
Sync Selection Scope List, Active Selection Scope & Selection Count between Presentation and AppUI

### DIFF
--- a/common/changes/@itwin/viewer-react/SyncSelectionScope_2023-09-05-17-30.json
+++ b/common/changes/@itwin/viewer-react/SyncSelectionScope_2023-09-05-17-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/viewer-react",
+      "comment": "Sync Selection Scope List, Active Selection Scope & Selection Count between Presentation and AppUI",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/viewer-react"
+}

--- a/packages/modules/viewer-react/src/components/iModel/IModelLoader.tsx
+++ b/packages/modules/viewer-react/src/components/iModel/IModelLoader.tsx
@@ -119,6 +119,7 @@ const IModelLoader = React.memo((viewerProps: ModelLoaderProps) => {
       }
       setConnection(imodelConnection);
 
+      // Syncs selection scope list between AppUi and Presentation after connecting to iModel
       syncSelectionScopeList(imodelConnection);
 
       return imodelConnection;

--- a/packages/modules/viewer-react/src/components/iModel/IModelLoader.tsx
+++ b/packages/modules/viewer-react/src/components/iModel/IModelLoader.tsx
@@ -39,7 +39,7 @@ const syncSelectionScopeList = async (iModel: IModelConnection) => {
     SessionStateActionId.SetAvailableSelectionScopes,
     availableScopes
   );
-  };
+};
   
 const IModelLoader = React.memo((viewerProps: ModelLoaderProps) => {
   const [error, setError] = useState<Error>();

--- a/packages/modules/viewer-react/src/components/iModel/IModelLoader.tsx
+++ b/packages/modules/viewer-react/src/components/iModel/IModelLoader.tsx
@@ -6,7 +6,7 @@
 import "@bentley/icons-generic-webfont/dist/bentley-icons-generic-webfont.css";
 import "./IModelLoader.scss";
 
-import { StateManager, UiFramework, UiItemsProvider } from "@itwin/appui-react";
+import { SessionStateActionId, StateManager, UiFramework, UiItemsProvider } from "@itwin/appui-react";
 import type { IModelConnection } from "@itwin/core-frontend";
 import { IModelApp } from "@itwin/core-frontend";
 import { SvgIModelLoader } from "@itwin/itwinui-illustrations-react";
@@ -28,7 +28,19 @@ import { ViewerPerformance } from "../../services/telemetry";
 import type { ModelLoaderProps } from "../../types";
 import { IModelViewer } from "./";
 import { BackstageItemsProvider } from "../app-ui/providers";
+import { Presentation } from "@itwin/presentation-frontend";
 
+// This preserves how the list of selection scopes was synced between Presentation and AppUi before its removal in 4.x
+const syncSelectionScopeList = async (iModel: IModelConnection) => {
+  // Fetch the available selection scopes and add them to the redux store
+  const availableScopes =
+    await Presentation.selection.scopes.getSelectionScopes(iModel);
+  UiFramework.dispatchActionToStore(
+    SessionStateActionId.SetAvailableSelectionScopes,
+    availableScopes
+  );
+  };
+  
 const IModelLoader = React.memo((viewerProps: ModelLoaderProps) => {
   const [error, setError] = useState<Error>();
   const [connection, setConnection] = useState<IModelConnection>();
@@ -106,6 +118,9 @@ const IModelLoader = React.memo((viewerProps: ModelLoaderProps) => {
         await onIModelConnected(imodelConnection);
       }
       setConnection(imodelConnection);
+
+      syncSelectionScopeList(imodelConnection);
+
       return imodelConnection;
     }
     return;

--- a/packages/modules/viewer-react/src/services/BaseInitializer.ts
+++ b/packages/modules/viewer-react/src/services/BaseInitializer.ts
@@ -149,10 +149,6 @@ export class BaseInitializer {
       syncSelectionCount();
       syncActiveSelectionScope();
 
-      const iModelConnection = UiFramework.getIModelConnection();
-      if (iModelConnection) {
-        syncSelectionScopeList(iModelConnection);
-      }
 
       // allow uiAdmin to open key-in palette when Ctrl+F2 is pressed - good for manually loading UI providers
       IModelApp.uiAdmin.updateFeatureFlags({ allowKeyinPalette: true });
@@ -295,23 +291,14 @@ const syncSelectionCount = () => {
   );
 };
 
-// This preserves how the list of selection scopes was synced between Presentation and AppUi before its removal in 4.x
-const syncSelectionScopeList = async (iModel: IModelConnection) => {
-// Fetch the available selection scopes and add them to the redux store
-const availableScopes =
-  await Presentation.selection.scopes.getSelectionScopes(iModel);
-UiFramework.dispatchActionToStore(
-  SessionStateActionId.SetAvailableSelectionScopes,
-  availableScopes
-);
-};
+
 
 // This preserves how the active selection scope was synced between Presentation and AppUi before its removal in 4.x
 const syncActiveSelectionScope = () => {
 SyncUiEventDispatcher.onSyncUiEvent.addListener((args: UiSyncEventArgs) => {
   if (args.eventIds.has(SessionStateActionId.SetSelectionScope)) {
       // After 4.x the appui no longer has a presentation  dep and therefore we have the responsibility of
-      // syncing the Presetnation.selection.scopes.activeScope with the AppUi's UiSyncEvent for SetSelectionScope
+      // syncing the Presentation.selection.scopes.activeScope with the AppUi's UiSyncEvent for SetSelectionScope
       Presentation.selection.scopes.activeScope = UiFramework.getActiveSelectionScope();
   }
   });

--- a/packages/modules/viewer-react/src/services/BaseInitializer.ts
+++ b/packages/modules/viewer-react/src/services/BaseInitializer.ts
@@ -45,9 +45,9 @@ const syncSelectionCount = () => {
         numSelected
       );
 
-      // NOTE: add a one time event listener to the iModel.seletionSet.onChanged to restore the numSelected to the value that we
-      //   extracted from the Presentation.selection.selectionChange event in order to override the numSelected AppUi sets from
-      //   the iModel.selectionSet.onChanged that will treat assemblies as a collection of elements instead of a single one
+      // NOTE: add a one time event listener to the iModelConnection.selectionSet.onChanged to restore the numSelected to the value that we
+      // extracted from the Presentation.selection.selectionChange event in order to override the numSelected AppUi sets from
+      // the iModelConnection.selectionSet.onChanged that will treat assemblies as a collection of elements instead of a single one
       UiFramework.getIModelConnection()?.selectionSet.onChanged.addOnce(
         (_ev) => {
           UiFramework.dispatchActionToStore(
@@ -191,6 +191,7 @@ export class BaseInitializer {
         },
       });
 
+      // Sync selection count & active selection scope between Presentation and AppUi. Runs after the Presentation is initialized.
       syncSelectionCount();
       syncActiveSelectionScope();
 

--- a/packages/modules/viewer-react/src/tests/components/iModel/IModelLoader.test.tsx
+++ b/packages/modules/viewer-react/src/tests/components/iModel/IModelLoader.test.tsx
@@ -42,6 +42,21 @@ jest.mock("@itwin/appui-react", () => {
   };
 });
 jest.mock("@itwin/appui-abstract");
+jest.mock("@itwin/presentation-frontend", () => {
+  return {
+    ...jest.createMockFromModule<any>("@itwin/presentation-frontend"),
+    Presentation: {
+      ...jest.createMockFromModule<any>("@itwin/presentation-frontend")
+        .Presentation,
+      initialize: jest.fn().mockImplementation(() => Promise.resolve()),
+      selection: {
+        scopes: {
+          getSelectionScopes: jest.fn(),
+        },
+      },
+    },
+  };
+});
 jest.mock("@itwin/core-frontend", () => {
   return {
     IModelApp: {

--- a/packages/modules/viewer-react/src/tests/services/BaseInitializer.test.ts
+++ b/packages/modules/viewer-react/src/tests/services/BaseInitializer.test.ts
@@ -35,6 +35,13 @@ jest.mock("@itwin/appui-react", () => {
     },
     FrameworkAccuDraw:
       jest.createMockFromModule<any>("@itwin/appui-react").FrameworkAccuDraw,
+    SyncUiEventDispatcher: {
+      ...jest.createMockFromModule<any>("@itwin/appui-react")
+        .SyncUiEventDispatcher,
+      onSyncUiEvent: {
+        addListener: jest.fn(),
+      },
+    },
   };
 });
 
@@ -45,6 +52,12 @@ jest.mock("@itwin/presentation-frontend", () => {
       ...jest.createMockFromModule<any>("@itwin/presentation-frontend")
         .Presentation,
       initialize: jest.fn().mockImplementation(() => Promise.resolve()),
+      selection: {
+        selectionChange : {
+          addListener: jest.fn()
+        },
+        scopes: {},
+      },
     },
   };
 });


### PR DESCRIPTION
- The selection count in the status bar counting all the elements an assembly is composed of instead of treating the assembly as a single entity when the selection scope is assembly / top assembly
- The underlying cause of this issue is that AppUi 4.x severed its dependencies on Presentation and instead of syncing from the Presentation.selection.selectionChanged. Does not syncs with the iModel.selectionSet.onChanged which won't consider the selection scope when counting the selection
- Solution proposed in the AppUI issue https://github.com/iTwin/appui/pull/323 was to split off a version of that element selection count status bar component that doesn't force it to be synced with the redux store.
- The change in this PR includes a workaround that overrides the redux store state for the selected element count by adding a listener to the iModelConnection.selectionSet.onChanged from the handler of the Presentation.selection.onChanged event to sync it back with that one
- Long term presentation would expose a hook or hoc to wrap that field with to have it easily sync with their selection change event

Reference: https://dev.azure.com/bentleycs/beconnect/_git/TCDEAppService/pullrequest/338295
- Added syncing active selection scope when first called since when initialized, the Presentation active scope is undefined.