### PR TITLE
Fix desktop-viewer-react version in desktop template

### DIFF
--- a/common/changes/@itwin/cra-template-desktop-viewer/gytis-fix-desktop-template_2024-09-03-13-23.json
+++ b/common/changes/@itwin/cra-template-desktop-viewer/gytis-fix-desktop-template_2024-09-03-13-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/cra-template-desktop-viewer",
+      "comment": "Fix @itwin/desktop-viewer-react package version",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/cra-template-desktop-viewer"
+}

--- a/packages/templates/cra-template-desktop-viewer/template.json
+++ b/packages/templates/cra-template-desktop-viewer/template.json
@@ -20,7 +20,7 @@
       "@itwin/core-quantity": "^4.7.3",
       "@itwin/core-react": "^4.3.0",
       "@itwin/core-telemetry": "^4.7.3",
-      "@itwin/desktop-viewer-react": "^4.7.3",
+      "@itwin/desktop-viewer-react": "^4.3.2",
       "@itwin/ecschema-metadata": "^4.7.3",
       "@itwin/ecschema-rpcinterface-common": "^4.7.3",
       "@itwin/ecschema-rpcinterface-impl": "^4.7.3",


### PR DESCRIPTION
Trying to run desktop-viewer template currently results in error:

```
Installing template dependencies using npm...
npm ERR! code ETARGET
npm ERR! notarget No matching version found for @itwin/desktop-viewer-react@^4.7.3.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.
```