### PR TITLE
Fix viewport context loss by changing event listener

### DIFF
--- a/common/changes/@itwin/web-viewer-react/nam-address-href-bug_2024-05-29-15-38.json
+++ b/common/changes/@itwin/web-viewer-react/nam-address-href-bug_2024-05-29-15-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/web-viewer-react",
+      "comment": "Address viewport context loss when location.href is modified",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/web-viewer-react"
+}

--- a/packages/modules/web-viewer-react/src/components/Viewer.tsx
+++ b/packages/modules/web-viewer-react/src/components/Viewer.tsx
@@ -20,9 +20,9 @@ export const Viewer = (props: WebViewerProps) => {
         .then(() => console.log("Shutdown success."))
         .catch(() => console.warn("Shutdown failed."));
     };
-    window.addEventListener("beforeunload", handleBeforeUnload);
+    window.addEventListener("unload", handleBeforeUnload);
     return () => {
-      window.removeEventListener("beforeunload", handleBeforeUnload);
+      window.removeEventListener("unload", handleBeforeUnload);
     };
   }, []);
   return initialized ? <BaseViewer {...props} /> : null;


### PR DESCRIPTION
When the window.location.href of the viewer tab is modified, but the link is not a valid one, we still see the viewport context disappear, because IModelApp.shutdown() is called `beforeunload` (i.e regardless of whether a user is redirected, or a tab is closed, or not). Changed the event listener to be a `unload` event, but this is not intended to be the long-term solution, because it is [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/Window/unload_event#usage_notes)

I explored using the `visibilitychanged` event, but the problem with that is IModelApp will be shutdown when a user switches to a different tab.  Checking the `window.visiblityState` and whether it is `visible` or `hidden` is the way to do it, but browsers aren't able to differentiate whether a `hidden` visibilityState is from the browser closing/refreshing a tab or because it is switched. So in conclusion, there is no good solution right now...