### PR TITLE
Fix desktop cra dependencies

### DIFF
--- a/common/changes/@itwin/cra-template-desktop-viewer/fix-desktop-cra-dependencies_2024-09-03-13-23.json
+++ b/common/changes/@itwin/cra-template-desktop-viewer/fix-desktop-cra-dependencies_2024-09-03-13-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/cra-template-desktop-viewer",
+      "comment": "fix desktop-viewer-react dependency version",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/cra-template-desktop-viewer"
+}

--- a/packages/templates/cra-template-desktop-viewer/template.json
+++ b/packages/templates/cra-template-desktop-viewer/template.json
@@ -20,7 +20,7 @@
       "@itwin/core-quantity": "^4.7.3",
       "@itwin/core-react": "^4.3.0",
       "@itwin/core-telemetry": "^4.7.3",
-      "@itwin/desktop-viewer-react": "^4.7.3",
+      "@itwin/desktop-viewer-react": "^4.3.2",
       "@itwin/ecschema-metadata": "^4.7.3",
       "@itwin/ecschema-rpcinterface-common": "^4.7.3",
       "@itwin/ecschema-rpcinterface-impl": "^4.7.3",
@@ -77,8 +77,6 @@
       "start": "npm run build:backend && run-p \"start:frontend\" \"electron:debug\"",
       "start:frontend": "react-scripts start"
     },
-    "browserslist": [
-      "last 1 electron version"
-    ]
+    "browserslist": ["last 1 electron version"]
   }
 }


### PR DESCRIPTION
Fix bad dependency bump to `@itwin/desktop-viewer-react` added in #319