### PR TITLE
Allow versions range (v4 and v5) for peerDependency @itwin/presentation-components

### DIFF
--- a/common/changes/@itwin/viewer-react/version-add_presentation_components_v5_as_supported_version_2024-08-08-17-18.json
+++ b/common/changes/@itwin/viewer-react/version-add_presentation_components_v5_as_supported_version_2024-08-08-17-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/viewer-react",
+      "comment": "Modifty accepted version for the peerDependency @itwin/presentation-components to allow version ^5.0.0 (^4.0.0 || ^5.0.0)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/viewer-react"
+}

--- a/common/changes/@itwin/viewer-react/version-add_presentation_components_v5_as_supported_version_2024-08-12-11-35.json
+++ b/common/changes/@itwin/viewer-react/version-add_presentation_components_v5_as_supported_version_2024-08-12-11-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/viewer-react",
+      "comment": "Bump @itwin/presentation-components from v4 to v5",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/viewer-react"
+}

--- a/common/changes/@itwin/viewer-react/version-add_presentation_components_v5_as_supported_version_2024-08-12-14-15.json
+++ b/common/changes/@itwin/viewer-react/version-add_presentation_components_v5_as_supported_version_2024-08-12-14-15.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/viewer-react",
-      "comment": "Update lock file",
+      "comment": "",
       "type": "patch"
     }
   ],

--- a/common/changes/@itwin/viewer-react/version-add_presentation_components_v5_as_supported_version_2024-08-12-14-15.json
+++ b/common/changes/@itwin/viewer-react/version-add_presentation_components_v5_as_supported_version_2024-08-12-14-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/viewer-react",
+      "comment": "Update lock file",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/viewer-react"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -439,7 +439,7 @@ importers:
       '@itwin/itwinui-illustrations-react': ^2.0.1
       '@itwin/itwinui-react': ^2.6.0
       '@itwin/presentation-common': ^4.7.3
-      '@itwin/presentation-components': ^4.0.0
+      '@itwin/presentation-components': ^5.0.0
       '@itwin/presentation-core-interop': ^0.2.3
       '@itwin/presentation-frontend': ^4.7.3
       '@itwin/presentation-shared': ^0.3.1
@@ -498,7 +498,7 @@ importers:
       '@itwin/imodels-access-frontend': 4.1.6_r7pomf6q3izykcd6xffknqbpim
       '@itwin/imodels-client-management': 4.4.0
       '@itwin/presentation-common': 4.7.4_jrcxtioaccikuahb3i3h6f5rhe
-      '@itwin/presentation-components': 4.4.1_z7scz3m5oksdxocfhbmamchwvy
+      '@itwin/presentation-components': 5.4.1_coeiqitrdc3kbyoxwt3ak4fycm
       '@itwin/presentation-frontend': 4.7.4_lbci6e5ivpkspr33wpe53pcp5i
       '@itwin/webgl-compatibility': 4.7.4
       '@testing-library/jest-dom': 4.2.4
@@ -3719,6 +3719,53 @@ packages:
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
+
+  /@itwin/presentation-components/5.4.1_coeiqitrdc3kbyoxwt3ak4fycm:
+    resolution: {integrity: sha512-o1ysqcbyVAWHyYTGVisFNfbix7GJdXp69c3QAeX/Xv2K0AS1ce2qYDEQCGwxwL1qIseIBbq9pZXADYjf9GH2bQ==}
+    peerDependencies:
+      '@itwin/appui-abstract': ^4.4.0
+      '@itwin/components-react': ^4.9.0
+      '@itwin/core-bentley': ^4.4.0
+      '@itwin/core-common': ^4.4.0
+      '@itwin/core-frontend': ^4.4.0
+      '@itwin/core-quantity': ^4.4.0
+      '@itwin/core-react': ^4.9.0
+      '@itwin/ecschema-metadata': ^4.4.0
+      '@itwin/imodel-components-react': ^4.9.0
+      '@itwin/itwinui-react': ^3.0.0
+      '@itwin/presentation-common': ^4.4.0
+      '@itwin/presentation-frontend': ^4.4.0
+      react: ^17.0.0 || ^18.0.0
+      react-dom: ^17.0.0 || ^18.0.0
+    dependencies:
+      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/components-react': 4.15.1_jscgs7su4cyo55wt5klvj3iepa
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
+      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/core-react': 4.15.1_bpptdsfauwdziiwg4uklizbr74
+      '@itwin/ecschema-metadata': 4.7.4_jokiwfzdpldlrb2ppvojwoxovq
+      '@itwin/imodel-components-react': 4.15.1_avm2jbcgpodgccdhk4zetypeem
+      '@itwin/itwinui-icons-react': 2.8.0_nnrd3gsncyragczmpvfhocinkq
+      '@itwin/itwinui-illustrations-react': 2.1.0_nnrd3gsncyragczmpvfhocinkq
+      '@itwin/itwinui-react': 2.12.26_nnrd3gsncyragczmpvfhocinkq
+      '@itwin/presentation-common': 4.7.4_jrcxtioaccikuahb3i3h6f5rhe
+      '@itwin/presentation-frontend': 4.7.4_lbci6e5ivpkspr33wpe53pcp5i
+      classnames: 2.5.1
+      fast-deep-equal: 3.1.3
+      fast-sort: 3.4.0
+      micro-memoize: 4.1.2
+      react: 18.3.1
+      react-dom: 18.3.1_react@18.3.1
+      react-error-boundary: 4.0.13_react@18.3.1
+      react-select: 5.7.0_psuonouaqi5wuc37nxyknoubym
+      react-select-async-paginate: 0.7.2_kipqsbdvtmv5eumhayztwa7ftm
+      rxjs: 7.8.1
+    transitivePeerDependencies:
+      - '@types/react'
+      - supports-color
+    dev: true
 
   /@itwin/presentation-core-interop/0.2.4_rll2n26bhzrezeyt23jhdcbtsy:
     resolution: {integrity: sha512-udofwj3KXjDIgW2FxJ/hblUNk/VQBZff/3eLjZUP3q2Jl6N116w0AqTP00aL/5p1RP2+E1yebP6gSno2iRS/EQ==}
@@ -14931,7 +14978,6 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.7
       react: 18.3.1
-    dev: false
 
   /react-error-boundary/4.0.3_react@18.3.1:
     resolution: {integrity: sha512-IzNKP/ViHWp2QRDgsDMirEcf0XLsLueN6Wgzm1TVwgbAH+paX8Z42VyKvZcFFRHgd+rPK2P4TLrOrHC/dommew==}

--- a/packages/modules/viewer-react/package.json
+++ b/packages/modules/viewer-react/package.json
@@ -59,7 +59,7 @@
     "@itwin/imodels-client-management": "^4.0.0",
     "@itwin/imodel-components-react": "^4.0.0",
     "@itwin/presentation-common": "^4.7.3",
-    "@itwin/presentation-components": "^4.0.0",
+    "@itwin/presentation-components": "^5.0.0",
     "@itwin/presentation-frontend": "^4.7.3",
     "@itwin/webgl-compatibility": "^4.7.3",
     "@testing-library/jest-dom": "^4.2.4",

--- a/packages/modules/viewer-react/package.json
+++ b/packages/modules/viewer-react/package.json
@@ -97,7 +97,7 @@
     "@itwin/imodels-access-frontend": "^4.0.0",
     "@itwin/imodels-client-management": "^4.0.0",
     "@itwin/presentation-common": "^4.0.0",
-    "@itwin/presentation-components": "^4.0.0",
+    "@itwin/presentation-components": "^4.0.0 || ^5.0.0",
     "@itwin/presentation-frontend": "^4.0.0",
     "react": "^17.0.2 || ^18.0.0",
     "react-dom": "^17.0.2 || ^18.0.0",


### PR DESCRIPTION
Modify the peerDependency for @itwin/presentation-components to allow a versions range (^4.0.0 || ^5.0.0) instead of one specific version.

From Arun: "We use presentation-components for 1 api, https://github.com/iTwin/viewer/blob/master/packages/modules/viewer-react/src/components/app-ui/providers/UnifiedSelectionViewportControl.tsx#L14, which doesn’t seem to have changed in 5.0.0, https://github.com/iTwin/presentation/blob/master/packages/components/CHANGELOG.md#500"
