### PR TITLE
Add ability to initialize Presentation with custom props

### DIFF
--- a/common/changes/@itwin/viewer-react/presentation_props_2024-05-23-14-16.json
+++ b/common/changes/@itwin/viewer-react/presentation_props_2024-05-23-14-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/viewer-react",
+      "comment": "Added ability to supply custom Presentation initialization props",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@itwin/viewer-react"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -3180,8 +3180,8 @@ packages:
       '@itwin/core-backend': 4.4.4
     dependencies:
       '@itwin/core-backend': 4.4.4_2dp5pljvu7qh5645hmdq3a7gp4
-      express: 4.18.3
-      express-ws: 5.0.2_express@4.18.3
+      express: 4.19.2
+      express-ws: 5.0.2_express@4.19.2
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -4309,7 +4309,7 @@ packages:
       '@types/base64-js': 1.3.2
       '@types/jquery': 3.5.29
       base64-js: 1.5.1
-      follow-redirects: 1.15.5
+      follow-redirects: 1.15.6
       form-data: 4.0.0
       opener: 1.5.2
     transitivePeerDependencies:
@@ -4565,7 +4565,7 @@ packages:
   /@surma/rollup-plugin-off-main-thread/2.2.3:
     resolution: {integrity: sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==}
     dependencies:
-      ejs: 3.1.9
+      ejs: 3.1.10
       json5: 2.2.3
       magic-string: 0.25.9
       string.prototype.matchall: 4.0.10
@@ -6174,7 +6174,7 @@ packages:
   /axios/1.6.7:
     resolution: {integrity: sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==}
     dependencies:
-      follow-redirects: 1.15.5
+      follow-redirects: 1.15.6
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -7114,8 +7114,8 @@ packages:
   /cookie-signature/1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
 
-  /cookie/0.5.0:
-    resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
+  /cookie/0.6.0:
+    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
 
   /copy-descriptor/0.1.1:
@@ -8000,8 +8000,8 @@ packages:
   /ee-first/1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  /ejs/3.1.9:
-    resolution: {integrity: sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==}
+  /ejs/3.1.10:
+    resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
     hasBin: true
     dependencies:
@@ -9207,21 +9207,21 @@ packages:
       jest-util: 29.7.0
     dev: true
 
-  /express-ws/5.0.2_express@4.18.3:
+  /express-ws/5.0.2_express@4.19.2:
     resolution: {integrity: sha512-0uvmuk61O9HXgLhGl3QhNSEtRsQevtmbL94/eILaliEADZBHZOQUAiHFrGPrgsjikohyrmSG5g+sCfASTt0lkQ==}
     engines: {node: '>=4.5.0'}
     peerDependencies:
       express: ^4.0.0 || ^5.0.0-alpha.1
     dependencies:
-      express: 4.18.3
+      express: 4.19.2
       ws: 7.5.9
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
     dev: false
 
-  /express/4.18.3:
-    resolution: {integrity: sha512-6VyCijWQ+9O7WuVMTRBTl+cjNNIzD5cY5mQ1WM8r/LEkI2u8EYpOotESNwzNlyCn3g+dmjKYI6BmNneSr/FSRw==}
+  /express/4.19.2:
+    resolution: {integrity: sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==}
     engines: {node: '>= 0.10.0'}
     dependencies:
       accepts: 1.3.8
@@ -9229,7 +9229,7 @@ packages:
       body-parser: 1.20.2
       content-disposition: 0.5.4
       content-type: 1.0.5
-      cookie: 0.5.0
+      cookie: 0.6.0
       cookie-signature: 1.0.6
       debug: 2.6.9
       depd: 2.0.0
@@ -9511,8 +9511,8 @@ packages:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
     dev: true
 
-  /follow-redirects/1.15.5:
-    resolution: {integrity: sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==}
+  /follow-redirects/1.15.6:
+    resolution: {integrity: sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -9830,7 +9830,7 @@ packages:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 5.0.1
+      minimatch: 5.1.6
       once: 1.4.0
     dev: true
 
@@ -10277,7 +10277,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.5
+      follow-redirects: 1.15.6
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -17417,8 +17417,8 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /webpack-dev-middleware/5.3.3_webpack@5.90.3:
-    resolution: {integrity: sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==}
+  /webpack-dev-middleware/5.3.4_webpack@5.90.3:
+    resolution: {integrity: sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
       webpack: ^4.0.0 || ^5.0.0
@@ -17458,7 +17458,7 @@ packages:
       compression: 1.7.4
       connect-history-api-fallback: 2.0.0
       default-gateway: 6.0.3
-      express: 4.18.3
+      express: 4.19.2
       graceful-fs: 4.2.11
       html-entities: 2.5.2
       http-proxy-middleware: 2.0.6_@types+express@4.17.21
@@ -17473,7 +17473,7 @@ packages:
       sockjs: 0.3.24
       spdy: 4.0.2
       webpack: 5.90.3
-      webpack-dev-middleware: 5.3.3_webpack@5.90.3
+      webpack-dev-middleware: 5.3.4_webpack@5.90.3
       ws: 8.16.0
     transitivePeerDependencies:
       - bufferutil

--- a/packages/modules/viewer-react/src/services/BaseInitializer.ts
+++ b/packages/modules/viewer-react/src/services/BaseInitializer.ts
@@ -191,11 +191,7 @@ export class BaseInitializer {
       yield UiFramework.initialize(undefined);
 
       // initialize Presentation
-      yield Presentation.initialize({
-        presentation: {
-          activeLocale: IModelApp.localization.getLanguageList()[0],
-        },
-      });
+      yield Presentation.initialize(viewerOptions?.presentationProps);
 
       // Sync selection count & active selection scope between Presentation and AppUi. Runs after the Presentation is initialized.
       syncSelectionCount();

--- a/packages/modules/viewer-react/src/types.ts
+++ b/packages/modules/viewer-react/src/types.ts
@@ -32,6 +32,7 @@ import type {
   XAndY,
   XYAndZ,
 } from "@itwin/core-geometry";
+import { PresentationProps } from "@itwin/presentation-frontend";
 
 export type Without<T1, T2> = { [P in Exclude<keyof T1, keyof T2>]?: never };
 export type XOR<T1, T2> = T1 | T2 extends Record<string, unknown>
@@ -137,6 +138,8 @@ export interface ViewerInitializerParams extends ViewerIModelAppOptions {
   additionalI18nNamespaces?: string[];
   /** array of iTwin.js Extensions */
   extensions?: ExtensionProvider[];
+  /** Props for presentation initialization */
+  presentationProps?: PresentationProps
 }
 export type RequiredViewerProps = XOR<
   XOR<ConnectedViewerProps, FileViewerProps>,
@@ -192,6 +195,7 @@ const iTwinViewerInitializerParamSample: OptionalToUndefinedUnion<ViewerInitiali
     additionalI18nNamespaces: undefined,
     extensions: undefined,
     userPreferences: undefined,
+    presentationProps: undefined,
   };
 
 export const iTwinViewerInitializerParamList = Object.keys(


### PR DESCRIPTION
Added ability to supply custom props to use during Presentation initialization. This is need to allow supplying new unified selection storage to be used by presentation-frontend.

Remove code setting active locale as it is done by default when initializing Presentation: https://github.com/iTwin/itwinjs-core/blob/73187a864fe12a1ca44d38f799bc9a2d79dfa40a/presentation/frontend/src/presentation-frontend/Presentation.ts#L74