### PR TITLE
Fix blank connection reporting "IModel is not open for rpc" error

### DIFF
--- a/common/changes/@itwin/viewer-react/FixBlankConnectionSyncSelectionScope_2023-09-21-23-07.json
+++ b/common/changes/@itwin/viewer-react/FixBlankConnectionSyncSelectionScope_2023-09-21-23-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/viewer-react",
+      "comment": "Fix sync selection scope error when the iModelConnection is blank",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/viewer-react"
+}

--- a/packages/modules/viewer-react/src/components/iModel/IModelLoader.tsx
+++ b/packages/modules/viewer-react/src/components/iModel/IModelLoader.tsx
@@ -74,25 +74,28 @@ const IModelLoader = React.memo((viewerProps: ModelLoaderProps) => {
   useTheme(theme);
 
   // This preserves how the list of selection scopes was synced between Presentation and AppUi before its removal in 4.x
-  const syncSelectionScopeList = async (iModelConnection: IModelConnection) => {
-    if (iModelConnection.isBlankConnection() || !iModelConnection.isOpen) {
-      return;
-    }
+  const syncSelectionScopeList = useCallback(
+    async (iModelConnection: IModelConnection) => {
+      if (iModelConnection.isBlankConnection() || !iModelConnection.isOpen) {
+        return;
+      }
 
-    // Fetch the available selection scopes and add them to the redux store
-    try {
-      const availableScopes =
-        await Presentation.selection.scopes.getSelectionScopes(
-          iModelConnection
+      // Fetch the available selection scopes and add them to the redux store
+      try {
+        const availableScopes =
+          await Presentation.selection.scopes.getSelectionScopes(
+            iModelConnection
+          );
+        UiFramework.dispatchActionToStore(
+          SessionStateActionId.SetAvailableSelectionScopes,
+          availableScopes
         );
-      UiFramework.dispatchActionToStore(
-        SessionStateActionId.SetAvailableSelectionScopes,
-        availableScopes
-      );
-    } catch {
-      console.log("Error syncing selection scope list.");
-    }
-  };
+      } catch {
+        console.log("Error syncing selection scope list.");
+      }
+    },
+    []
+  );
 
   const getModelConnection = useCallback(async (): Promise<
     IModelConnection | undefined

--- a/packages/modules/viewer-react/src/components/iModel/IModelLoader.tsx
+++ b/packages/modules/viewer-react/src/components/iModel/IModelLoader.tsx
@@ -33,26 +33,7 @@ import {
 import { ViewerPerformance } from "../../services/telemetry";
 import type { ModelLoaderProps } from "../../types";
 import { BackstageItemsProvider } from "../app-ui/providers";
-import { IModelViewer } from "./";
-
-// This preserves how the list of selection scopes was synced between Presentation and AppUi before its removal in 4.x
-const syncSelectionScopeList = async (iModelConnection: IModelConnection) => {
-  if (iModelConnection.isBlankConnection() || !iModelConnection.isOpen) {
-    return;
-  }
-
-  // Fetch the available selection scopes and add them to the redux store
-  try {
-    const availableScopes =
-      await Presentation.selection.scopes.getSelectionScopes(iModelConnection);
-    UiFramework.dispatchActionToStore(
-      SessionStateActionId.SetAvailableSelectionScopes,
-      availableScopes
-    );
-  } catch {
-    console.log("Error syncing selection scope list.");
-  }
-};
+import { IModelViewer } from "./IModelViewer";
 
 const IModelLoader = React.memo((viewerProps: ModelLoaderProps) => {
   const [error, setError] = useState<Error>();
@@ -91,6 +72,27 @@ const IModelLoader = React.memo((viewerProps: ModelLoaderProps) => {
     });
 
   useTheme(theme);
+
+  // This preserves how the list of selection scopes was synced between Presentation and AppUi before its removal in 4.x
+  const syncSelectionScopeList = async (iModelConnection: IModelConnection) => {
+    if (iModelConnection.isBlankConnection() || !iModelConnection.isOpen) {
+      return;
+    }
+
+    // Fetch the available selection scopes and add them to the redux store
+    try {
+      const availableScopes =
+        await Presentation.selection.scopes.getSelectionScopes(
+          iModelConnection
+        );
+      UiFramework.dispatchActionToStore(
+        SessionStateActionId.SetAvailableSelectionScopes,
+        availableScopes
+      );
+    } catch {
+      console.log("Error syncing selection scope list.");
+    }
+  };
 
   const getModelConnection = useCallback(async (): Promise<
     IModelConnection | undefined

--- a/packages/modules/viewer-react/src/components/iModel/IModelLoader.tsx
+++ b/packages/modules/viewer-react/src/components/iModel/IModelLoader.tsx
@@ -6,10 +6,16 @@
 import "@bentley/icons-generic-webfont/dist/bentley-icons-generic-webfont.css";
 import "./IModelLoader.scss";
 
-import { SessionStateActionId, StateManager, UiFramework, UiItemsProvider } from "@itwin/appui-react";
+import type { UiItemsProvider } from "@itwin/appui-react";
+import {
+  SessionStateActionId,
+  StateManager,
+  UiFramework,
+} from "@itwin/appui-react";
 import type { IModelConnection } from "@itwin/core-frontend";
 import { IModelApp } from "@itwin/core-frontend";
 import { SvgIModelLoader } from "@itwin/itwinui-illustrations-react";
+import { Presentation } from "@itwin/presentation-frontend";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Provider } from "react-redux";
 
@@ -26,21 +32,28 @@ import {
 } from "../../services/iModel";
 import { ViewerPerformance } from "../../services/telemetry";
 import type { ModelLoaderProps } from "../../types";
-import { IModelViewer } from "./";
 import { BackstageItemsProvider } from "../app-ui/providers";
-import { Presentation } from "@itwin/presentation-frontend";
+import { IModelViewer } from "./";
 
 // This preserves how the list of selection scopes was synced between Presentation and AppUi before its removal in 4.x
-const syncSelectionScopeList = async (iModel: IModelConnection) => {
+const syncSelectionScopeList = async (iModelConnection: IModelConnection) => {
+  if (iModelConnection.isBlankConnection() || !iModelConnection.isOpen) {
+    return;
+  }
+
   // Fetch the available selection scopes and add them to the redux store
-  const availableScopes =
-    await Presentation.selection.scopes.getSelectionScopes(iModel);
-  UiFramework.dispatchActionToStore(
-    SessionStateActionId.SetAvailableSelectionScopes,
-    availableScopes
-  );
+  try {
+    const availableScopes =
+      await Presentation.selection.scopes.getSelectionScopes(iModelConnection);
+    UiFramework.dispatchActionToStore(
+      SessionStateActionId.SetAvailableSelectionScopes,
+      availableScopes
+    );
+  } catch {
+    console.log("Error syncing selection scope list.");
+  }
 };
-  
+
 const IModelLoader = React.memo((viewerProps: ModelLoaderProps) => {
   const [error, setError] = useState<Error>();
   const [connection, setConnection] = useState<IModelConnection>();
@@ -54,7 +67,7 @@ const IModelLoader = React.memo((viewerProps: ModelLoaderProps) => {
     uiProviders,
     theme,
     onIModelConnected,
-    backstageItems,
+    backstageItems, // eslint-disable-line deprecation/deprecation
     loadingComponent,
   } = viewerProps;
 
@@ -64,7 +77,7 @@ const IModelLoader = React.memo((viewerProps: ModelLoaderProps) => {
       providers.push(new BackstageItemsProvider(backstageItems));
     }
     return providers;
-  }, [uiProviders, backstageItems])
+  }, [uiProviders, backstageItems]);
 
   useUiProviders(providers);
 
@@ -119,8 +132,7 @@ const IModelLoader = React.memo((viewerProps: ModelLoaderProps) => {
       }
       setConnection(imodelConnection);
 
-      // Syncs selection scope list between AppUi and Presentation after connecting to iModel
-      syncSelectionScopeList(imodelConnection);
+      await syncSelectionScopeList(imodelConnection);
 
       return imodelConnection;
     }


### PR DESCRIPTION
- This bug was due to a missing check for BlankConnection when syncing the selection scope list. I have added the check for BlankConnection based on how it was implemented in AppUI 3.7x before the removal.

Reference: https://github.com/iTwin/itwinjs-core/blob/25f60b69e1fbde6ef10142c2dd8c3953d10c220a/ui/appui-react/src/appui-react/syncui/SyncUiEventDispatcher.ts#L250