### PR TITLE
Updated .env files in CRA templates to have the `itwin-platform` scope

### DIFF
--- a/common/changes/@itwin/cra-template-desktop-viewer/mindaugas-update-default-template-scopes_2024-10-31-11-22.json
+++ b/common/changes/@itwin/cra-template-desktop-viewer/mindaugas-update-default-template-scopes_2024-10-31-11-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/cra-template-desktop-viewer",
+      "comment": "Updated .env file in CRA template to have the `itwin-platform` scope.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/cra-template-desktop-viewer"
+}

--- a/common/changes/@itwin/cra-template-web-viewer/mindaugas-update-default-template-scopes_2024-10-31-11-22.json
+++ b/common/changes/@itwin/cra-template-web-viewer/mindaugas-update-default-template-scopes_2024-10-31-11-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/cra-template-web-viewer",
+      "comment": "Updated .env file in CRA template to have the `itwin-platform` scope.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/cra-template-web-viewer"
+}

--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -6,6 +6,8 @@
       "braces": "^3.0.3",
       "path-to-regexp@>=0.2.0": "^8.0.0",
       "path-to-regexp@<0.1.10": "^0.1.10",
-      "postcss": "^8.4.31"
+      "postcss": "^8.4.31",
+      "http-proxy-middleware": "^2.0.7",
+      "rollup": "^2.79.2"
     }
   }

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -3,9 +3,11 @@ lockfileVersion: 5.4
 overrides:
   body-parser@<1.20.3: ^1.20.3
   braces: ^3.0.3
-  postcss: ^8.4.31
   path-to-regexp@>=0.2.0: ^8.0.0
   path-to-regexp@<0.1.10: ^0.1.10
+  postcss: ^8.4.31
+  http-proxy-middleware: ^2.0.7
+  rollup: ^2.79.2
 
 importers:
 
@@ -4647,7 +4649,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dev: false
 
-  /@rollup/plugin-babel/5.3.1_je4nbmfg47mhbnn75kmajdcj7i:
+  /@rollup/plugin-babel/5.3.1_w6kn3gmbfhpa2ap3fyykp2cmt4:
     resolution: {integrity: sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
@@ -4660,38 +4662,38 @@ packages:
     dependencies:
       '@babel/core': 7.24.7
       '@babel/helper-module-imports': 7.24.7
-      '@rollup/pluginutils': 3.1.0_rollup@2.79.1
-      rollup: 2.79.1
+      '@rollup/pluginutils': 3.1.0_rollup@2.79.2
+      rollup: 2.79.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@rollup/plugin-node-resolve/11.2.1_rollup@2.79.1:
+  /@rollup/plugin-node-resolve/11.2.1_rollup@2.79.2:
     resolution: {integrity: sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.79.1
+      '@rollup/pluginutils': 3.1.0_rollup@2.79.2
       '@types/resolve': 1.17.1
       builtin-modules: 3.3.0
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.8
-      rollup: 2.79.1
+      rollup: 2.79.2
     dev: true
 
-  /@rollup/plugin-replace/2.4.2_rollup@2.79.1:
+  /@rollup/plugin-replace/2.4.2_rollup@2.79.2:
     resolution: {integrity: sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==}
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.79.1
+      '@rollup/pluginutils': 3.1.0_rollup@2.79.2
       magic-string: 0.25.9
-      rollup: 2.79.1
+      rollup: 2.79.2
     dev: true
 
-  /@rollup/pluginutils/3.1.0_rollup@2.79.1:
+  /@rollup/pluginutils/3.1.0_rollup@2.79.2:
     resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
@@ -4700,7 +4702,7 @@ packages:
       '@types/estree': 0.0.39
       estree-walker: 1.0.1
       picomatch: 2.3.1
-      rollup: 2.79.1
+      rollup: 2.79.2
     dev: true
 
   /@rushstack/eslint-patch/1.10.3:
@@ -10516,8 +10518,8 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /http-proxy-middleware/2.0.6_@types+express@4.17.21:
-    resolution: {integrity: sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==}
+  /http-proxy-middleware/2.0.7_@types+express@4.17.21:
+    resolution: {integrity: sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@types/express': ^4.17.13
@@ -15586,7 +15588,7 @@ packages:
       rollup-plugin-inject: 3.0.2
     dev: true
 
-  /rollup-plugin-terser/7.0.2_rollup@2.79.1:
+  /rollup-plugin-terser/7.0.2_rollup@2.79.2:
     resolution: {integrity: sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==}
     deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-terser
     peerDependencies:
@@ -15594,7 +15596,7 @@ packages:
     dependencies:
       '@babel/code-frame': 7.24.7
       jest-worker: 26.6.2
-      rollup: 2.79.1
+      rollup: 2.79.2
       serialize-javascript: 4.0.0
       terser: 5.31.1
     dev: true
@@ -15605,8 +15607,8 @@ packages:
       estree-walker: 0.6.1
     dev: true
 
-  /rollup/2.79.1:
-    resolution: {integrity: sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==}
+  /rollup/2.79.2:
+    resolution: {integrity: sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==}
     engines: {node: '>=10.0.0'}
     hasBin: true
     optionalDependencies:
@@ -17709,7 +17711,7 @@ packages:
       express: 4.19.2
       graceful-fs: 4.2.11
       html-entities: 2.5.2
-      http-proxy-middleware: 2.0.6_@types+express@4.17.21
+      http-proxy-middleware: 2.0.7_@types+express@4.17.21
       ipaddr.js: 2.2.0
       launch-editor: 2.8.0
       open: 8.4.2
@@ -17978,9 +17980,9 @@ packages:
       '@babel/core': 7.24.7
       '@babel/preset-env': 7.24.7_@babel+core@7.24.7
       '@babel/runtime': 7.24.7
-      '@rollup/plugin-babel': 5.3.1_je4nbmfg47mhbnn75kmajdcj7i
-      '@rollup/plugin-node-resolve': 11.2.1_rollup@2.79.1
-      '@rollup/plugin-replace': 2.4.2_rollup@2.79.1
+      '@rollup/plugin-babel': 5.3.1_w6kn3gmbfhpa2ap3fyykp2cmt4
+      '@rollup/plugin-node-resolve': 11.2.1_rollup@2.79.2
+      '@rollup/plugin-replace': 2.4.2_rollup@2.79.2
       '@surma/rollup-plugin-off-main-thread': 2.2.3
       ajv: 8.16.0
       common-tags: 1.8.2
@@ -17989,8 +17991,8 @@ packages:
       glob: 7.2.3
       lodash: 4.17.21
       pretty-bytes: 5.6.0
-      rollup: 2.79.1
-      rollup-plugin-terser: 7.0.2_rollup@2.79.1
+      rollup: 2.79.2
+      rollup-plugin-terser: 7.0.2_rollup@2.79.2
       source-map: 0.8.0-beta.0
       stringify-object: 3.3.0
       strip-comments: 2.0.1

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -3,9 +3,9 @@ lockfileVersion: 5.4
 overrides:
   body-parser@<1.20.3: ^1.20.3
   braces: ^3.0.3
+  postcss: ^8.4.31
   path-to-regexp@>=0.2.0: ^8.0.0
   path-to-regexp@<0.1.10: ^0.1.10
-  postcss: ^8.4.31
 
 importers:
 
@@ -83,73 +83,73 @@ importers:
       webpack: ^5.1.2
     dependencies:
       '@bentley/icons-generic-webfont': 1.0.34
-      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/appui-layout-react': 4.8.3_zs6rif5h5jixp3mcoeld6e43pu
-      '@itwin/appui-react': 4.17.2_ggnmyqo32cg3w26befg4w43y64
-      '@itwin/components-react': 4.17.2_zs6rif5h5jixp3mcoeld6e43pu
-      '@itwin/core-backend': 4.9.5_r6lwpu3senlcflmx65u2gwowne
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
-      '@itwin/core-electron': 4.9.5_xnnzauzbsosxbhso2acbfdnloq
-      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
-      '@itwin/core-geometry': 4.9.5
-      '@itwin/core-i18n': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/core-markup': 4.9.5_rsqcs3hzbyxjzpttbshdocpt74
-      '@itwin/core-orbitgt': 4.9.5
-      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/core-react': 4.17.2_b5szh4swag42x6ykxwn6buimra
-      '@itwin/core-telemetry': 4.9.5_@itwin+core-geometry@4.9.5
+      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/appui-layout-react': 4.8.3_jscgs7su4cyo55wt5klvj3iepa
+      '@itwin/appui-react': 4.15.1_yrqai5hl5gvsf4dek6el5aloii
+      '@itwin/components-react': 4.15.1_jscgs7su4cyo55wt5klvj3iepa
+      '@itwin/core-backend': 4.7.4_zzr6hivuljmnvzdhcyobjpaqme
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/core-electron': 4.7.4_hworozxoblmw2cyo32mpk5ebjm
+      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
+      '@itwin/core-geometry': 4.7.4
+      '@itwin/core-i18n': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/core-markup': 4.7.4_aa3bt7vk4zzsxcvhcdi4ojlcwe
+      '@itwin/core-orbitgt': 4.7.4
+      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/core-react': 4.15.1_bpptdsfauwdziiwg4uklizbr74
+      '@itwin/core-telemetry': 4.7.4_@itwin+core-geometry@4.7.4
       '@itwin/desktop-viewer-react': link:../../modules/desktop-viewer-react
-      '@itwin/ecschema-metadata': 4.9.5_ht7pcu4cvk5h6sxcpkl7x76mje
-      '@itwin/ecschema-rpcinterface-common': 4.9.5_ubcdmbjl4iri5lyyvzc2dtfxiq
-      '@itwin/ecschema-rpcinterface-impl': 4.9.5_wkhnl5tbdp3ufasrx26orysshe
-      '@itwin/electron-authorization': 0.15.0_a56cjor36hmzwips5mhrqrpbva
-      '@itwin/express-server': 4.9.5_ghqkdihqtcgmxbakiynn72u3oi
+      '@itwin/ecschema-metadata': 4.7.4_jokiwfzdpldlrb2ppvojwoxovq
+      '@itwin/ecschema-rpcinterface-common': 4.7.4_bcf6l4a62o6ayq645yaljtfq2i
+      '@itwin/ecschema-rpcinterface-impl': 4.7.4_5hmlesdtddppohhn2hwm7h44ha
+      '@itwin/electron-authorization': 0.15.0_4vf3fjdy4loqcqolj5aeocucyi
+      '@itwin/express-server': 4.7.4_7f6lob4dy5xhizoy2hu6gtyoy4
       '@itwin/imodel-browser-react': 1.3.1_nnrd3gsncyragczmpvfhocinkq
-      '@itwin/imodel-components-react': 4.17.2_inn3jcow7lwqfeofdqhb3etkfi
-      '@itwin/imodels-access-backend': 5.2.3_3pcl427xpsrwbipdq34svx7mdu
-      '@itwin/imodels-access-frontend': 5.2.3_x7r3qyjan52efy6jnvzj72woaa
+      '@itwin/imodel-components-react': 4.15.1_avm2jbcgpodgccdhk4zetypeem
+      '@itwin/imodels-access-backend': 5.2.1_4z423c7twni3c7p4vwjttw7w4q
+      '@itwin/imodels-access-frontend': 5.2.1_r7pomf6q3izykcd6xffknqbpim
       '@itwin/itwinui-css': 1.12.10
-      '@itwin/itwinui-icons-react': 2.9.0_nnrd3gsncyragczmpvfhocinkq
+      '@itwin/itwinui-icons-react': 2.8.0_nnrd3gsncyragczmpvfhocinkq
       '@itwin/itwinui-illustrations-react': 2.1.0_nnrd3gsncyragczmpvfhocinkq
       '@itwin/itwinui-layouts-css': 0.2.0
       '@itwin/itwinui-layouts-react': 0.2.0_nnrd3gsncyragczmpvfhocinkq
       '@itwin/itwinui-react': 2.12.26_nnrd3gsncyragczmpvfhocinkq
       '@itwin/itwinui-variables': 2.1.2
-      '@itwin/measure-tools-react': 0.13.0_i7qwmeovtjabsqcqehc6iw7vpa
-      '@itwin/presentation-backend': 4.9.5_6poatpavnnrtfvnacw25xntdke
-      '@itwin/presentation-common': 4.9.5_752sgixgtdkx2uobp37xqv5rci
-      '@itwin/presentation-components': 5.6.0_pgm6v4yzke2vvcj2rwx47ufaoy
-      '@itwin/presentation-frontend': 4.9.5_cfzxbnb6dite7ncbt3vw277mvu
-      '@itwin/property-grid-react': 1.13.0_ogdchnjgcc3nlmep57rhegv4nu
-      '@itwin/tree-widget-react': 1.2.2_wdle7gtptdoktkpvzniwyk6jjq
-      '@itwin/unified-selection': 0.4.6
-      '@itwin/webgl-compatibility': 4.9.5
+      '@itwin/measure-tools-react': 0.13.0_hhvtoxm2vupiyzv3tuuiwwirjq
+      '@itwin/presentation-backend': 4.7.4_nztxufmverfbgaq2tic42bdzqu
+      '@itwin/presentation-common': 4.7.4_jrcxtioaccikuahb3i3h6f5rhe
+      '@itwin/presentation-components': 5.4.1_coeiqitrdc3kbyoxwt3ak4fycm
+      '@itwin/presentation-frontend': 4.7.4_lbci6e5ivpkspr33wpe53pcp5i
+      '@itwin/property-grid-react': 1.10.0_qjr4doayn7cutuokumbiwhomja
+      '@itwin/tree-widget-react': 1.2.2_mwt5u2ylvl5wdlvny262vrwmma
+      '@itwin/unified-selection': 0.4.5
+      '@itwin/webgl-compatibility': 4.7.4
       dotenv-flow: 3.3.0
       electron: 24.8.8
       minimist: 1.2.8
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
       react-redux: 7.2.9_nnrd3gsncyragczmpvfhocinkq
-      react-router: 6.27.0_react@18.3.1
-      react-router-dom: 6.27.0_nnrd3gsncyragczmpvfhocinkq
+      react-router: 6.24.1_react@18.3.1
+      react-router-dom: 6.24.1_nnrd3gsncyragczmpvfhocinkq
       redux: 4.2.1
     devDependencies:
       '@bentley/react-scripts': 5.0.7_pe74uhjrq4tiyv4442ml54dfiu
-      '@itwin/build-tools': 4.9.5_@types+node@18.19.62
+      '@itwin/build-tools': 4.7.4_@types+node@18.19.39
       '@types/electron-devtools-installer': 2.2.5
       '@types/minimist': 1.2.5
-      '@types/node': 18.19.62
-      '@types/react': 18.3.12
-      '@types/react-dom': 18.3.1
+      '@types/node': 18.19.39
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
       cpx2: 4.2.0
       cross-env: 5.2.1
       electron-devtools-installer: 2.2.4
       npm-run-all: 4.1.5
       rimraf: 3.0.2
-      sass: 1.80.5
+      sass: 1.77.7
       typescript: 5.0.4
-      webpack: 5.95.0
+      webpack: 5.92.1
 
   ../../packages/apps/web-viewer-test:
     specifiers:
@@ -201,51 +201,51 @@ importers:
       typescript: ~5.0.4
     dependencies:
       '@bentley/icons-generic': 1.0.34
-      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/appui-layout-react': 4.8.3_zs6rif5h5jixp3mcoeld6e43pu
-      '@itwin/appui-react': 4.17.2_ggnmyqo32cg3w26befg4w43y64
-      '@itwin/browser-authorization': 1.1.3_uihgl3rfhguqy2f4jpx67fyjwm
-      '@itwin/components-react': 4.17.2_zs6rif5h5jixp3mcoeld6e43pu
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
-      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
-      '@itwin/core-geometry': 4.9.5
-      '@itwin/core-i18n': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/core-markup': 4.9.5_rsqcs3hzbyxjzpttbshdocpt74
-      '@itwin/core-orbitgt': 4.9.5
-      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/core-react': 4.17.2_b5szh4swag42x6ykxwn6buimra
-      '@itwin/core-telemetry': 4.9.5_@itwin+core-geometry@4.9.5
-      '@itwin/ecschema-metadata': 4.9.5_ht7pcu4cvk5h6sxcpkl7x76mje
-      '@itwin/ecschema-rpcinterface-common': 4.9.5_ubcdmbjl4iri5lyyvzc2dtfxiq
-      '@itwin/frontend-devtools': 4.9.5_orynrjj7mkimir6kjmara2i7dq
-      '@itwin/imodel-components-react': 4.17.2_inn3jcow7lwqfeofdqhb3etkfi
-      '@itwin/imodels-access-frontend': 5.2.3_x7r3qyjan52efy6jnvzj72woaa
+      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/appui-layout-react': 4.8.3_jscgs7su4cyo55wt5klvj3iepa
+      '@itwin/appui-react': 4.15.1_yrqai5hl5gvsf4dek6el5aloii
+      '@itwin/browser-authorization': 1.1.2_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/components-react': 4.15.1_jscgs7su4cyo55wt5klvj3iepa
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
+      '@itwin/core-geometry': 4.7.4
+      '@itwin/core-i18n': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/core-markup': 4.7.4_aa3bt7vk4zzsxcvhcdi4ojlcwe
+      '@itwin/core-orbitgt': 4.7.4
+      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/core-react': 4.15.1_bpptdsfauwdziiwg4uklizbr74
+      '@itwin/core-telemetry': 4.7.4_@itwin+core-geometry@4.7.4
+      '@itwin/ecschema-metadata': 4.7.4_jokiwfzdpldlrb2ppvojwoxovq
+      '@itwin/ecschema-rpcinterface-common': 4.7.4_bcf6l4a62o6ayq645yaljtfq2i
+      '@itwin/frontend-devtools': 4.7.4_7jxo73lwmrfxldbvkntwilqkhe
+      '@itwin/imodel-components-react': 4.15.1_avm2jbcgpodgccdhk4zetypeem
+      '@itwin/imodels-access-frontend': 5.2.1_r7pomf6q3izykcd6xffknqbpim
       '@itwin/itwinui-react': 2.12.26_nnrd3gsncyragczmpvfhocinkq
-      '@itwin/measure-tools-react': 0.13.0_i7qwmeovtjabsqcqehc6iw7vpa
-      '@itwin/presentation-common': 4.9.5_752sgixgtdkx2uobp37xqv5rci
-      '@itwin/presentation-components': 5.6.0_pgm6v4yzke2vvcj2rwx47ufaoy
-      '@itwin/presentation-frontend': 4.9.5_cfzxbnb6dite7ncbt3vw277mvu
-      '@itwin/property-grid-react': 1.13.0_ogdchnjgcc3nlmep57rhegv4nu
-      '@itwin/reality-data-client': 1.2.1_@itwin+core-bentley@4.9.5
+      '@itwin/measure-tools-react': 0.13.0_hhvtoxm2vupiyzv3tuuiwwirjq
+      '@itwin/presentation-common': 4.7.4_jrcxtioaccikuahb3i3h6f5rhe
+      '@itwin/presentation-components': 5.4.1_coeiqitrdc3kbyoxwt3ak4fycm
+      '@itwin/presentation-frontend': 4.7.4_lbci6e5ivpkspr33wpe53pcp5i
+      '@itwin/property-grid-react': 1.10.0_qjr4doayn7cutuokumbiwhomja
+      '@itwin/reality-data-client': 1.2.1_@itwin+core-bentley@4.7.4
       '@itwin/test-local-extension': link:../../modules/test-local-extension
-      '@itwin/tree-widget-react': 1.2.2_wdle7gtptdoktkpvzniwyk6jjq
-      '@itwin/unified-selection': 0.4.6
+      '@itwin/tree-widget-react': 1.2.2_mwt5u2ylvl5wdlvny262vrwmma
+      '@itwin/unified-selection': 0.4.5
       '@itwin/web-viewer-react': link:../../modules/web-viewer-react
-      '@itwin/webgl-compatibility': 4.9.5
-      '@remix-run/router': 1.20.0
+      '@itwin/webgl-compatibility': 4.7.4
+      '@remix-run/router': 1.17.1
       history: 5.3.0
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
       react-redux: 7.2.9_nnrd3gsncyragczmpvfhocinkq
-      react-router: 6.27.0_react@18.3.1
-      react-router-dom: 6.27.0_nnrd3gsncyragczmpvfhocinkq
+      react-router: 6.24.1_react@18.3.1
+      react-router-dom: 6.24.1_nnrd3gsncyragczmpvfhocinkq
       redux: 4.2.1
     devDependencies:
       '@bentley/react-scripts': 5.0.7_pe74uhjrq4tiyv4442ml54dfiu
-      '@types/node': 18.19.62
-      '@types/react': 18.3.12
-      '@types/react-dom': 18.3.1
+      '@types/node': 18.19.39
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
       typescript: 5.0.4
 
   ../../packages/modules/desktop-viewer-react:
@@ -296,51 +296,51 @@ importers:
       ts-jest: ^29.1.0
       typescript: ~5.0.2
     dependencies:
-      '@itwin/imodels-client-management': 5.9.0
+      '@itwin/imodels-client-management': 5.8.1
       '@itwin/viewer-react': link:../viewer-react
     devDependencies:
-      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/appui-layout-react': 4.8.3_zs6rif5h5jixp3mcoeld6e43pu
-      '@itwin/appui-react': 4.17.2_ggnmyqo32cg3w26befg4w43y64
-      '@itwin/build-tools': 4.9.5_@types+node@18.19.62
-      '@itwin/components-react': 4.17.2_zs6rif5h5jixp3mcoeld6e43pu
-      '@itwin/core-backend': 4.9.5_r6lwpu3senlcflmx65u2gwowne
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
-      '@itwin/core-electron': 4.9.5_xnnzauzbsosxbhso2acbfdnloq
-      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
-      '@itwin/core-geometry': 4.9.5
-      '@itwin/core-markup': 4.9.5_rsqcs3hzbyxjzpttbshdocpt74
-      '@itwin/core-orbitgt': 4.9.5
-      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/core-react': 4.17.2_b5szh4swag42x6ykxwn6buimra
-      '@itwin/core-telemetry': 4.9.5_@itwin+core-geometry@4.9.5
-      '@itwin/ecschema-metadata': 4.9.5_ht7pcu4cvk5h6sxcpkl7x76mje
-      '@itwin/electron-authorization': 0.15.0_a56cjor36hmzwips5mhrqrpbva
-      '@itwin/imodel-components-react': 4.17.2_inn3jcow7lwqfeofdqhb3etkfi
-      '@itwin/presentation-common': 4.9.5_752sgixgtdkx2uobp37xqv5rci
-      '@itwin/presentation-components': 5.6.0_hb7vovirygu74f3smprdxccedu
-      '@itwin/presentation-frontend': 4.9.5_cfzxbnb6dite7ncbt3vw277mvu
-      '@itwin/webgl-compatibility': 4.9.5
+      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/appui-layout-react': 4.8.3_jscgs7su4cyo55wt5klvj3iepa
+      '@itwin/appui-react': 4.15.1_yrqai5hl5gvsf4dek6el5aloii
+      '@itwin/build-tools': 4.7.4_@types+node@18.19.39
+      '@itwin/components-react': 4.15.1_jscgs7su4cyo55wt5klvj3iepa
+      '@itwin/core-backend': 4.7.4_zzr6hivuljmnvzdhcyobjpaqme
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/core-electron': 4.7.4_hworozxoblmw2cyo32mpk5ebjm
+      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
+      '@itwin/core-geometry': 4.7.4
+      '@itwin/core-markup': 4.7.4_aa3bt7vk4zzsxcvhcdi4ojlcwe
+      '@itwin/core-orbitgt': 4.7.4
+      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/core-react': 4.15.1_bpptdsfauwdziiwg4uklizbr74
+      '@itwin/core-telemetry': 4.7.4_@itwin+core-geometry@4.7.4
+      '@itwin/ecschema-metadata': 4.7.4_jokiwfzdpldlrb2ppvojwoxovq
+      '@itwin/electron-authorization': 0.15.0_4vf3fjdy4loqcqolj5aeocucyi
+      '@itwin/imodel-components-react': 4.15.1_avm2jbcgpodgccdhk4zetypeem
+      '@itwin/presentation-common': 4.7.4_jrcxtioaccikuahb3i3h6f5rhe
+      '@itwin/presentation-components': 5.4.1_tr757zhbqqbt4rcaxvlnctg2de
+      '@itwin/presentation-frontend': 4.7.4_lbci6e5ivpkspr33wpe53pcp5i
+      '@itwin/webgl-compatibility': 4.7.4
       '@testing-library/jest-dom': 4.2.4
       '@testing-library/react': 14.3.1_nnrd3gsncyragczmpvfhocinkq
       '@testing-library/user-event': 7.2.1
       '@types/jest': 26.0.24
-      '@types/node': 18.19.62
-      '@types/react': 18.3.12
-      '@types/react-dom': 18.3.1
-      '@types/react-redux': 7.1.34
+      '@types/node': 18.19.39
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+      '@types/react-redux': 7.1.33
       concurrently: 5.3.0
       copyfiles: 2.4.1
       electron: 24.8.8
       identity-obj-proxy: 3.0.0
-      jest: 29.7.0_@types+node@18.19.62
+      jest: 29.7.0_@types+node@18.19.39
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
       react-redux: 7.2.9_nnrd3gsncyragczmpvfhocinkq
       redux: 4.2.1
       rimraf: 3.0.2
-      ts-jest: 29.2.5_qbbgenyc4wnry6yt7igwhfhjbm
+      ts-jest: 29.2.0_qbbgenyc4wnry6yt7igwhfhjbm
       typescript: 5.0.4
 
   ../../packages/modules/test-local-extension:
@@ -362,22 +362,22 @@ importers:
       serve: ^14.2.0
       typescript: ~5.0.2
     dependencies:
-      '@itwin/core-extension': 4.9.5_kyionygyo673et7f54wxvz6g2i
+      '@itwin/core-extension': 4.7.4_ieegwyxugmwu7xrlokpbnlonea
     devDependencies:
       '@esbuild-plugins/node-globals-polyfill': 0.1.1_esbuild@0.13.15
       '@esbuild-plugins/node-modules-polyfill': 0.1.4_esbuild@0.13.15
-      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/build-tools': 4.9.5
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
-      '@itwin/core-geometry': 4.9.5
-      '@itwin/core-orbitgt': 4.9.5
-      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/webgl-compatibility': 4.9.5
+      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/build-tools': 4.7.4
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/core-geometry': 4.7.4
+      '@itwin/core-orbitgt': 4.7.4
+      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/webgl-compatibility': 4.7.4
       esbuild: 0.13.15
       npm-run-all: 4.1.5
       rimraf: 3.0.2
-      serve: 14.2.4
+      serve: 14.2.3
       typescript: 5.0.4
 
   ../../packages/modules/test-remote-extension:
@@ -399,22 +399,22 @@ importers:
       serve: ^14.2.0
       typescript: ~5.0.2
     dependencies:
-      '@itwin/core-extension': 4.9.5_kyionygyo673et7f54wxvz6g2i
+      '@itwin/core-extension': 4.7.4_ieegwyxugmwu7xrlokpbnlonea
     devDependencies:
       '@esbuild-plugins/node-globals-polyfill': 0.1.1_esbuild@0.13.15
       '@esbuild-plugins/node-modules-polyfill': 0.1.4_esbuild@0.13.15
-      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/build-tools': 4.9.5
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
-      '@itwin/core-geometry': 4.9.5
-      '@itwin/core-orbitgt': 4.9.5
-      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/webgl-compatibility': 4.9.5
+      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/build-tools': 4.7.4
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/core-geometry': 4.7.4
+      '@itwin/core-orbitgt': 4.7.4
+      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/webgl-compatibility': 4.7.4
       esbuild: 0.13.15
       npm-run-all: 4.1.5
       rimraf: 3.0.2
-      serve: 14.2.4
+      serve: 14.2.3
       typescript: 5.0.4
 
   ../../packages/modules/viewer-react:
@@ -475,55 +475,55 @@ importers:
       '@bentley/icons-generic-webfont': 1.0.34
       '@itwin/itwinui-illustrations-react': 2.1.0_nnrd3gsncyragczmpvfhocinkq
       '@itwin/itwinui-react': 2.12.26_nnrd3gsncyragczmpvfhocinkq
-      '@itwin/presentation-core-interop': 0.2.7_tm7n22tj7qb4kxylpvuy237mmy
+      '@itwin/presentation-core-interop': 0.2.4_rll2n26bhzrezeyt23jhdcbtsy
       '@itwin/presentation-shared': 0.3.2
-      '@itwin/reality-data-client': 1.2.1_@itwin+core-bentley@4.9.5
-      '@itwin/unified-selection': 0.4.6
+      '@itwin/reality-data-client': 1.2.1_@itwin+core-bentley@4.7.4
+      '@itwin/unified-selection': 0.4.5
       lodash.isequal: 4.5.0
     devDependencies:
-      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/appui-layout-react': 4.8.3_zs6rif5h5jixp3mcoeld6e43pu
-      '@itwin/appui-react': 4.17.2_ggnmyqo32cg3w26befg4w43y64
-      '@itwin/build-tools': 4.9.5_@types+node@18.19.62
-      '@itwin/components-react': 4.17.2_zs6rif5h5jixp3mcoeld6e43pu
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
-      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
-      '@itwin/core-geometry': 4.9.5
-      '@itwin/core-i18n': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/core-markup': 4.9.5_rsqcs3hzbyxjzpttbshdocpt74
-      '@itwin/core-orbitgt': 4.9.5
-      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/core-react': 4.17.2_b5szh4swag42x6ykxwn6buimra
-      '@itwin/core-telemetry': 4.9.5_@itwin+core-geometry@4.9.5
-      '@itwin/ecschema-metadata': 4.9.5_ht7pcu4cvk5h6sxcpkl7x76mje
-      '@itwin/imodel-components-react': 4.17.2_inn3jcow7lwqfeofdqhb3etkfi
-      '@itwin/imodels-access-frontend': 5.2.3_x7r3qyjan52efy6jnvzj72woaa
-      '@itwin/imodels-client-management': 5.9.0
-      '@itwin/presentation-common': 4.9.5_752sgixgtdkx2uobp37xqv5rci
-      '@itwin/presentation-components': 5.6.0_pgm6v4yzke2vvcj2rwx47ufaoy
-      '@itwin/presentation-frontend': 4.9.5_cfzxbnb6dite7ncbt3vw277mvu
-      '@itwin/webgl-compatibility': 4.9.5
+      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/appui-layout-react': 4.8.3_jscgs7su4cyo55wt5klvj3iepa
+      '@itwin/appui-react': 4.15.1_yrqai5hl5gvsf4dek6el5aloii
+      '@itwin/build-tools': 4.7.4_@types+node@18.19.39
+      '@itwin/components-react': 4.15.1_jscgs7su4cyo55wt5klvj3iepa
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
+      '@itwin/core-geometry': 4.7.4
+      '@itwin/core-i18n': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/core-markup': 4.7.4_aa3bt7vk4zzsxcvhcdi4ojlcwe
+      '@itwin/core-orbitgt': 4.7.4
+      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/core-react': 4.15.1_bpptdsfauwdziiwg4uklizbr74
+      '@itwin/core-telemetry': 4.7.4_@itwin+core-geometry@4.7.4
+      '@itwin/ecschema-metadata': 4.7.4_jokiwfzdpldlrb2ppvojwoxovq
+      '@itwin/imodel-components-react': 4.15.1_avm2jbcgpodgccdhk4zetypeem
+      '@itwin/imodels-access-frontend': 5.2.1_r7pomf6q3izykcd6xffknqbpim
+      '@itwin/imodels-client-management': 5.8.1
+      '@itwin/presentation-common': 4.7.4_jrcxtioaccikuahb3i3h6f5rhe
+      '@itwin/presentation-components': 5.4.1_coeiqitrdc3kbyoxwt3ak4fycm
+      '@itwin/presentation-frontend': 4.7.4_lbci6e5ivpkspr33wpe53pcp5i
+      '@itwin/webgl-compatibility': 4.7.4
       '@testing-library/jest-dom': 4.2.4
       '@testing-library/react': 14.3.1_nnrd3gsncyragczmpvfhocinkq
       '@testing-library/user-event': 7.2.1
       '@types/jest': 26.0.24
       '@types/lodash.isequal': 4.5.8
-      '@types/node': 18.19.62
-      '@types/react': 18.3.12
-      '@types/react-dom': 18.3.1
-      '@types/react-redux': 7.1.34
+      '@types/node': 18.19.39
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+      '@types/react-redux': 7.1.33
       concurrently: 5.3.0
       copyfiles: 2.4.1
       identity-obj-proxy: 3.0.0
-      jest: 29.7.0_@types+node@18.19.62
+      jest: 29.7.0_@types+node@18.19.39
       jest-environment-jsdom: 29.7.0
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
       react-redux: 7.2.9_nnrd3gsncyragczmpvfhocinkq
       redux: 4.2.1
       rimraf: 3.0.2
-      ts-jest: 29.2.5_qbbgenyc4wnry6yt7igwhfhjbm
+      ts-jest: 29.2.0_qbbgenyc4wnry6yt7igwhfhjbm
       typescript: 5.0.4
 
   ../../packages/modules/web-viewer-react:
@@ -571,48 +571,48 @@ importers:
       ts-jest: ^29.1.0
       typescript: ~5.0.2
     dependencies:
-      '@itwin/imodels-client-management': 5.9.0
+      '@itwin/imodels-client-management': 5.8.1
       '@itwin/viewer-react': link:../viewer-react
     devDependencies:
-      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/appui-layout-react': 4.8.3_zs6rif5h5jixp3mcoeld6e43pu
-      '@itwin/appui-react': 4.17.2_ggnmyqo32cg3w26befg4w43y64
-      '@itwin/build-tools': 4.9.5_@types+node@18.19.62
-      '@itwin/components-react': 4.17.2_zs6rif5h5jixp3mcoeld6e43pu
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
-      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
-      '@itwin/core-geometry': 4.9.5
-      '@itwin/core-markup': 4.9.5_rsqcs3hzbyxjzpttbshdocpt74
-      '@itwin/core-orbitgt': 4.9.5
-      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/core-react': 4.17.2_b5szh4swag42x6ykxwn6buimra
-      '@itwin/core-telemetry': 4.9.5_@itwin+core-geometry@4.9.5
-      '@itwin/ecschema-metadata': 4.9.5_ht7pcu4cvk5h6sxcpkl7x76mje
-      '@itwin/imodel-components-react': 4.17.2_inn3jcow7lwqfeofdqhb3etkfi
-      '@itwin/presentation-common': 4.9.5_752sgixgtdkx2uobp37xqv5rci
-      '@itwin/presentation-components': 5.6.0_hb7vovirygu74f3smprdxccedu
-      '@itwin/presentation-frontend': 4.9.5_cfzxbnb6dite7ncbt3vw277mvu
-      '@itwin/webgl-compatibility': 4.9.5
+      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/appui-layout-react': 4.8.3_jscgs7su4cyo55wt5klvj3iepa
+      '@itwin/appui-react': 4.15.1_yrqai5hl5gvsf4dek6el5aloii
+      '@itwin/build-tools': 4.7.4_@types+node@18.19.39
+      '@itwin/components-react': 4.15.1_jscgs7su4cyo55wt5klvj3iepa
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
+      '@itwin/core-geometry': 4.7.4
+      '@itwin/core-markup': 4.7.4_aa3bt7vk4zzsxcvhcdi4ojlcwe
+      '@itwin/core-orbitgt': 4.7.4
+      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/core-react': 4.15.1_bpptdsfauwdziiwg4uklizbr74
+      '@itwin/core-telemetry': 4.7.4_@itwin+core-geometry@4.7.4
+      '@itwin/ecschema-metadata': 4.7.4_jokiwfzdpldlrb2ppvojwoxovq
+      '@itwin/imodel-components-react': 4.15.1_avm2jbcgpodgccdhk4zetypeem
+      '@itwin/presentation-common': 4.7.4_jrcxtioaccikuahb3i3h6f5rhe
+      '@itwin/presentation-components': 5.4.1_tr757zhbqqbt4rcaxvlnctg2de
+      '@itwin/presentation-frontend': 4.7.4_lbci6e5ivpkspr33wpe53pcp5i
+      '@itwin/webgl-compatibility': 4.7.4
       '@testing-library/jest-dom': 4.2.4
       '@testing-library/react': 14.3.1_nnrd3gsncyragczmpvfhocinkq
       '@testing-library/user-event': 7.2.1
       '@types/jest': 26.0.24
-      '@types/node': 18.19.62
-      '@types/react': 18.3.12
-      '@types/react-dom': 18.3.1
-      '@types/react-redux': 7.1.34
+      '@types/node': 18.19.39
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+      '@types/react-redux': 7.1.33
       concurrently: 5.3.0
       copyfiles: 2.4.1
       identity-obj-proxy: 3.0.0
-      jest: 29.7.0_@types+node@18.19.62
+      jest: 29.7.0_@types+node@18.19.39
       jest-environment-jsdom: 29.7.0
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
       react-redux: 7.2.9_nnrd3gsncyragczmpvfhocinkq
       redux: 4.2.1
       rimraf: 3.0.2
-      ts-jest: 29.2.5_qbbgenyc4wnry6yt7igwhfhjbm
+      ts-jest: 29.2.0_qbbgenyc4wnry6yt7igwhfhjbm
       typescript: 5.0.4
 
   ../../packages/templates/cra-template-desktop-viewer:
@@ -649,16 +649,16 @@ importers:
       '@typescript-eslint/eslint-plugin': 4.33.0_ffi3uiz42rv3jyhs6cr7p7qqry
       '@typescript-eslint/parser': 4.33.0_eslint@7.32.0
       eslint: 7.32.0
-      eslint-config-airbnb: 18.2.1_j47woh5gdjkhehtho5cd7z7hme
+      eslint-config-airbnb: 18.2.1_cb6pno7fzmlsn2yskxvbihgdme
       eslint-config-prettier: 6.15.0_eslint@7.32.0
-      eslint-config-react-app: 6.0.0_vblgvs7dq6s2rjad5szwfif2ae
+      eslint-config-react-app: 6.0.0_ssuykkwe44xqfk7ygtu5dsspum
       eslint-plugin-deprecation: 1.2.1_eslint@7.32.0
       eslint-plugin-flowtype: 5.10.0_eslint@7.32.0
-      eslint-plugin-import: 2.31.0_eslint@7.32.0
-      eslint-plugin-jsx-a11y: 6.10.2_eslint@7.32.0
+      eslint-plugin-import: 2.29.1_eslint@7.32.0
+      eslint-plugin-jsx-a11y: 6.9.0_eslint@7.32.0
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.32.0
       eslint-plugin-prettier: 3.4.1_6l26irxuevddeh5uhyzqivbl64
-      eslint-plugin-react: 7.37.2_eslint@7.32.0
+      eslint-plugin-react: 7.34.3_eslint@7.32.0
       eslint-plugin-react-hooks: 4.6.2_eslint@7.32.0
       eslint-plugin-simple-import-sort: 5.0.3_eslint@7.32.0
       lint-staged: 10.5.4
@@ -689,13 +689,13 @@ packages:
       '@jridgewell/trace-mapping': 0.3.25
     dev: true
 
-  /@apideck/better-ajv-errors/0.3.6_ajv@8.17.1:
+  /@apideck/better-ajv-errors/0.3.6_ajv@8.16.0:
     resolution: {integrity: sha512-P+ZygBLZtkp0qqOAJJVX4oX/sFo5JR3eBWwwuqHHhK0GIgQOKWrAfiAaWX0aArHkRWHMuggFEgAZNxVPwPZYaA==}
     engines: {node: '>=10'}
     peerDependencies:
       ajv: '>=8'
     dependencies:
-      ajv: 8.17.1
+      ajv: 8.16.0
       json-schema: 0.4.0
       jsonpointer: 5.0.1
       leven: 3.1.0
@@ -705,34 +705,33 @@ packages:
     resolution: {integrity: sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      tslib: 2.8.0
-    dev: false
+      tslib: 2.6.3
 
   /@azure/abort-controller/2.1.2:
     resolution: {integrity: sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      tslib: 2.8.0
+      tslib: 2.6.3
 
-  /@azure/core-auth/1.9.0:
-    resolution: {integrity: sha512-FPwHpZywuyasDSLMqJ6fhbOK3TqUdviZNF8OqRGA4W5Ewib2lEEZ+pBsYcBa88B2NGO/SEnYPGhyBqNlE8ilSw==}
+  /@azure/core-auth/1.7.2:
+    resolution: {integrity: sha512-Igm/S3fDYmnMq1uKS38Ae1/m37B3zigdlZw+kocwEhh5GjyKjPrXKO2J6rzpC1wAxrNil/jX9BJRqBshyjnF3g==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-util': 1.11.0
-      tslib: 2.8.0
+      '@azure/core-util': 1.9.0
+      tslib: 2.6.3
 
   /@azure/core-client/1.9.2:
     resolution: {integrity: sha512-kRdry/rav3fUKHl/aDLd/pDLcB+4pOFwPPTVEExuMyaI5r+JBbMWqRbCY1pn5BniDaU3lRxO9eaQ1AmSMehl/w==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.9.0
-      '@azure/core-rest-pipeline': 1.17.0
-      '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.11.0
-      '@azure/logger': 1.1.4
-      tslib: 2.8.0
+      '@azure/core-auth': 1.7.2
+      '@azure/core-rest-pipeline': 1.16.1
+      '@azure/core-tracing': 1.1.2
+      '@azure/core-util': 1.9.0
+      '@azure/logger': 1.1.2
+      tslib: 2.6.3
     transitivePeerDependencies:
       - supports-color
 
@@ -742,7 +741,7 @@ packages:
     dependencies:
       '@azure/abort-controller': 2.1.2
       '@azure/core-client': 1.9.2
-      '@azure/core-rest-pipeline': 1.17.0
+      '@azure/core-rest-pipeline': 1.16.1
     transitivePeerDependencies:
       - supports-color
 
@@ -751,113 +750,111 @@ packages:
     engines: {node: '>=18.0.0'}
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-util': 1.11.0
-      '@azure/logger': 1.1.4
-      tslib: 2.8.0
+      '@azure/core-util': 1.9.0
+      '@azure/logger': 1.1.2
+      tslib: 2.6.3
 
   /@azure/core-paging/1.6.2:
     resolution: {integrity: sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      tslib: 2.8.0
+      tslib: 2.6.3
 
-  /@azure/core-rest-pipeline/1.17.0:
-    resolution: {integrity: sha512-62Vv8nC+uPId3j86XJ0WI+sBf0jlqTqPUFCBNrGtlaUeQUIXWV/D8GE5A1d+Qx8H7OQojn2WguC8kChD6v0shA==}
+  /@azure/core-rest-pipeline/1.16.1:
+    resolution: {integrity: sha512-ExPSbgjwCoht6kB7B4MeZoBAxcQSIl29r/bPeazZJx50ej4JJCByimLOrZoIsurISNyJQQHf30b3JfqC3Hb88A==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.9.0
-      '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.11.0
-      '@azure/logger': 1.1.4
+      '@azure/core-auth': 1.7.2
+      '@azure/core-tracing': 1.1.2
+      '@azure/core-util': 1.9.0
+      '@azure/logger': 1.1.2
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.5
-      tslib: 2.8.0
+      tslib: 2.6.3
     transitivePeerDependencies:
       - supports-color
 
-  /@azure/core-tracing/1.2.0:
-    resolution: {integrity: sha512-UKTiEJPkWcESPYJz3X5uKRYyOcJD+4nYph+KpfdPRnQJVrZfk0KJgdnaAWKfhsBBtAf/D58Az4AvCJEmWgIBAg==}
+  /@azure/core-tracing/1.1.2:
+    resolution: {integrity: sha512-dawW9ifvWAWmUm9/h+/UQ2jrdvjCJ7VJEuCJ6XVNudzcOwm53BFZH4Q845vjfgoUAM8ZxokvVNxNxAITc502YA==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      tslib: 2.8.0
+      tslib: 2.6.3
 
-  /@azure/core-util/1.11.0:
-    resolution: {integrity: sha512-DxOSLua+NdpWoSqULhjDyAZTXFdP/LKkqtYuxxz1SCN289zk3OG8UOpnCQAz/tygyACBtWp/BoO72ptK7msY8g==}
+  /@azure/core-util/1.9.0:
+    resolution: {integrity: sha512-AfalUQ1ZppaKuxPPMsFEUdX6GZPB3d9paR9d/TTL7Ow2De8cJaC7ibi7kWVlFAVPCYo31OcnGymc0R89DX8Oaw==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@azure/abort-controller': 2.1.2
-      tslib: 2.8.0
+      tslib: 2.6.3
 
-  /@azure/core-xml/1.4.4:
-    resolution: {integrity: sha512-J4FYAqakGXcbfeZjwjMzjNcpcH4E+JtEBv+xcV1yL0Ydn/6wbQfeFKTCHh9wttAi0lmajHw7yBbHPRG+YHckZQ==}
+  /@azure/core-xml/1.4.2:
+    resolution: {integrity: sha512-CW3MZhApe/S4iikbYKE7s83fjDBPIr2kpidX+hlGRwh7N4o1nIpQ/PfJTeioqhfqdMvRtheEl+ft64fyTaLNaA==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      fast-xml-parser: 4.5.0
-      tslib: 2.8.0
+      fast-xml-parser: 4.4.1
+      tslib: 2.6.3
 
-  /@azure/logger/1.1.4:
-    resolution: {integrity: sha512-4IXXzcCdLdlXuCG+8UKEwLA1T1NHqUfanhXYHiQTn+6sfWCZXduqbtXDGceg3Ce5QxTGo7EqmbV6Bi+aqKuClQ==}
+  /@azure/logger/1.1.2:
+    resolution: {integrity: sha512-l170uE7bsKpIU6B/giRc9i4NI0Mj+tANMMMxf7Zi/5cKzEqPayP7+X1WPrG7e+91JgY8N+7K7nF2WOi7iVhXvg==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      tslib: 2.8.0
+      tslib: 2.6.3
 
-  /@azure/storage-blob/12.25.0:
-    resolution: {integrity: sha512-oodouhA3nCCIh843tMMbxty3WqfNT+Vgzj3Xo5jqR9UPnzq3d7mzLjlHAYz7lW+b4km3SIgz+NAgztvhm7Z6kQ==}
+  /@azure/storage-blob/12.23.0:
+    resolution: {integrity: sha512-c1KJ5R5hqR/HtvmFtTn/Y1BNMq45NUBp0LZH7yF8WFMET+wmESgEr0FVTu/Z5NonmfUjbgJZG5Nh8xHc5RdWGQ==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.9.0
+      '@azure/abort-controller': 1.1.0
+      '@azure/core-auth': 1.7.2
       '@azure/core-client': 1.9.2
       '@azure/core-http-compat': 2.1.2
       '@azure/core-lro': 2.7.2
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.17.0
-      '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.11.0
-      '@azure/core-xml': 1.4.4
-      '@azure/logger': 1.1.4
+      '@azure/core-rest-pipeline': 1.16.1
+      '@azure/core-tracing': 1.1.2
+      '@azure/core-util': 1.9.0
+      '@azure/core-xml': 1.4.2
+      '@azure/logger': 1.1.2
       events: 3.3.0
-      tslib: 2.8.0
+      tslib: 2.6.3
     transitivePeerDependencies:
       - supports-color
 
   /@babel/code-frame/7.12.11:
     resolution: {integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==}
     dependencies:
-      '@babel/highlight': 7.25.9
+      '@babel/highlight': 7.24.7
     dev: true
 
-  /@babel/code-frame/7.26.2:
-    resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
+  /@babel/code-frame/7.24.7:
+    resolution: {integrity: sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-validator-identifier': 7.25.9
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-    dev: true
+      '@babel/highlight': 7.24.7
+      picocolors: 1.0.1
 
-  /@babel/compat-data/7.26.2:
-    resolution: {integrity: sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg==}
+  /@babel/compat-data/7.24.7:
+    resolution: {integrity: sha512-qJzAIcv03PyaWqxRgO4mSU3lihncDT296vnyuE2O8uA4w3UHWI4S3hgeZd1L8W1Bft40w9JxJ2b412iDUFFRhw==}
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/core/7.26.0:
-    resolution: {integrity: sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==}
+  /@babel/core/7.24.7:
+    resolution: {integrity: sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@babel/code-frame': 7.26.2
-      '@babel/generator': 7.26.2
-      '@babel/helper-compilation-targets': 7.25.9
-      '@babel/helper-module-transforms': 7.26.0_@babel+core@7.26.0
-      '@babel/helpers': 7.26.0
-      '@babel/parser': 7.26.2
-      '@babel/template': 7.25.9
-      '@babel/traverse': 7.25.9
-      '@babel/types': 7.26.0
+      '@babel/code-frame': 7.24.7
+      '@babel/generator': 7.24.7
+      '@babel/helper-compilation-targets': 7.24.7
+      '@babel/helper-module-transforms': 7.24.7_@babel+core@7.24.7
+      '@babel/helpers': 7.24.7
+      '@babel/parser': 7.24.7
+      '@babel/template': 7.24.7
+      '@babel/traverse': 7.24.7
+      '@babel/types': 7.24.7
       convert-source-map: 2.0.0
-      debug: 4.3.7
+      debug: 4.3.5
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -865,1437 +862,1468 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/eslint-parser/7.25.9_ug2igzfsn2htp6pvbk547j4y6y:
-    resolution: {integrity: sha512-5UXfgpK0j0Xr/xIdgdLEhOFxaDZ0bRPWJJchRpqOSur/3rZoPbqqki5mm0p4NE2cs28krBEiSM2MB7//afRSQQ==}
+  /@babel/eslint-parser/7.24.7_ivopgdbs46443pcald3k67gmwm:
+    resolution: {integrity: sha512-SO5E3bVxDuxyNxM5agFv480YA2HO6ohZbGxbazZdIk3KQOPOGVNw6q78I9/lbviIf95eq6tPozeYnJLbjnC8IA==}
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
     peerDependencies:
       '@babel/core': ^7.11.0
       eslint: ^7.5.0 || ^8.0.0 || ^9.0.0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.24.7
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 8.57.1
+      eslint: 8.57.0
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
     dev: true
 
-  /@babel/generator/7.26.2:
-    resolution: {integrity: sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==}
+  /@babel/generator/7.24.7:
+    resolution: {integrity: sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/parser': 7.26.2
-      '@babel/types': 7.26.0
+      '@babel/types': 7.24.7
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
-      jsesc: 3.0.2
-    dev: true
+      jsesc: 2.5.2
 
-  /@babel/helper-annotate-as-pure/7.25.9:
-    resolution: {integrity: sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==}
+  /@babel/helper-annotate-as-pure/7.24.7:
+    resolution: {integrity: sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.26.0
+      '@babel/types': 7.24.7
     dev: true
 
-  /@babel/helper-builder-binary-assignment-operator-visitor/7.25.9:
-    resolution: {integrity: sha512-C47lC7LIDCnz0h4vai/tpNOI95tCd5ZT3iBt/DBH5lXKHZsyNQv18yf1wIIg2ntiQNgmAvA+DgZ82iW8Qdym8g==}
+  /@babel/helper-builder-binary-assignment-operator-visitor/7.24.7:
+    resolution: {integrity: sha512-xZeCVVdwb4MsDBkkyZ64tReWYrLRHlMN72vP7Bdm3OUOuyFZExhsHUUnuWnm2/XOlAJzR0LfPpB56WXZn0X/lA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/traverse': 7.25.9
-      '@babel/types': 7.26.0
+      '@babel/traverse': 7.24.7
+      '@babel/types': 7.24.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/helper-compilation-targets/7.25.9:
-    resolution: {integrity: sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==}
+  /@babel/helper-compilation-targets/7.24.7:
+    resolution: {integrity: sha512-ctSdRHBi20qWOfy27RUb4Fhp07KSJ3sXcuSvTrXrc4aG8NSYDo1ici3Vhg9bg69y5bj0Mr1lh0aeEgTvc12rMg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/compat-data': 7.26.2
-      '@babel/helper-validator-option': 7.25.9
-      browserslist: 4.24.2
+      '@babel/compat-data': 7.24.7
+      '@babel/helper-validator-option': 7.24.7
+      browserslist: 4.23.2
       lru-cache: 5.1.1
       semver: 6.3.1
     dev: true
 
-  /@babel/helper-create-class-features-plugin/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==}
+  /@babel/helper-create-class-features-plugin/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-kTkaDl7c9vO80zeX1rJxnuRpEsD5tA81yh11X1gQo+PhSti3JS+7qeZo9U4RHobKRiFPKaGK3svUAeb8D0Q7eg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-member-expression-to-functions': 7.25.9
-      '@babel/helper-optimise-call-expression': 7.25.9
-      '@babel/helper-replace-supers': 7.25.9_@babel+core@7.26.0
-      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-environment-visitor': 7.24.7
+      '@babel/helper-function-name': 7.24.7
+      '@babel/helper-member-expression-to-functions': 7.24.7
+      '@babel/helper-optimise-call-expression': 7.24.7
+      '@babel/helper-replace-supers': 7.24.7_@babel+core@7.24.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
+      '@babel/helper-split-export-declaration': 7.24.7
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/helper-create-regexp-features-plugin/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-ORPNZ3h6ZRkOyAa/SaHU+XsLZr0UQzRwuDQ0cczIA17nAzZ+85G5cVkOJIj7QavLZGSe8QXUmNFxSZzjcZF9bw==}
+  /@babel/helper-create-regexp-features-plugin/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-03TCmXy2FtXJEZfbXDTSqq1fRJArk7lX9DOFC/47VthYcxyIOx+eXQmdo6DOQvrbpIix+KfXwvuXdFDZHxt+rA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-annotate-as-pure': 7.25.9
-      regexpu-core: 6.1.1
+      '@babel/core': 7.24.7
+      '@babel/helper-annotate-as-pure': 7.24.7
+      regexpu-core: 5.3.2
       semver: 6.3.1
     dev: true
 
-  /@babel/helper-define-polyfill-provider/0.6.2_@babel+core@7.26.0:
+  /@babel/helper-define-polyfill-provider/0.6.2_@babel+core@7.24.7:
     resolution: {integrity: sha512-LV76g+C502biUK6AyZ3LK10vDpDyCzZnhZFXkH1L75zHPj68+qc8Zfpx2th+gzwA2MzyK+1g/3EPl62yFnVttQ==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-compilation-targets': 7.25.9
-      '@babel/helper-plugin-utils': 7.25.9
-      debug: 4.3.7
+      '@babel/core': 7.24.7
+      '@babel/helper-compilation-targets': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      debug: 4.3.5
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/helper-member-expression-to-functions/7.25.9:
-    resolution: {integrity: sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==}
+  /@babel/helper-environment-visitor/7.24.7:
+    resolution: {integrity: sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/traverse': 7.25.9
-      '@babel/types': 7.26.0
+      '@babel/types': 7.24.7
+
+  /@babel/helper-function-name/7.24.7:
+    resolution: {integrity: sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.24.7
+      '@babel/types': 7.24.7
+
+  /@babel/helper-hoist-variables/7.24.7:
+    resolution: {integrity: sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.24.7
+
+  /@babel/helper-member-expression-to-functions/7.24.7:
+    resolution: {integrity: sha512-LGeMaf5JN4hAT471eJdBs/GK1DoYIJ5GCtZN/EsL6KUiiDZOvO/eKE11AMZJa2zP4zk4qe9V2O/hxAmkRc8p6w==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/traverse': 7.24.7
+      '@babel/types': 7.24.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/helper-module-imports/7.25.9:
-    resolution: {integrity: sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==}
+  /@babel/helper-module-imports/7.24.7:
+    resolution: {integrity: sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/traverse': 7.25.9
-      '@babel/types': 7.26.0
+      '@babel/traverse': 7.24.7
+      '@babel/types': 7.24.7
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
-  /@babel/helper-module-transforms/7.26.0_@babel+core@7.26.0:
-    resolution: {integrity: sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==}
+  /@babel/helper-module-transforms/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-1fuJEwIrp+97rM4RWdO+qrRsZlAeL1lQJoPqtCYWv0NL115XM93hIH4CSRln2w52SqvmY5hqdtauB6QFCDiZNQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-module-imports': 7.25.9
-      '@babel/helper-validator-identifier': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-environment-visitor': 7.24.7
+      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-simple-access': 7.24.7
+      '@babel/helper-split-export-declaration': 7.24.7
+      '@babel/helper-validator-identifier': 7.24.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/helper-optimise-call-expression/7.25.9:
-    resolution: {integrity: sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==}
+  /@babel/helper-optimise-call-expression/7.24.7:
+    resolution: {integrity: sha512-jKiTsW2xmWwxT1ixIdfXUZp+P5yURx2suzLZr5Hi64rURpDYdMW0pv+Uf17EYk2Rd428Lx4tLsnjGJzYKDM/6A==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.26.0
+      '@babel/types': 7.24.7
     dev: true
 
-  /@babel/helper-plugin-utils/7.25.9:
-    resolution: {integrity: sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==}
+  /@babel/helper-plugin-utils/7.24.7:
+    resolution: {integrity: sha512-Rq76wjt7yz9AAc1KnlRKNAi/dMSVWgDRx43FHoJEbcYU6xOWaE2dVPwcdTukJrjxS65GITyfbvEYHvkirZ6uEg==}
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/helper-remap-async-to-generator/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-IZtukuUeBbhgOcaW2s06OXTzVNJR0ybm4W5xC1opWFFJMZbwRj5LCk+ByYH7WdZPZTt8KnFwA8pvjN2yqcPlgw==}
+  /@babel/helper-remap-async-to-generator/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-9pKLcTlZ92hNZMQfGCHImUpDOlAgkkpqalWEeftW5FBya75k8Li2ilerxkM/uBEj01iBZXcCIB/bwvDYgWyibA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-wrap-function': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-environment-visitor': 7.24.7
+      '@babel/helper-wrap-function': 7.24.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/helper-replace-supers/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-IiDqTOTBQy0sWyeXyGSC5TBJpGFXBkRynjBeXsvbhQFKj2viwJC76Epz35YLU1fpe/Am6Vppb7W7zM4fPQzLsQ==}
+  /@babel/helper-replace-supers/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-qTAxxBM81VEyoAY0TtLrx1oAEJc09ZK67Q9ljQToqCnA+55eNwCORaxlKyu+rNfX86o8OXRUSNUnrtsAZXM9sg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-member-expression-to-functions': 7.25.9
-      '@babel/helper-optimise-call-expression': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-environment-visitor': 7.24.7
+      '@babel/helper-member-expression-to-functions': 7.24.7
+      '@babel/helper-optimise-call-expression': 7.24.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/helper-simple-access/7.25.9:
-    resolution: {integrity: sha512-c6WHXuiaRsJTyHYLJV75t9IqsmTbItYfdj99PnzYGQZkYKvan5/2jKJ7gu31J3/BJ/A18grImSPModuyG/Eo0Q==}
+  /@babel/helper-simple-access/7.24.7:
+    resolution: {integrity: sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/traverse': 7.25.9
-      '@babel/types': 7.26.0
+      '@babel/traverse': 7.24.7
+      '@babel/types': 7.24.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/helper-skip-transparent-expression-wrappers/7.25.9:
-    resolution: {integrity: sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==}
+  /@babel/helper-skip-transparent-expression-wrappers/7.24.7:
+    resolution: {integrity: sha512-IO+DLT3LQUElMbpzlatRASEyQtfhSE0+m465v++3jyyXeBTBUjtVZg28/gHeV5mrTJqvEKhKroBGAvhW+qPHiQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/traverse': 7.25.9
-      '@babel/types': 7.26.0
+      '@babel/traverse': 7.24.7
+      '@babel/types': 7.24.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/helper-string-parser/7.25.9:
-    resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
-    engines: {node: '>=6.9.0'}
-    dev: true
-
-  /@babel/helper-validator-identifier/7.25.9:
-    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
-    engines: {node: '>=6.9.0'}
-    dev: true
-
-  /@babel/helper-validator-option/7.25.9:
-    resolution: {integrity: sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==}
-    engines: {node: '>=6.9.0'}
-    dev: true
-
-  /@babel/helper-wrap-function/7.25.9:
-    resolution: {integrity: sha512-ETzz9UTjQSTmw39GboatdymDq4XIQbR8ySgVrylRhPOFpsd+JrKHIuF0de7GCWmem+T4uC5z7EZguod7Wj4A4g==}
+  /@babel/helper-split-export-declaration/7.24.7:
+    resolution: {integrity: sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.25.9
-      '@babel/traverse': 7.25.9
-      '@babel/types': 7.26.0
+      '@babel/types': 7.24.7
+
+  /@babel/helper-string-parser/7.24.7:
+    resolution: {integrity: sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==}
+    engines: {node: '>=6.9.0'}
+
+  /@babel/helper-validator-identifier/7.24.7:
+    resolution: {integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==}
+    engines: {node: '>=6.9.0'}
+
+  /@babel/helper-validator-option/7.24.7:
+    resolution: {integrity: sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-wrap-function/7.24.7:
+    resolution: {integrity: sha512-N9JIYk3TD+1vq/wn77YnJOqMtfWhNewNE+DJV4puD2X7Ew9J4JvrzrFDfTfyv5EgEXVy9/Wt8QiOErzEmv5Ifw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-function-name': 7.24.7
+      '@babel/template': 7.24.7
+      '@babel/traverse': 7.24.7
+      '@babel/types': 7.24.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/helpers/7.26.0:
-    resolution: {integrity: sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==}
+  /@babel/helpers/7.24.7:
+    resolution: {integrity: sha512-NlmJJtvcw72yRJRcnCmGvSi+3jDEg8qFu3z0AFoymmzLx5ERVWyzd9kVXr7Th9/8yIJi2Zc6av4Tqz3wFs8QWg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.25.9
-      '@babel/types': 7.26.0
+      '@babel/template': 7.24.7
+      '@babel/types': 7.24.7
     dev: true
 
-  /@babel/highlight/7.25.9:
-    resolution: {integrity: sha512-llL88JShoCsth8fF8R4SJnIn+WLvR6ccFxu1H3FlMhDontdcmZWf2HgIZ7AIqV3Xcck1idlohrN4EUBQz6klbw==}
+  /@babel/highlight/7.24.7:
+    resolution: {integrity: sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/helper-validator-identifier': 7.24.7
       chalk: 2.4.2
       js-tokens: 4.0.0
-      picocolors: 1.1.1
-    dev: true
+      picocolors: 1.0.1
 
-  /@babel/parser/7.26.2:
-    resolution: {integrity: sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==}
+  /@babel/parser/7.24.7:
+    resolution: {integrity: sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-    dependencies:
-      '@babel/types': 7.26.0
-    dev: true
 
-  /@babel/plugin-bugfix-firefox-class-in-computed-class-key/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-ZkRyVkThtxQ/J6nv3JFYv1RYY+JT5BvU0y3k5bWrmuG4woXypRa4PXmm9RhOwodRkYFWqC0C0cqcJ4OqR7kW+g==}
+  /@babel/plugin-bugfix-firefox-class-in-computed-class-key/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-TiT1ss81W80eQsN+722OaeQMY/G4yTb4G9JrqeiDADs3N8lbPMGldWi9x8tyqCW5NLx1Jh2AvkE6r6QvEltMMQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/traverse': 7.25.9
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/core': 7.24.7
+      '@babel/helper-environment-visitor': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-bugfix-safari-class-field-initializer-scope/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-MrGRLZxLD/Zjj0gdU15dfs+HH/OXvnw/U4jJD8vpcP2CJQapPEv1IWwjc/qMg7ItBlPwSv1hRBbb7LeuANdcnw==}
+  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-unaQgZ/iRu/By6tsjMZzpeBZjChYfLYry6HrEXPoz3KmfF0sVBQ1l8zKMQ4xRGLWVsjuvB8nQfjNP/DcfEOCsg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-2qUwwfAFpJLZqxd02YW9btUCZHl+RFvdDkNfZwaIJrvB8Tesjsk8pEQkTvGwZXLqXUx/2oyY3ySRhm6HOXuCug==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-    dev: true
-
-  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-6xWgLZTJXwilVjlnV7ospI3xi+sl8lN8rXXbBD6vYn3UYDlGsag8wrZkKcSI8G6KgqKP7vNFaDgeDnfAABq61g==}
+  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-+izXIbke1T33mY4MSNnrqhPXDz01WYhEf3yF5NbnUtkiNnm+XBZJl3kNfoK6NKmYlz/D07+l2GWVK/QfDkNCuQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.13.0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
-      '@babel/plugin-transform-optional-chaining': 7.25.9_@babel+core@7.26.0
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
+      '@babel/plugin-transform-optional-chaining': 7.24.7_@babel+core@7.24.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-aLnMXYPnzwwqhYSCyXfKkIkYgJ8zv9RK+roo9DkTXz38ynIhd9XCbN08s3MGvqL2MYGVUGdRQLL/JqBIeJhJBg==}
+  /@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-utA4HuR6F4Vvcr+o4DnjL8fCOlgRFGbeeBEGNg3ZTrLFw6VWG5XmUrvcQ0FjIYMU2ST4XcR2Wsp7t9qOAPnxMg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/traverse': 7.25.9
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/core': 7.24.7
+      '@babel/helper-environment-visitor': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-proposal-class-properties/7.18.6_@babel+core@7.26.0:
+  /@babel/plugin-proposal-class-properties/7.18.6_@babel+core@7.24.7:
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
     engines: {node: '>=6.9.0'}
     deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-create-class-features-plugin': 7.25.9_@babel+core@7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-create-class-features-plugin': 7.24.7_@babel+core@7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-decorators/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-smkNLL/O1ezy9Nhy4CNosc4Va+1wo5w4gzSZeLe6y6dM4mmHfYOCPolXQPHQxonZCF+ZyebxN9vqOolkYrSn5g==}
+  /@babel/plugin-proposal-decorators/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-RL9GR0pUG5Kc8BUWLNDm2T5OpYwSX15r98I0IkgmRQTXuELq/OynH8xtMTMvTJFjXbMWFVTKtYkTaYQsuAwQlQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-create-class-features-plugin': 7.25.9_@babel+core@7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/plugin-syntax-decorators': 7.25.9_@babel+core@7.26.0
+      '@babel/core': 7.24.7
+      '@babel/helper-create-class-features-plugin': 7.24.7_@babel+core@7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-decorators': 7.24.7_@babel+core@7.24.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-nullish-coalescing-operator/7.18.6_@babel+core@7.26.0:
+  /@babel/plugin-proposal-nullish-coalescing-operator/7.18.6_@babel+core@7.24.7:
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
     engines: {node: '>=6.9.0'}
     deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-nullish-coalescing-operator instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.26.0
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.24.7
     dev: true
 
-  /@babel/plugin-proposal-numeric-separator/7.18.6_@babel+core@7.26.0:
+  /@babel/plugin-proposal-numeric-separator/7.18.6_@babel+core@7.24.7:
     resolution: {integrity: sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==}
     engines: {node: '>=6.9.0'}
     deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-numeric-separator instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.26.0
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.24.7
     dev: true
 
-  /@babel/plugin-proposal-optional-chaining/7.21.0_@babel+core@7.26.0:
+  /@babel/plugin-proposal-optional-chaining/7.21.0_@babel+core@7.24.7:
     resolution: {integrity: sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==}
     engines: {node: '>=6.9.0'}
     deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-chaining instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.26.0
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.24.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-private-methods/7.18.6_@babel+core@7.26.0:
+  /@babel/plugin-proposal-private-methods/7.18.6_@babel+core@7.24.7:
     resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
     engines: {node: '>=6.9.0'}
     deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-create-class-features-plugin': 7.25.9_@babel+core@7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-create-class-features-plugin': 7.24.7_@babel+core@7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-private-property-in-object/7.21.0-placeholder-for-preset-env.2_@babel+core@7.26.0:
+  /@babel/plugin-proposal-private-property-in-object/7.21.0-placeholder-for-preset-env.2_@babel+core@7.24.7:
     resolution: {integrity: sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.26.0:
+  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.24.7:
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.26.0:
+  /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.24.7:
     resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.26.0:
+  /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.24.7:
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-class-static-block/7.14.5_@babel+core@7.26.0:
+  /@babel/plugin-syntax-class-static-block/7.14.5_@babel+core@7.24.7:
     resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-decorators/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-ryzI0McXUPJnRCvMo4lumIKZUzhYUO/ScI+Mz4YVaTLt04DHNSjEUjKVvbzQjZFLuod/cYEc07mJWhzl6v4DPg==}
+  /@babel/plugin-syntax-decorators/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-Ui4uLJJrRV1lb38zg1yYTmRKmiZLiftDEvZN2iq3kd9kUFU+PttmzTbAFC2ucRk/XJmtek6G23gPsuZbhrT8fQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-flow/7.26.0_@babel+core@7.26.0:
-    resolution: {integrity: sha512-B+O2DnPc0iG+YXFqOxv2WNuNU97ToWjOomUQ78DouOENWUaM5sVrmet9mcomUGQFwpJd//gvUagXBSdzO1fRKg==}
+  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.24.7:
+    resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+    dev: true
+
+  /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.24.7:
+    resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+    dev: true
+
+  /@babel/plugin-syntax-flow/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-9G8GYT/dxn/D1IIKOUBmGX0mnmj46mGH9NnZyJLwtCpgh5f7D2VbuKodb+2s9m1Yavh1s7ASQN8lf0eqrb1LTw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-import-assertions/7.26.0_@babel+core@7.26.0:
-    resolution: {integrity: sha512-QCWT5Hh830hK5EQa7XzuqIkQU9tT/whqbDz7kuaZMHFl1inRRg7JnuAEOQ0Ur0QUl0NufCk1msK2BeY79Aj/eg==}
+  /@babel/plugin-syntax-import-assertions/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-Ec3NRUMoi8gskrkBe3fNmEQfxDvY8bgfQpz6jlk/41kX9eUjvpyqWU7PBP/pLAvMaSQjbMNKJmvX57jP+M6bPg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-import-attributes/7.26.0_@babel+core@7.26.0:
-    resolution: {integrity: sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==}
+  /@babel/plugin-syntax-import-attributes/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-hbX+lKKeUMGihnK8nvKqmXBInriT3GVjzXKFriV3YC6APGxMbP8RZNFwy91+hocLXq90Mta+HshoB31802bb8A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.26.0:
+  /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.24.7:
     resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.26.0:
+  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.24.7:
     resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-jsx/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==}
+  /@babel/plugin-syntax-jsx/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.26.0:
+  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.24.7:
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.26.0:
+  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.24.7:
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.26.0:
+  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.24.7:
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.26.0:
+  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.24.7:
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.26.0:
+  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.24.7:
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.26.0:
+  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.24.7:
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-private-property-in-object/7.14.5_@babel+core@7.26.0:
+  /@babel/plugin-syntax-private-property-in-object/7.14.5_@babel+core@7.24.7:
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.26.0:
+  /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.24.7:
     resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-typescript/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==}
+  /@babel/plugin-syntax-typescript/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-c/+fVeJBB0FeKsFvwytYiUD+LBvhHjGSI0g446PRGdSVGZLRNArBUno2PETbAly3tpiNAQR5XaZ+JslxkotsbA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-unicode-sets-regex/7.18.6_@babel+core@7.26.0:
+  /@babel/plugin-syntax-unicode-sets-regex/7.18.6_@babel+core@7.24.7:
     resolution: {integrity: sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-create-regexp-features-plugin': 7.25.9_@babel+core@7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-create-regexp-features-plugin': 7.24.7_@babel+core@7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-arrow-functions/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-6jmooXYIwn9ca5/RylZADJ+EnSxVUS5sjeJ9UPk6RWRzXCmOJCy6dqItPJFpw2cuCangPK4OYr5uhGKcmrm5Qg==}
+  /@babel/plugin-transform-arrow-functions/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-Dt9LQs6iEY++gXUwY03DNFat5C2NbO48jj+j/bSAz6b3HgPs39qcPiYt77fDObIcFwj3/C2ICX9YMwGflUoSHQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-async-generator-functions/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-RXV6QAzTBbhDMO9fWwOmwwTuYaiPbggWQ9INdZqAYeSHyG7FzQ+nOZaUUjNwKv9pV3aE4WFqFm1Hnbci5tBCAw==}
+  /@babel/plugin-transform-async-generator-functions/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-o+iF77e3u7ZS4AoAuJvapz9Fm001PuD2V3Lp6OSE4FYQke+cSewYtnek+THqGRWyQloRCyvWL1OkyfNEl9vr/g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/helper-remap-async-to-generator': 7.25.9_@babel+core@7.26.0
-      '@babel/traverse': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-environment-visitor': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-remap-async-to-generator': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.24.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-async-to-generator/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-NT7Ejn7Z/LjUH0Gv5KsBCxh7BH3fbLTV0ptHvpeMvrt3cPThHfJfst9Wrb7S8EvJ7vRTFI7z+VAvFVEQn/m5zQ==}
+  /@babel/plugin-transform-async-to-generator/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-SQY01PcJfmQ+4Ash7NE+rpbLFbmqA2GPIgqzxfFTL4t1FKRq4zTms/7htKpoCUI9OcFYgzqfmCdH53s6/jn5fA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-module-imports': 7.25.9
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/helper-remap-async-to-generator': 7.25.9_@babel+core@7.26.0
+      '@babel/core': 7.24.7
+      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-remap-async-to-generator': 7.24.7_@babel+core@7.24.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-block-scoped-functions/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-toHc9fzab0ZfenFpsyYinOX0J/5dgJVA2fm64xPewu7CoYHWEivIWKxkK2rMi4r3yQqLnVmheMXRdG+k239CgA==}
+  /@babel/plugin-transform-block-scoped-functions/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-yO7RAz6EsVQDaBH18IDJcMB1HnrUn2FJ/Jslc/WtPPWcjhpUJXU/rjbwmluzp7v/ZzWcEhTMXELnnsz8djWDwQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-block-scoping/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-1F05O7AYjymAtqbsFETboN1NvBdcnzMerO+zlMyJBEz6WkMdejvGWw9p05iTSjC85RLlBseHHQpYaM4gzJkBGg==}
+  /@babel/plugin-transform-block-scoping/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-Nd5CvgMbWc+oWzBsuaMcbwjJWAcp5qzrbg69SZdHSP7AMY0AbWFqFO0WTFCA1jxhMCwodRwvRec8k0QUbZk7RQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-class-properties/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-bbMAII8GRSkcd0h0b4X+36GksxuheLFjP65ul9w6C3KgAamI3JqErNgSrosX6ZPj+Mpim5VvEbawXxJCyEUV3Q==}
+  /@babel/plugin-transform-class-properties/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-vKbfawVYayKcSeSR5YYzzyXvsDFWU2mD8U5TFeXtbCPLFUqe7GyCgvO6XDHzje862ODrOwy6WCPmKeWHbCFJ4w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-create-class-features-plugin': 7.25.9_@babel+core@7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-create-class-features-plugin': 7.24.7_@babel+core@7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-class-static-block/7.26.0_@babel+core@7.26.0:
-    resolution: {integrity: sha512-6J2APTs7BDDm+UMqP1useWqhcRAXo0WIoVj26N7kPFB6S73Lgvyka4KTZYIxtgYXiN5HTyRObA72N2iu628iTQ==}
+  /@babel/plugin-transform-class-static-block/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-HMXK3WbBPpZQufbMG4B46A90PkuuhN9vBCb5T8+VAHqvAqvcLi+2cKoukcpmUYkszLhScU3l1iudhrks3DggRQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.12.0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-create-class-features-plugin': 7.25.9_@babel+core@7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-create-class-features-plugin': 7.24.7_@babel+core@7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.24.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-classes/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-mD8APIXmseE7oZvZgGABDyM34GUmK45Um2TXiBUt7PnuAxrgoSVf123qUzPxEr/+/BHrRn5NMZCdE2m/1F8DGg==}
+  /@babel/plugin-transform-classes/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-CFbbBigp8ln4FU6Bpy6g7sE8B/WmCmzvivzUC6xDAdWVsjYTXijpuuGJmYkAaoWAzcItGKT3IOAbxRItZ5HTjw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-compilation-targets': 7.25.9
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/helper-replace-supers': 7.25.9_@babel+core@7.26.0
-      '@babel/traverse': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-compilation-targets': 7.24.7
+      '@babel/helper-environment-visitor': 7.24.7
+      '@babel/helper-function-name': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-replace-supers': 7.24.7_@babel+core@7.24.7
+      '@babel/helper-split-export-declaration': 7.24.7
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-computed-properties/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-HnBegGqXZR12xbcTHlJ9HGxw1OniltT26J5YpfruGqtUHlz/xKf/G2ak9e+t0rVqrjXa9WOhvYPz1ERfMj23AA==}
+  /@babel/plugin-transform-computed-properties/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-25cS7v+707Gu6Ds2oY6tCkUwsJ9YIDbggd9+cu9jzzDgiNq7hR/8dkzxWfKWnTic26vsI3EsCXNd4iEB6e8esQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/template': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/template': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-destructuring/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-WkCGb/3ZxXepmMiX101nnGiU+1CAdut8oHyEOHxkKuS1qKpU2SMXE2uSvfz8PBuLd49V6LEsbtyPhWC7fnkgvQ==}
+  /@babel/plugin-transform-destructuring/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-19eJO/8kdCQ9zISOf+SEUJM/bAUIsvY3YDnXZTupUCQ8LgrWnsG/gFB9dvXqdXnRXMAM8fvt7b0CBKQHNGy1mw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-dotall-regex/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-t7ZQ7g5trIgSRYhI9pIJtRl64KHotutUJsh4Eze5l7olJv+mRSg4/MmbZ0tv1eeqRbdvo/+trvJD/Oc5DmW2cA==}
+  /@babel/plugin-transform-dotall-regex/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-ZOA3W+1RRTSWvyqcMJDLqbchh7U4NRGqwRfFSVbOLS/ePIP4vHB5e8T8eXcuqyN1QkgKyj5wuW0lcS85v4CrSw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-create-regexp-features-plugin': 7.25.9_@babel+core@7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-create-regexp-features-plugin': 7.24.7_@babel+core@7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-duplicate-keys/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-LZxhJ6dvBb/f3x8xwWIuyiAHy56nrRG3PeYTpBkkzkYRRQ6tJLu68lEF5VIqMUZiAV7a8+Tb78nEoMCMcqjXBw==}
+  /@babel/plugin-transform-duplicate-keys/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-JdYfXyCRihAe46jUIliuL2/s0x0wObgwwiGxw/UbgJBr20gQBThrokO4nYKgWkD7uBaqM7+9x5TU7NkExZJyzw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-duplicate-named-capturing-groups-regex/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-0UfuJS0EsXbRvKnwcLjFtJy/Sxc5J5jhLHnFhy7u4zih97Hz6tJkLU+O+FMMrNZrosUPxDi6sYxJ/EA8jDiAog==}
+  /@babel/plugin-transform-dynamic-import/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-sc3X26PhZQDb3JhORmakcbvkeInvxz+A8oda99lj7J60QRuPZvNAk9wQlTBS1ZynelDrDmTU4pw1tyc5d5ZMUg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.24.7
+    dev: true
+
+  /@babel/plugin-transform-exponentiation-operator/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-Rqe/vSc9OYgDajNIK35u7ot+KeCoetqQYFXM4Epf7M7ez3lWlOjrDjrwMei6caCVhfdw+mIKD4cgdGNy5JQotQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-builder-binary-assignment-operator-visitor': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/plugin-transform-export-namespace-from/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-v0K9uNYsPL3oXZ/7F9NNIbAj2jv1whUEtyA6aujhekLs56R++JDQuzRcP2/z4WX5Vg/c5lE9uWZA0/iUoFhLTA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.24.7
+    dev: true
+
+  /@babel/plugin-transform-flow-strip-types/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-cjRKJ7FobOH2eakx7Ja+KpJRj8+y+/SiB3ooYm/n2UJfxu0oEaOoxOinitkJcPqv9KxS0kxTGPUaR7L2XcXDXA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-flow': 7.24.7_@babel+core@7.24.7
+    dev: true
+
+  /@babel/plugin-transform-for-of/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-wo9ogrDG1ITTTBsy46oGiN1dS9A7MROBTcYsfS8DtsImMkHk9JXJ3EWQM6X2SUw4x80uGPlwj0o00Uoc6nEE3g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/plugin-transform-function-name/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-U9FcnA821YoILngSmYkW6FjyQe2TyZD5pHt4EVIhmcTkrJw/3KqcrRSxuOo5tFZJi7TE19iDyI1u+weTI7bn2w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-compilation-targets': 7.24.7
+      '@babel/helper-function-name': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+    dev: true
+
+  /@babel/plugin-transform-json-strings/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-2yFnBGDvRuxAaE/f0vfBKvtnvvqU8tGpMHqMNpTN2oWMKIR3NqFkjaAgGwawhqK/pIN2T3XdjGPdaG0vDhOBGw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.24.7
+    dev: true
+
+  /@babel/plugin-transform-literals/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-vcwCbb4HDH+hWi8Pqenwnjy+UiklO4Kt1vfspcQYFhJdpthSnW8XvWGyDZWKNVrVbVViI/S7K9PDJZiUmP2fYQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+    dev: true
+
+  /@babel/plugin-transform-logical-assignment-operators/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-4D2tpwlQ1odXmTEIFWy9ELJcZHqrStlzK/dAOWYyxX3zT0iXQB6banjgeOJQXzEc4S0E0a5A+hahxPaEFYftsw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.24.7
+    dev: true
+
+  /@babel/plugin-transform-member-expression-literals/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-T/hRC1uqrzXMKLQ6UCwMT85S3EvqaBXDGf0FaMf4446Qx9vKwlghvee0+uuZcDUCZU5RuNi4781UQ7R308zzBw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+    dev: true
+
+  /@babel/plugin-transform-modules-amd/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-9+pB1qxV3vs/8Hdmz/CulFB8w2tuu6EB94JZFsjdqxQokwGa9Unap7Bo2gGBGIvPmDIVvQrom7r5m/TCDMURhg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-module-transforms': 7.24.7_@babel+core@7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/plugin-transform-modules-commonjs/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-iFI8GDxtevHJ/Z22J5xQpVqFLlMNstcLXh994xifFwxxGslr2ZXXLWgtBeLctOD63UFDArdvN6Tg8RFw+aEmjQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-module-transforms': 7.24.7_@babel+core@7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-simple-access': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/plugin-transform-modules-systemjs/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-GYQE0tW7YoaN13qFh3O1NCY4MPkUiAH3fiF7UcV/I3ajmDKEdG3l+UOcbAm4zUE3gnvUU+Eni7XrVKo9eO9auw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-hoist-variables': 7.24.7
+      '@babel/helper-module-transforms': 7.24.7_@babel+core@7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-validator-identifier': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/plugin-transform-modules-umd/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-3aytQvqJ/h9z4g8AsKPLvD4Zqi2qT+L3j7XoFFu1XBlZWEl2/1kWnhmAbxpLgPrHSY0M6UA02jyTiwUVtiKR6A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-module-transforms': 7.24.7_@babel+core@7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/plugin-transform-named-capturing-groups-regex/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-/jr7h/EWeJtk1U/uz2jlsCioHkZk1JJZVcc8oQsJ1dUlaJD83f4/6Zeh2aHt9BIFokHIsSeDfhUmju0+1GPd6g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-create-regexp-features-plugin': 7.25.9_@babel+core@7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-create-regexp-features-plugin': 7.24.7_@babel+core@7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-dynamic-import/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-GCggjexbmSLaFhqsojeugBpeaRIgWNTcgKVq/0qIteFEqY2A+b9QidYadrWlnbWQUrW5fn+mCvf3tr7OeBFTyg==}
+  /@babel/plugin-transform-new-target/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-RNKwfRIXg4Ls/8mMTza5oPF5RkOW8Wy/WgMAp1/F1yZ8mMbtwXW+HDoJiOsagWrAhI5f57Vncrmr9XeT4CVapA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-exponentiation-operator/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-KRhdhlVk2nObA5AYa7QMgTMTVJdfHprfpAk4DjZVtllqRg9qarilstTKEhpVjyt+Npi8ThRyiV8176Am3CodPA==}
+  /@babel/plugin-transform-nullish-coalescing-operator/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-Ts7xQVk1OEocqzm8rHMXHlxvsfZ0cEF2yomUqpKENHWMF4zKk175Y4q8H5knJes6PgYad50uuRmt3UJuhBw8pQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-builder-binary-assignment-operator-visitor': 7.25.9
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.24.7
+    dev: true
+
+  /@babel/plugin-transform-numeric-separator/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-e6q1TiVUzvH9KRvicuxdBTUj4AdKSRwzIyFFnfnezpCfP2/7Qmbb8qbU2j7GODbl4JMkblitCQjKYUaX/qkkwA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.24.7
+    dev: true
+
+  /@babel/plugin-transform-object-rest-spread/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-4QrHAr0aXQCEFni2q4DqKLD31n2DL+RxcwnNjDFkSG0eNQ/xCavnRkfCUjsyqGC2OviNJvZOF/mQqZBw7i2C5Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-compilation-targets': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.24.7
+      '@babel/plugin-transform-parameters': 7.24.7_@babel+core@7.24.7
+    dev: true
+
+  /@babel/plugin-transform-object-super/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-A/vVLwN6lBrMFmMDmPPz0jnE6ZGx7Jq7d6sT/Ev4H65RER6pZ+kczlf1DthF5N0qaPHBsI7UXiE8Zy66nmAovg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-replace-supers': 7.24.7_@babel+core@7.24.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-export-namespace-from/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-2NsEz+CxzJIVOPx2o9UsW1rXLqtChtLoVnwYHHiB04wS5sgn7mrV45fWMBX0Kk+ub9uXytVYfNP2HjbVbCB3Ww==}
+  /@babel/plugin-transform-optional-catch-binding/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-uLEndKqP5BfBbC/5jTwPxLh9kqPWWgzN/f8w6UwAIirAEqiIVJWWY312X72Eub09g5KF9+Zn7+hT7sDxmhRuKA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.24.7
     dev: true
 
-  /@babel/plugin-transform-flow-strip-types/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-/VVukELzPDdci7UUsWQaSkhgnjIWXnIyRpM02ldxaVoFK96c41So8JcKT3m0gYjyv7j5FNPGS5vfELrWalkbDA==}
+  /@babel/plugin-transform-optional-chaining/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-tK+0N9yd4j+x/4hxF3F0e0fu/VdcxU18y5SevtyM/PCFlQvXbR0Zmlo2eBrKtVipGNFzpq56o8WsIIKcJFUCRQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/plugin-syntax-flow': 7.26.0_@babel+core@7.26.0
-    dev: true
-
-  /@babel/plugin-transform-for-of/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-LqHxduHoaGELJl2uhImHwRQudhCM50pT46rIBNvtT/Oql3nqiS3wOwP+5ten7NpYSXrrVLgtZU3DZmPtWZo16A==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.24.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-function-name/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-8lP+Yxjv14Vc5MuWBpJsoUCd3hD6V9DgBon2FVYL4jJgbnVQ9fTgYmonchzZJOVNgzEgbxp4OwAf6xz6M/14XA==}
+  /@babel/plugin-transform-parameters/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-yGWW5Rr+sQOhK0Ot8hjDJuxU3XLRQGflvT4lhlSY0DFvdb3TwKaY26CJzHtYllU0vT9j58hc37ndFPsqT1SrzA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-compilation-targets': 7.25.9
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+    dev: true
+
+  /@babel/plugin-transform-private-methods/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-COTCOkG2hn4JKGEKBADkA8WNb35TGkkRbI5iT845dB+NyqgO8Hn+ajPbSnIQznneJTa3d30scb6iz/DhH8GsJQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-create-class-features-plugin': 7.24.7_@babel+core@7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-json-strings/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-xoTMk0WXceiiIvsaquQQUaLLXSW1KJ159KP87VilruQm0LNNGxWzahxSS6T6i4Zg3ezp4vA4zuwiNUR53qmQAw==}
+  /@babel/plugin-transform-private-property-in-object/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-9z76mxwnwFxMyxZWEgdgECQglF2Q7cFLm0kMf8pGwt+GSJsY0cONKj/UuO4bOH0w/uAel3ekS4ra5CEAyJRmDA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-    dev: true
-
-  /@babel/plugin-transform-literals/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-9N7+2lFziW8W9pBl2TzaNht3+pgMIRP74zizeCSrtnSKVdUl8mAjjOP2OOVQAfZ881P2cNjDj1uAMEdeD50nuQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-    dev: true
-
-  /@babel/plugin-transform-logical-assignment-operators/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-wI4wRAzGko551Y8eVf6iOY9EouIDTtPb0ByZx+ktDGHwv6bHFimrgJM/2T021txPZ2s4c7bqvHbd+vXG6K948Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-    dev: true
-
-  /@babel/plugin-transform-member-expression-literals/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-PYazBVfofCQkkMzh2P6IdIUaCEWni3iYEerAsRWuVd8+jlM1S9S9cz1dF9hIzyoZ8IA3+OwVYIp9v9e+GbgZhA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-    dev: true
-
-  /@babel/plugin-transform-modules-amd/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-g5T11tnI36jVClQlMlt4qKDLlWnG5pP9CSM4GhdRciTNMRgkfpo5cR6b4rGIOYPgRRuFAvwjPQ/Yk+ql4dyhbw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-module-transforms': 7.26.0_@babel+core@7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-create-class-features-plugin': 7.24.7_@babel+core@7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.24.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-modules-commonjs/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-dwh2Ol1jWwL2MgkCzUSOvfmKElqQcuswAZypBSUsScMXvgdT8Ekq5YA6TtqpTVWH+4903NmboMuH1o9i8Rxlyg==}
+  /@babel/plugin-transform-property-literals/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-EMi4MLQSHfd2nrCqQEWxFdha2gBCqU4ZcCng4WBGZ5CJL4bBRW0ptdqqDdeirGZcpALazVVNJqRmsO8/+oNCBA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-module-transforms': 7.26.0_@babel+core@7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/helper-simple-access': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+    dev: true
+
+  /@babel/plugin-transform-react-constant-elements/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-7LidzZfUXyfZ8/buRW6qIIHBY8wAZ1OrY9c/wTr8YhZ6vMPo+Uc/CVFLYY1spZrEQlD4w5u8wjqk5NQ3OVqQKA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+    dev: true
+
+  /@babel/plugin-transform-react-display-name/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-H/Snz9PFxKsS1JLI4dJLtnJgCJRoo0AUm3chP6NYr+9En1JMKloheEiLIhlp5MDVznWo+H3AAC1Mc8lmUEpsgg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+    dev: true
+
+  /@babel/plugin-transform-react-jsx-development/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-QG9EnzoGn+Qar7rxuW+ZOsbWOt56FvvI93xInqsZDC5fsekx1AlIO4KIJ5M+D0p0SqSH156EpmZyXq630B8OlQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/plugin-transform-react-jsx': 7.24.7_@babel+core@7.24.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-modules-systemjs/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-hyss7iIlH/zLHaehT+xwiymtPOpsiwIIRlCAOwBB04ta5Tt+lNItADdlXw3jAWZ96VJ2jlhl/c+PNIQPKNfvcA==}
+  /@babel/plugin-transform-react-jsx/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-+Dj06GDZEFRYvclU6k4bme55GKBEWUmByM/eoKuqg4zTNQHiApWRhQph5fxQB2wAEFvRzL1tOEj1RJ19wJrhoA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-module-transforms': 7.26.0_@babel+core@7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/helper-validator-identifier': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-jsx': 7.24.7_@babel+core@7.24.7
+      '@babel/types': 7.24.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-modules-umd/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-bS9MVObUgE7ww36HEfwe6g9WakQ0KF07mQF74uuXdkoziUPfKyu/nIm663kz//e5O1nPInPFx36z7WJmJ4yNEw==}
+  /@babel/plugin-transform-react-pure-annotations/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-PLgBVk3fzbmEjBJ/u8kFzOqS9tUeDjiaWud/rRym/yjCo/M9cASPlnrd2ZmmZpQT40fOOrvR8jh+n8jikrOhNA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-module-transforms': 7.26.0_@babel+core@7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/core': 7.24.7
+      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-named-capturing-groups-regex/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-oqB6WHdKTGl3q/ItQhpLSnWWOpjUJLsOCLVyeFgeTktkBSCiurvPOsyt93gibI9CmuKvTUEtWmG5VhZD+5T/KA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-create-regexp-features-plugin': 7.25.9_@babel+core@7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-    dev: true
-
-  /@babel/plugin-transform-new-target/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-U/3p8X1yCSoKyUj2eOBIx3FOn6pElFOKvAAGf8HTtItuPyB+ZeOqfn+mvTtg9ZlOAjsPdK3ayQEjqHjU/yLeVQ==}
+  /@babel/plugin-transform-regenerator/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-lq3fvXPdimDrlg6LWBoqj+r/DEWgONuwjuOuQCSYgRroXDH/IdM1C0IZf59fL5cHLpjEH/O6opIRBbqv7ELnuA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-    dev: true
-
-  /@babel/plugin-transform-nullish-coalescing-operator/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-ENfftpLZw5EItALAD4WsY/KUWvhUlZndm5GC7G3evUsVeSJB6p0pBeLQUnRnBCBx7zV0RKQjR9kCuwrsIrjWog==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-    dev: true
-
-  /@babel/plugin-transform-numeric-separator/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-TlprrJ1GBZ3r6s96Yq8gEQv82s8/5HnCVHtEJScUj90thHQbwe+E5MLhi2bbNHBEJuzrvltXSru+BUxHDoog7Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-    dev: true
-
-  /@babel/plugin-transform-object-rest-spread/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-fSaXafEE9CVHPweLYw4J0emp1t8zYTXyzN3UuG+lylqkvYd7RMrsOQ8TYx5RF231be0vqtFC6jnx3UmpJmKBYg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-compilation-targets': 7.25.9
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/plugin-transform-parameters': 7.25.9_@babel+core@7.26.0
-    dev: true
-
-  /@babel/plugin-transform-object-super/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-Kj/Gh+Rw2RNLbCK1VAWj2U48yxxqL2x0k10nPtSdRa0O2xnHXalD0s+o1A6a0W43gJ00ANo38jxkQreckOzv5A==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/helper-replace-supers': 7.25.9_@babel+core@7.26.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-optional-catch-binding/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-qM/6m6hQZzDcZF3onzIhZeDHDO43bkNNlOX0i8n3lR6zLbu0GN2d8qfM/IERJZYauhAHSLHy39NF0Ctdvcid7g==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-    dev: true
-
-  /@babel/plugin-transform-optional-chaining/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-6AvV0FsLULbpnXeBjrY4dmWF8F7gf8QnvTEoO/wX/5xm/xE1Xo8oPuD3MPS+KS9f9XBEAWN7X1aWr4z9HdOr7A==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-parameters/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-wzz6MKwpnshBAiRmn4jR8LYz/g8Ksg0o80XmwZDlordjwEk9SxBzTWC7F5ef1jhbrbOW2DJ5J6ayRukrJmnr0g==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-    dev: true
-
-  /@babel/plugin-transform-private-methods/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-D/JUozNpQLAPUVusvqMxyvjzllRaF8/nSrP1s2YGQT/W4LHK4xxsMcHjhOGTS01mp9Hda8nswb+FblLdJornQw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-create-class-features-plugin': 7.25.9_@babel+core@7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-private-property-in-object/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-Evf3kcMqzXA3xfYJmZ9Pg1OvKdtqsDMSWBDzZOPLvHiTt36E75jLDQo5w1gtRU95Q4E5PDttrTf25Fw8d/uWLw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-create-class-features-plugin': 7.25.9_@babel+core@7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-property-literals/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-IvIUeV5KrS/VPavfSM/Iu+RE6llrHrYIKY1yfCzyO/lMXHQ+p7uGhonmGVisv6tSBSVgWzMBohTcvkC9vQcQFA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-    dev: true
-
-  /@babel/plugin-transform-react-constant-elements/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-Ncw2JFsJVuvfRsa2lSHiC55kETQVLSnsYGQ1JDDwkUeWGTL/8Tom8aLTnlqgoeuopWrbbGndrc9AlLYrIosrow==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-    dev: true
-
-  /@babel/plugin-transform-react-display-name/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-KJfMlYIUxQB1CJfO3e0+h0ZHWOTLCPP115Awhaz8U0Zpq36Gl/cXlpoyMRnUWlhNUBAzldnCiAZNvCDj7CrKxQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-    dev: true
-
-  /@babel/plugin-transform-react-jsx-development/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-9mj6rm7XVYs4mdLIpbZnHOYdpW42uoiBCTVowg7sP1thUOiANgMb4UtpRivR0pp5iL+ocvUv7X4mZgFRpJEzGw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/plugin-transform-react-jsx': 7.25.9_@babel+core@7.26.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-react-jsx/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-s5XwpQYCqGerXl+Pu6VDL3x0j2d82eiV77UJ8a2mDHAW7j9SWRqQ2y1fNo1Z74CdcYipl5Z41zvjj4Nfzq36rw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-module-imports': 7.25.9
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/plugin-syntax-jsx': 7.25.9_@babel+core@7.26.0
-      '@babel/types': 7.26.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-react-pure-annotations/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-KQ/Takk3T8Qzj5TppkS1be588lkbTp5uj7w6a0LeQaTMSckU/wK0oJ/pih+T690tkgI5jfmg2TqDJvd41Sj1Cg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-plugin-utils': 7.25.9
-    dev: true
-
-  /@babel/plugin-transform-regenerator/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-vwDcDNsgMPDGP0nMqzahDWE5/MLcX8sv96+wfX7as7LoF/kr97Bo/7fI00lXY4wUXYfVmwIIyG80fGZ1uvt2qg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
       regenerator-transform: 0.15.2
     dev: true
 
-  /@babel/plugin-transform-regexp-modifiers/7.26.0_@babel+core@7.26.0:
-    resolution: {integrity: sha512-vN6saax7lrA2yA/Pak3sCxuD6F5InBjn9IcrIKQPjpsLvuHYLVroTxjdlVRHjjBWxKOqIwpTXDkOssYT4BFdRw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-create-regexp-features-plugin': 7.25.9_@babel+core@7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-    dev: true
-
-  /@babel/plugin-transform-reserved-words/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-7DL7DKYjn5Su++4RXu8puKZm2XBPHyjWLUidaPEkCUBbE7IPcsrkRHggAOOKydH1dASWdcUBxrkOGNxUv5P3Jg==}
+  /@babel/plugin-transform-reserved-words/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-0DUq0pHcPKbjFZCfTss/pGkYMfy3vFWydkUBd9r0GHpIyfs2eCDENvqadMycRS9wZCXR41wucAfJHJmwA0UmoQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-runtime/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-nZp7GlEl+yULJrClz0SwHPqir3lc0zsPrDHQUcxGspSL7AKrexNSEfTbfqnDNJUO13bgKyfuOLMF8Xqtu8j3YQ==}
+  /@babel/plugin-transform-runtime/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-YqXjrk4C+a1kZjewqt+Mmu2UuV1s07y8kqcUf4qYLnoqemhR4gRQikhdAhSVJioMjVTu6Mo6pAbaypEA3jY6fw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-module-imports': 7.25.9
-      '@babel/helper-plugin-utils': 7.25.9
-      babel-plugin-polyfill-corejs2: 0.4.11_@babel+core@7.26.0
-      babel-plugin-polyfill-corejs3: 0.10.6_@babel+core@7.26.0
-      babel-plugin-polyfill-regenerator: 0.6.2_@babel+core@7.26.0
+      '@babel/core': 7.24.7
+      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      babel-plugin-polyfill-corejs2: 0.4.11_@babel+core@7.24.7
+      babel-plugin-polyfill-corejs3: 0.10.4_@babel+core@7.24.7
+      babel-plugin-polyfill-regenerator: 0.6.2_@babel+core@7.24.7
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-shorthand-properties/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-MUv6t0FhO5qHnS/W8XCbHmiRWOphNufpE1IVxhK5kuN3Td9FT1x4rx4K42s3RYdMXCXpfWkGSbCSd0Z64xA7Ng==}
+  /@babel/plugin-transform-shorthand-properties/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-KsDsevZMDsigzbA09+vacnLpmPH4aWjcZjXdyFKGzpplxhbeB4wYtury3vglQkg6KM/xEPKt73eCjPPf1PgXBA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-spread/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-oNknIB0TbURU5pqJFVbOOFspVlrpVwo2H1+HUIsVDvp5VauGGDP1ZEvO8Nn5xyMEs3dakajOxlmkNW7kNgSm6A==}
+  /@babel/plugin-transform-spread/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-x96oO0I09dgMDxJaANcRyD4ellXFLLiWhuwDxKZX5g2rWP1bTPkBSwCYv96VDXVT1bD9aPj8tppr5ITIh8hBng==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-sticky-regex/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-WqBUSgeVwucYDP9U/xNRQam7xV8W5Zf+6Eo7T2SRVUFlhRiMNFdFz58u0KZmCVVqs2i7SHgpRnAhzRNmKfi2uA==}
+  /@babel/plugin-transform-sticky-regex/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-kHPSIJc9v24zEml5geKg9Mjx5ULpfncj0wRpYtxbvKyTtHCYDkVE3aHQ03FrpEo4gEe2vrJJS1Y9CJTaThA52g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-template-literals/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-o97AE4syN71M/lxrCtQByzphAdlYluKPDBzDVzMmfCobUjjhAryZV0AIpRPrxN0eAkxXO6ZLEScmt+PNhj2OTw==}
+  /@babel/plugin-transform-template-literals/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-AfDTQmClklHCOLxtGoP7HkeMw56k1/bTQjwsfhL6pppo/M4TOBSq+jjBUBLmV/4oeFg4GWMavIl44ZeCtmmZTw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-typeof-symbol/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-v61XqUMiueJROUv66BVIOi0Fv/CUuZuZMl5NkRoCVxLAnMexZ0A3kMe7vvZ0nulxMuMp0Mk6S5hNh48yki08ZA==}
+  /@babel/plugin-transform-typeof-symbol/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-VtR8hDy7YLB7+Pet9IarXjg/zgCMSF+1mNS/EQEiEaUPoFXCVsHG64SIxcaaI2zJgRiv+YmgaQESUfWAdbjzgg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-typescript/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-7PbZQZP50tzv2KGGnhh82GSyMB01yKY9scIjf1a+GfZCtInOWqUH5+1EBU4t9fyR5Oykkkc9vFTs4OHrhHXljQ==}
+  /@babel/plugin-transform-typescript/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-iLD3UNkgx2n/HrjBesVbYX6j0yqn/sJktvbtKKgcaLIQ4bTTQ8obAypc1VpyHPD2y4Phh9zHOaAt8e/L14wCpw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-create-class-features-plugin': 7.25.9_@babel+core@7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
-      '@babel/plugin-syntax-typescript': 7.25.9_@babel+core@7.26.0
+      '@babel/core': 7.24.7
+      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-create-class-features-plugin': 7.24.7_@babel+core@7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-typescript': 7.24.7_@babel+core@7.24.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-unicode-escapes/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-s5EDrE6bW97LtxOcGj1Khcx5AaXwiMmi4toFWRDP9/y0Woo6pXC+iyPu/KuhKtfSrNFd7jJB+/fkOtZy6aIC6Q==}
+  /@babel/plugin-transform-unicode-escapes/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-U3ap1gm5+4edc2Q/P+9VrBNhGkfnf+8ZqppY71Bo/pzZmXhhLdqgaUl6cuB07O1+AQJtCLfaOmswiNbSQ9ivhw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-unicode-property-regex/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-Jt2d8Ga+QwRluxRQ307Vlxa6dMrYEMZCgGxoPR8V52rxPyldHu3hdlHspxaqYmE7oID5+kB+UKUB/eWS+DkkWg==}
+  /@babel/plugin-transform-unicode-property-regex/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-uH2O4OV5M9FZYQrwc7NdVmMxQJOCCzFeYudlZSzUAHRFeOujQefa92E74TQDVskNHCzOXoigEuoyzHDhaEaK5w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-create-regexp-features-plugin': 7.25.9_@babel+core@7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-create-regexp-features-plugin': 7.24.7_@babel+core@7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-unicode-regex/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-yoxstj7Rg9dlNn9UQxzk4fcNivwv4nUYz7fYXBaKxvw/lnmPuOm/ikoELygbYq68Bls3D/D+NBPHiLwZdZZ4HA==}
+  /@babel/plugin-transform-unicode-regex/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-hlQ96MBZSAXUq7ltkjtu3FJCCSMx/j629ns3hA3pXnBXjanNP0LHi+JpPeA81zaWgVK1VGH95Xuy7u0RyQ8kMg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-create-regexp-features-plugin': 7.25.9_@babel+core@7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-create-regexp-features-plugin': 7.24.7_@babel+core@7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-unicode-sets-regex/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-8BYqO3GeVNHtx69fdPshN3fnzUNLrWdHhk/icSwigksJGczKSizZ+Z6SBCxTs723Fr5VSNorTIK7a+R2tISvwQ==}
+  /@babel/plugin-transform-unicode-sets-regex/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-2G8aAvF4wy1w/AGZkemprdGMRg5o6zPNhbHVImRz3lss55TYCBd6xStN19rt8XJHq20sqV0JbyWjOWwQRwV/wg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-create-regexp-features-plugin': 7.25.9_@babel+core@7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/core': 7.24.7
+      '@babel/helper-create-regexp-features-plugin': 7.24.7_@babel+core@7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/preset-env/7.26.0_@babel+core@7.26.0:
-    resolution: {integrity: sha512-H84Fxq0CQJNdPFT2DrfnylZ3cf5K43rGfWK4LJGPpjKHiZlk0/RzwEus3PDDZZg+/Er7lCA03MVacueUuXdzfw==}
+  /@babel/preset-env/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-1YZNsc+y6cTvWlDHidMBsQZrZfEFjRIo/BZCT906PMdzOyXtSLTgqGdrpcuTDCXyd11Am5uQULtDIcCfnTc8fQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.26.2
-      '@babel/core': 7.26.0
-      '@babel/helper-compilation-targets': 7.25.9
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/helper-validator-option': 7.25.9
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2_@babel+core@7.26.0
-      '@babel/plugin-syntax-import-assertions': 7.26.0_@babel+core@7.26.0
-      '@babel/plugin-syntax-import-attributes': 7.26.0_@babel+core@7.26.0
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6_@babel+core@7.26.0
-      '@babel/plugin-transform-arrow-functions': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-async-generator-functions': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-async-to-generator': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-block-scoped-functions': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-block-scoping': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-class-properties': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-class-static-block': 7.26.0_@babel+core@7.26.0
-      '@babel/plugin-transform-classes': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-computed-properties': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-destructuring': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-dotall-regex': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-duplicate-keys': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-dynamic-import': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-exponentiation-operator': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-export-namespace-from': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-for-of': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-function-name': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-json-strings': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-literals': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-logical-assignment-operators': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-member-expression-literals': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-modules-amd': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-modules-commonjs': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-modules-systemjs': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-modules-umd': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-new-target': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-numeric-separator': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-object-rest-spread': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-object-super': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-optional-catch-binding': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-optional-chaining': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-parameters': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-private-methods': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-private-property-in-object': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-property-literals': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-regenerator': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-regexp-modifiers': 7.26.0_@babel+core@7.26.0
-      '@babel/plugin-transform-reserved-words': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-shorthand-properties': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-spread': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-sticky-regex': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-template-literals': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-typeof-symbol': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-unicode-escapes': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-unicode-property-regex': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-unicode-regex': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-unicode-sets-regex': 7.25.9_@babel+core@7.26.0
-      '@babel/preset-modules': 0.1.6-no-external-plugins_@babel+core@7.26.0
-      babel-plugin-polyfill-corejs2: 0.4.11_@babel+core@7.26.0
-      babel-plugin-polyfill-corejs3: 0.10.6_@babel+core@7.26.0
-      babel-plugin-polyfill-regenerator: 0.6.2_@babel+core@7.26.0
-      core-js-compat: 3.39.0
+      '@babel/compat-data': 7.24.7
+      '@babel/core': 7.24.7
+      '@babel/helper-compilation-targets': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-validator-option': 7.24.7
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2_@babel+core@7.24.7
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.24.7
+      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.24.7
+      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.24.7
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.24.7
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.24.7
+      '@babel/plugin-syntax-import-assertions': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-syntax-import-attributes': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.24.7
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.24.7
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.24.7
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.24.7
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.24.7
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.24.7
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.24.7
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.24.7
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.24.7
+      '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.24.7
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6_@babel+core@7.24.7
+      '@babel/plugin-transform-arrow-functions': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-async-generator-functions': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-async-to-generator': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-block-scoped-functions': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-block-scoping': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-class-properties': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-class-static-block': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-classes': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-computed-properties': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-destructuring': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-dotall-regex': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-duplicate-keys': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-dynamic-import': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-exponentiation-operator': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-export-namespace-from': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-for-of': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-function-name': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-json-strings': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-literals': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-logical-assignment-operators': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-member-expression-literals': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-modules-amd': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-modules-commonjs': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-modules-systemjs': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-modules-umd': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-new-target': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-numeric-separator': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-object-rest-spread': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-object-super': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-optional-catch-binding': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-optional-chaining': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-parameters': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-private-methods': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-private-property-in-object': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-property-literals': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-regenerator': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-reserved-words': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-shorthand-properties': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-spread': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-sticky-regex': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-template-literals': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-typeof-symbol': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-unicode-escapes': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-unicode-property-regex': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-unicode-regex': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-unicode-sets-regex': 7.24.7_@babel+core@7.24.7
+      '@babel/preset-modules': 0.1.6-no-external-plugins_@babel+core@7.24.7
+      babel-plugin-polyfill-corejs2: 0.4.11_@babel+core@7.24.7
+      babel-plugin-polyfill-corejs3: 0.10.4_@babel+core@7.24.7
+      babel-plugin-polyfill-regenerator: 0.6.2_@babel+core@7.24.7
+      core-js-compat: 3.37.1
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/preset-modules/0.1.6-no-external-plugins_@babel+core@7.26.0:
+  /@babel/preset-modules/0.1.6-no-external-plugins_@babel+core@7.24.7:
     resolution: {integrity: sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/types': 7.26.0
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/types': 7.24.7
       esutils: 2.0.3
     dev: true
 
-  /@babel/preset-react/7.25.9_@babel+core@7.26.0:
-    resolution: {integrity: sha512-D3to0uSPiWE7rBrdIICCd0tJSIGpLaaGptna2+w7Pft5xMqLpA1sz99DK5TZ1TjGbdQ/VI1eCSZ06dv3lT4JOw==}
+  /@babel/preset-react/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-AAH4lEkpmzFWrGVlHaxJB7RLH21uPQ9+He+eFLWHmF9IuFQVugz8eAsamaW0DXRrTfco5zj1wWtpdcXJUOfsag==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/helper-validator-option': 7.25.9
-      '@babel/plugin-transform-react-display-name': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-react-jsx': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-react-jsx-development': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-react-pure-annotations': 7.25.9_@babel+core@7.26.0
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-validator-option': 7.24.7
+      '@babel/plugin-transform-react-display-name': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-react-jsx': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-react-jsx-development': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-react-pure-annotations': 7.24.7_@babel+core@7.24.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/preset-typescript/7.26.0_@babel+core@7.26.0:
-    resolution: {integrity: sha512-NMk1IGZ5I/oHhoXEElcm+xUnL/szL6xflkFZmoEU9xj1qSJXpiS7rsspYo92B4DRCDvZn2erT5LdsCeXAKNCkg==}
+  /@babel/preset-typescript/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-SyXRe3OdWwIwalxDg5UtJnJQO+YPcTfwiIY2B0Xlddh9o7jpWLvv8X1RthIeDOxQ+O1ML5BLPCONToObyVQVuQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/helper-validator-option': 7.25.9
-      '@babel/plugin-syntax-jsx': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-modules-commonjs': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-typescript': 7.25.9_@babel+core@7.26.0
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-validator-option': 7.24.7
+      '@babel/plugin-syntax-jsx': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-modules-commonjs': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-typescript': 7.24.7_@babel+core@7.24.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/runtime/7.26.0:
-    resolution: {integrity: sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==}
+  /@babel/regjsgen/0.8.0:
+    resolution: {integrity: sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==}
+    dev: true
+
+  /@babel/runtime/7.24.7:
+    resolution: {integrity: sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.14.1
 
-  /@babel/template/7.25.9:
-    resolution: {integrity: sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==}
+  /@babel/template/7.24.7:
+    resolution: {integrity: sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.26.2
-      '@babel/parser': 7.26.2
-      '@babel/types': 7.26.0
-    dev: true
+      '@babel/code-frame': 7.24.7
+      '@babel/parser': 7.24.7
+      '@babel/types': 7.24.7
 
-  /@babel/traverse/7.25.9:
-    resolution: {integrity: sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==}
+  /@babel/traverse/7.24.7:
+    resolution: {integrity: sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.26.2
-      '@babel/generator': 7.26.2
-      '@babel/parser': 7.26.2
-      '@babel/template': 7.25.9
-      '@babel/types': 7.26.0
-      debug: 4.3.7
+      '@babel/code-frame': 7.24.7
+      '@babel/generator': 7.24.7
+      '@babel/helper-environment-visitor': 7.24.7
+      '@babel/helper-function-name': 7.24.7
+      '@babel/helper-hoist-variables': 7.24.7
+      '@babel/helper-split-export-declaration': 7.24.7
+      '@babel/parser': 7.24.7
+      '@babel/types': 7.24.7
+      debug: 4.3.5
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
-  /@babel/types/7.26.0:
-    resolution: {integrity: sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==}
+  /@babel/types/7.24.7:
+    resolution: {integrity: sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-string-parser': 7.25.9
-      '@babel/helper-validator-identifier': 7.25.9
-    dev: true
+      '@babel/helper-string-parser': 7.24.7
+      '@babel/helper-validator-identifier': 7.24.7
+      to-fast-properties: 2.0.0
 
   /@bcoe/v8-coverage/0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -2308,8 +2336,8 @@ packages:
   /@bentley/icons-generic/1.0.34:
     resolution: {integrity: sha512-IIs1wDcY2oZ8tJ3EZRw0U51M+0ZL3MvwoDYYmhUXaa9/UZqpFoOyLBGaxjirQteWXqTIMm3mFvmC+Nbn1ok4Iw==}
 
-  /@bentley/imodeljs-native/4.9.35:
-    resolution: {integrity: sha512-45MM6aYmcMpg81SyNtdRZ2z2e+lFSresnrvsPO/28mC/79k1WHk727R8B3OglvR9/Qob6rX0rG1lC+POeodUHQ==}
+  /@bentley/imodeljs-native/4.7.29:
+    resolution: {integrity: sha512-zJNHKurImoPk+8DbTUFAs6Pph56c1do/S/eFRfqnKPcxQGS6nfvrxBWyEulwmslnt1zMYdB766+myuJlPVXxFw==}
     requiresBuild: true
 
   /@bentley/react-scripts/5.0.7_pe74uhjrq4tiyv4442ml54dfiu:
@@ -2323,62 +2351,62 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@babel/core': 7.26.0
-      '@itwin/core-webpack-tools': 3.8.0_webpack@5.95.0
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15_e3ej43g5iw5szlea4i3o2x6iq4
+      '@babel/core': 7.24.7
+      '@itwin/core-webpack-tools': 3.8.0_webpack@5.92.1
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15_zciuhk7ajont242gc253fauh24
       '@svgr/webpack': 6.5.1
-      babel-jest: 27.5.1_@babel+core@7.26.0
-      babel-loader: 8.4.1_i3bi27r3gwde5aemtthvmmugoi
+      babel-jest: 27.5.1_@babel+core@7.24.7
+      babel-loader: 8.3.0_z5hqyrl7ys5omqq6tawbtvekhm
       babel-plugin-import-remove-resource-query: 1.0.0
-      babel-plugin-named-asset-import: 0.3.8_@babel+core@7.26.0
+      babel-plugin-named-asset-import: 0.3.8_@babel+core@7.24.7
       babel-preset-react-app: 10.0.1
       bfj: 7.1.0
-      browserslist: 4.24.2
+      browserslist: 4.23.2
       camelcase: 6.3.0
       case-sensitive-paths-webpack-plugin: 2.4.0
-      copy-webpack-plugin: 10.2.4_webpack@5.95.0
-      css-loader: 6.11.0_webpack@5.95.0
-      css-minimizer-webpack-plugin: 3.4.1_webpack@5.95.0
+      copy-webpack-plugin: 10.2.4_webpack@5.92.1
+      css-loader: 6.11.0_webpack@5.92.1
+      css-minimizer-webpack-plugin: 3.4.1_webpack@5.92.1
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
-      eslint: 8.57.1
-      eslint-config-react-app: 7.0.1_l6sf7e4olydjhtf3qe76zuqhfi
-      eslint-webpack-plugin: 3.2.0_23g3mlqifdeyf7a5itkkqemkee
-      fast-sass-loader: 2.0.1_sass@1.80.5+webpack@5.95.0
-      file-loader: 6.2.0_webpack@5.95.0
+      eslint: 8.57.0
+      eslint-config-react-app: 7.0.1_rxydg5byhhw2ikqe4ecaedklea
+      eslint-webpack-plugin: 3.2.0_2razpbuuqgklq63beclqevrxh4
+      fast-sass-loader: 2.0.1_sass@1.77.7+webpack@5.92.1
+      file-loader: 6.2.0_webpack@5.92.1
       fs-extra: 10.1.0
-      html-webpack-plugin: 5.6.3_webpack@5.95.0
+      html-webpack-plugin: 5.6.0_webpack@5.92.1
       identity-obj-proxy: 3.0.0
       jest: 27.5.1
       jest-resolve: 27.5.1
       jest-watch-typeahead: 1.1.0_jest@27.5.1
-      mini-css-extract-plugin: 2.9.1_webpack@5.95.0
-      postcss: 8.4.47
-      postcss-flexbugs-fixes: 5.0.2_postcss@8.4.47
-      postcss-loader: 6.2.1_ttspydkdwnlpk544tqarzu6cim
-      postcss-normalize: 10.0.1_22bcdb3nr4qkkg7bvewmb25sri
-      postcss-preset-env: 7.8.3_postcss@8.4.47
+      mini-css-extract-plugin: 2.9.0_webpack@5.92.1
+      postcss: 8.4.39
+      postcss-flexbugs-fixes: 5.0.2_postcss@8.4.39
+      postcss-loader: 6.2.1_h7ybz3vosd2sabh3expkxy422u
+      postcss-normalize: 10.0.1_73z3fjs2jrhgsuowbj3qmsq6yu
+      postcss-preset-env: 7.8.3_postcss@8.4.39
       prompts: 2.4.2
       react: 18.3.1
       react-app-polyfill: 3.0.0
-      react-dev-utils: 12.0.1_z6tosmbba6a4h5dofl3zomc5vu
+      react-dev-utils: 12.0.1_vmohbas7cixbs7dvjlkwhs5g3i
       react-refresh: 0.11.0
       resolve: 1.22.8
       resolve-url-loader: 4.0.0
-      sass: 1.80.5
-      sass-loader: 12.6.0_sass@1.80.5+webpack@5.95.0
-      semver: 7.6.3
-      source-map-loader: 3.0.2_webpack@5.95.0
-      style-loader: 3.3.4_webpack@5.95.0
+      sass: 1.77.7
+      sass-loader: 12.6.0_sass@1.77.7+webpack@5.92.1
+      semver: 7.6.2
+      source-map-loader: 3.0.2_webpack@5.92.1
+      style-loader: 3.3.4_webpack@5.92.1
       svg-sprite-loader: 6.0.11
-      tailwindcss: 3.4.14
-      terser-webpack-plugin: 5.3.10_webpack@5.95.0
-      ts-jest: 27.1.5_6i3m6jxo354ochmqovrdrplut4
+      tailwindcss: 3.4.4
+      terser-webpack-plugin: 5.3.10_webpack@5.92.1
+      ts-jest: 27.1.5_ffc5qouy45v3zjlzng7flfczky
       typescript: 5.0.4
-      webpack: 5.95.0
-      webpack-dev-server: 4.15.2_webpack@5.95.0
-      webpack-manifest-plugin: 4.1.1_webpack@5.95.0
-      workbox-webpack-plugin: 6.6.0_webpack@5.95.0
+      webpack: 5.92.1
+      webpack-dev-server: 4.15.2_webpack@5.92.1
+      webpack-manifest-plugin: 4.1.1_webpack@5.92.1
+      workbox-webpack-plugin: 6.6.0_webpack@5.92.1
     optionalDependencies:
       fsevents: 2.3.3
     transitivePeerDependencies:
@@ -2418,164 +2446,164 @@ packages:
     resolution: {integrity: sha512-YAYeJ+Xqh7fUou1d1j9XHl44BmsuThiTr4iNrgCQ3J27IbhXsxXDGZ1cXv8Qvs99d4rBbLiSKy3+WZiet32PcQ==}
     dev: true
 
-  /@csstools/postcss-cascade-layers/1.1.1_postcss@8.4.47:
+  /@csstools/postcss-cascade-layers/1.1.1_postcss@8.4.39:
     resolution: {integrity: sha512-+KdYrpKC5TgomQr2DlZF4lDEpHcoxnj5IGddYYfBWJAKfj1JtuHUIqMa+E1pJJ+z3kvDViWMqyqPlG4Ja7amQA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/selector-specificity': 2.2.0_j747yjqyvnzekvomyruvypt3ti
-      postcss: 8.4.47
-      postcss-selector-parser: 6.1.2
+      '@csstools/selector-specificity': 2.2.0_jbx4mus4njtel3ypyfykqgp6rq
+      postcss: 8.4.39
+      postcss-selector-parser: 6.1.0
     dev: true
 
-  /@csstools/postcss-color-function/1.1.1_postcss@8.4.47:
+  /@csstools/postcss-color-function/1.1.1_postcss@8.4.39:
     resolution: {integrity: sha512-Bc0f62WmHdtRDjf5f3e2STwRAl89N2CLb+9iAwzrv4L2hncrbDwnQD9PCq0gtAt7pOI2leIV08HIBUd4jxD8cw==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 1.3.0_postcss@8.4.47
-      postcss: 8.4.47
+      '@csstools/postcss-progressive-custom-properties': 1.3.0_postcss@8.4.39
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-font-format-keywords/1.0.1_postcss@8.4.47:
+  /@csstools/postcss-font-format-keywords/1.0.1_postcss@8.4.39:
     resolution: {integrity: sha512-ZgrlzuUAjXIOc2JueK0X5sZDjCtgimVp/O5CEqTcs5ShWBa6smhWYbS0x5cVc/+rycTDbjjzoP0KTDnUneZGOg==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-hwb-function/1.0.2_postcss@8.4.47:
+  /@csstools/postcss-hwb-function/1.0.2_postcss@8.4.39:
     resolution: {integrity: sha512-YHdEru4o3Rsbjmu6vHy4UKOXZD+Rn2zmkAmLRfPet6+Jz4Ojw8cbWxe1n42VaXQhD3CQUXXTooIy8OkVbUcL+w==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-ic-unit/1.0.1_postcss@8.4.47:
+  /@csstools/postcss-ic-unit/1.0.1_postcss@8.4.39:
     resolution: {integrity: sha512-Ot1rcwRAaRHNKC9tAqoqNZhjdYBzKk1POgWfhN4uCOE47ebGcLRqXjKkApVDpjifL6u2/55ekkpnFcp+s/OZUw==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 1.3.0_postcss@8.4.47
-      postcss: 8.4.47
+      '@csstools/postcss-progressive-custom-properties': 1.3.0_postcss@8.4.39
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-is-pseudo-class/2.0.7_postcss@8.4.47:
+  /@csstools/postcss-is-pseudo-class/2.0.7_postcss@8.4.39:
     resolution: {integrity: sha512-7JPeVVZHd+jxYdULl87lvjgvWldYu+Bc62s9vD/ED6/QTGjy0jy0US/f6BG53sVMTBJ1lzKZFpYmofBN9eaRiA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/selector-specificity': 2.2.0_j747yjqyvnzekvomyruvypt3ti
-      postcss: 8.4.47
-      postcss-selector-parser: 6.1.2
+      '@csstools/selector-specificity': 2.2.0_jbx4mus4njtel3ypyfykqgp6rq
+      postcss: 8.4.39
+      postcss-selector-parser: 6.1.0
     dev: true
 
-  /@csstools/postcss-nested-calc/1.0.0_postcss@8.4.47:
+  /@csstools/postcss-nested-calc/1.0.0_postcss@8.4.39:
     resolution: {integrity: sha512-JCsQsw1wjYwv1bJmgjKSoZNvf7R6+wuHDAbi5f/7MbFhl2d/+v+TvBTU4BJH3G1X1H87dHl0mh6TfYogbT/dJQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-normalize-display-values/1.0.1_postcss@8.4.47:
+  /@csstools/postcss-normalize-display-values/1.0.1_postcss@8.4.39:
     resolution: {integrity: sha512-jcOanIbv55OFKQ3sYeFD/T0Ti7AMXc9nM1hZWu8m/2722gOTxFg7xYu4RDLJLeZmPUVQlGzo4jhzvTUq3x4ZUw==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-oklab-function/1.1.1_postcss@8.4.47:
+  /@csstools/postcss-oklab-function/1.1.1_postcss@8.4.39:
     resolution: {integrity: sha512-nJpJgsdA3dA9y5pgyb/UfEzE7W5Ka7u0CX0/HIMVBNWzWemdcTH3XwANECU6anWv/ao4vVNLTMxhiPNZsTK6iA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 1.3.0_postcss@8.4.47
-      postcss: 8.4.47
+      '@csstools/postcss-progressive-custom-properties': 1.3.0_postcss@8.4.39
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-progressive-custom-properties/1.3.0_postcss@8.4.47:
+  /@csstools/postcss-progressive-custom-properties/1.3.0_postcss@8.4.39:
     resolution: {integrity: sha512-ASA9W1aIy5ygskZYuWams4BzafD12ULvSypmaLJT2jvQ8G0M3I8PRQhC0h7mG0Z3LI05+agZjqSR9+K9yaQQjA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.3
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-stepped-value-functions/1.0.1_postcss@8.4.47:
+  /@csstools/postcss-stepped-value-functions/1.0.1_postcss@8.4.39:
     resolution: {integrity: sha512-dz0LNoo3ijpTOQqEJLY8nyaapl6umbmDcgj4AD0lgVQ572b2eqA1iGZYTTWhrcrHztWDDRAX2DGYyw2VBjvCvQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-text-decoration-shorthand/1.0.0_postcss@8.4.47:
+  /@csstools/postcss-text-decoration-shorthand/1.0.0_postcss@8.4.39:
     resolution: {integrity: sha512-c1XwKJ2eMIWrzQenN0XbcfzckOLLJiczqy+YvfGmzoVXd7pT9FfObiSEfzs84bpE/VqfpEuAZ9tCRbZkZxxbdw==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-trigonometric-functions/1.0.2_postcss@8.4.47:
+  /@csstools/postcss-trigonometric-functions/1.0.2_postcss@8.4.39:
     resolution: {integrity: sha512-woKaLO///4bb+zZC2s80l+7cm07M7268MsyG3M0ActXXEFi6SuhvriQYcb58iiKGbjwwIU7n45iRLEHypB47Og==}
     engines: {node: ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-unset-value/1.0.2_postcss@8.4.47:
+  /@csstools/postcss-unset-value/1.0.2_postcss@8.4.39:
     resolution: {integrity: sha512-c8J4roPBILnelAsdLr4XOAR/GsTm0GJi4XpcfvoWk3U6KiTCqiFYc63KhRMQQX35jYMp4Ao8Ij9+IZRgMfJp1g==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
     dev: true
 
-  /@csstools/selector-specificity/2.2.0_j747yjqyvnzekvomyruvypt3ti:
+  /@csstools/selector-specificity/2.2.0_jbx4mus4njtel3ypyfykqgp6rq:
     resolution: {integrity: sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==}
     engines: {node: ^14 || ^16 || >=18}
     peerDependencies:
       postcss-selector-parser: ^6.0.10
     dependencies:
-      postcss-selector-parser: 6.1.2
+      postcss-selector-parser: 6.1.0
     dev: true
 
   /@electron/get/2.0.3:
     resolution: {integrity: sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==}
     engines: {node: '>=12'}
     dependencies:
-      debug: 4.3.7
+      debug: 4.3.5
       env-paths: 2.2.1
       fs-extra: 8.1.0
       got: 11.8.6
@@ -2586,6 +2614,88 @@ packages:
       global-agent: 3.0.0
     transitivePeerDependencies:
       - supports-color
+
+  /@emotion/babel-plugin/11.11.0:
+    resolution: {integrity: sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==}
+    dependencies:
+      '@babel/helper-module-imports': 7.24.7
+      '@babel/runtime': 7.24.7
+      '@emotion/hash': 0.9.1
+      '@emotion/memoize': 0.8.1
+      '@emotion/serialize': 1.1.4
+      babel-plugin-macros: 3.1.0
+      convert-source-map: 1.9.0
+      escape-string-regexp: 4.0.0
+      find-root: 1.1.0
+      source-map: 0.5.7
+      stylis: 4.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  /@emotion/cache/11.11.0:
+    resolution: {integrity: sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==}
+    dependencies:
+      '@emotion/memoize': 0.8.1
+      '@emotion/sheet': 1.2.2
+      '@emotion/utils': 1.2.1
+      '@emotion/weak-memoize': 0.3.1
+      stylis: 4.2.0
+
+  /@emotion/hash/0.9.1:
+    resolution: {integrity: sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==}
+
+  /@emotion/memoize/0.8.1:
+    resolution: {integrity: sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==}
+
+  /@emotion/react/11.11.4_3vdbhqr2ncalcx7opnshezpx3q:
+    resolution: {integrity: sha512-t8AjMlF0gHpvvxk5mAtCqR4vmxiGHCeJBaQO6gncUSdklELOgtwjerNY2yuJNfwnc6vi16U/+uMF+afIawJ9iw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.7
+      '@emotion/babel-plugin': 11.11.0
+      '@emotion/cache': 11.11.0
+      '@emotion/serialize': 1.1.4
+      '@emotion/use-insertion-effect-with-fallbacks': 1.0.1_react@18.3.1
+      '@emotion/utils': 1.2.1
+      '@emotion/weak-memoize': 0.3.1
+      '@types/react': 18.3.3
+      hoist-non-react-statics: 3.3.2
+      react: 18.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  /@emotion/serialize/1.1.4:
+    resolution: {integrity: sha512-RIN04MBT8g+FnDwgvIUi8czvr1LU1alUMI05LekWB5DGyTm8cCBMCRpq3GqaiyEDRptEXOyXnvZ58GZYu4kBxQ==}
+    dependencies:
+      '@emotion/hash': 0.9.1
+      '@emotion/memoize': 0.8.1
+      '@emotion/unitless': 0.8.1
+      '@emotion/utils': 1.2.1
+      csstype: 3.1.3
+
+  /@emotion/sheet/1.2.2:
+    resolution: {integrity: sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA==}
+
+  /@emotion/unitless/0.8.1:
+    resolution: {integrity: sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==}
+
+  /@emotion/use-insertion-effect-with-fallbacks/1.0.1_react@18.3.1:
+    resolution: {integrity: sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==}
+    peerDependencies:
+      react: '>=16.8.0'
+    dependencies:
+      react: 18.3.1
+
+  /@emotion/utils/1.2.1:
+    resolution: {integrity: sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg==}
+
+  /@emotion/weak-memoize/0.3.1:
+    resolution: {integrity: sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==}
 
   /@esbuild-plugins/node-globals-polyfill/0.1.1_esbuild@0.13.15:
     resolution: {integrity: sha512-MR0oAA+mlnJWrt1RQVQ+4VYuRJW/P2YmRTv1AsplObyvuBMnPHiizUF95HHYiSsMGLhyGtWufaq2XQg6+iurBg==}
@@ -2605,18 +2715,18 @@ packages:
       rollup-plugin-node-polyfills: 0.2.1
     dev: true
 
-  /@eslint-community/eslint-utils/4.4.1_eslint@8.57.1:
-    resolution: {integrity: sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==}
+  /@eslint-community/eslint-utils/4.4.0_eslint@8.57.0:
+    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
     dependencies:
-      eslint: 8.57.1
+      eslint: 8.57.0
       eslint-visitor-keys: 3.4.3
     dev: true
 
-  /@eslint-community/regexpp/4.12.1:
-    resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
+  /@eslint-community/regexpp/4.11.0:
+    resolution: {integrity: sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
     dev: true
 
@@ -2625,7 +2735,7 @@ packages:
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.7
+      debug: 4.3.5
       espree: 7.3.1
       globals: 13.24.0
       ignore: 4.0.6
@@ -2642,10 +2752,10 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.7
+      debug: 4.3.5
       espree: 9.6.1
       globals: 13.24.0
-      ignore: 5.3.2
+      ignore: 5.3.1
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       minimatch: 3.1.2
@@ -2654,54 +2764,54 @@ packages:
       - supports-color
     dev: true
 
-  /@eslint/js/8.57.1:
-    resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
+  /@eslint/js/8.57.0:
+    resolution: {integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@floating-ui/core/1.6.8:
-    resolution: {integrity: sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==}
+  /@floating-ui/core/1.6.4:
+    resolution: {integrity: sha512-a4IowK4QkXl4SCWTGUR0INAfEOX3wtsYw3rKK5InQEHMGObkR8Xk44qYQD9P4r6HHw0iIfK6GUKECmY8sTkqRA==}
     dependencies:
-      '@floating-ui/utils': 0.2.8
+      '@floating-ui/utils': 0.2.4
 
-  /@floating-ui/dom/1.6.12:
-    resolution: {integrity: sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w==}
+  /@floating-ui/dom/1.6.7:
+    resolution: {integrity: sha512-wmVfPG5o2xnKDU4jx/m4w5qva9FWHcnZ8BvzEe90D/RpwsJaTAVYPEPdQ8sbr/N8zZTAHlZUTQdqg8ZUbzHmng==}
     dependencies:
-      '@floating-ui/core': 1.6.8
-      '@floating-ui/utils': 0.2.8
+      '@floating-ui/core': 1.6.4
+      '@floating-ui/utils': 0.2.4
 
-  /@floating-ui/react-dom/2.1.2_nnrd3gsncyragczmpvfhocinkq:
-    resolution: {integrity: sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==}
+  /@floating-ui/react-dom/2.1.1_nnrd3gsncyragczmpvfhocinkq:
+    resolution: {integrity: sha512-4h84MJt3CHrtG18mGsXuLCHMrug49d7DFkU0RMIyshRveBeyV2hmV/pDaF2Uxtu8kgq5r46llp5E5FQiR0K2Yg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
-      '@floating-ui/dom': 1.6.12
+      '@floating-ui/dom': 1.6.7
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
 
-  /@floating-ui/react/0.26.26_nnrd3gsncyragczmpvfhocinkq:
-    resolution: {integrity: sha512-iv2BjdcyoF1j1708Z9CrGtMc9ZZvMPZnDqyB1FrSWYCi+/nlPArUO/u9QhwC4E1Pi4T0g18GZ4W702m0NDh9bw==}
+  /@floating-ui/react/0.26.19_nnrd3gsncyragczmpvfhocinkq:
+    resolution: {integrity: sha512-Jk6zITdjjIvjO/VdQFvpRaD3qPwOHH6AoDHxjhpy+oK4KFgaSP871HYWUAPdnLmx1gQ+w/pB312co3tVml+BXA==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
-      '@floating-ui/react-dom': 2.1.2_nnrd3gsncyragczmpvfhocinkq
-      '@floating-ui/utils': 0.2.8
+      '@floating-ui/react-dom': 2.1.1_nnrd3gsncyragczmpvfhocinkq
+      '@floating-ui/utils': 0.2.4
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
       tabbable: 6.2.0
 
-  /@floating-ui/utils/0.2.8:
-    resolution: {integrity: sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==}
+  /@floating-ui/utils/0.2.4:
+    resolution: {integrity: sha512-dWO2pw8hhi+WrXq1YJy2yCuWoL20PddgGaqTgVe4cOS9Q6qklXCiA1tJEqX6BEwRNSCP84/afac9hd4MS+zEUA==}
 
-  /@humanwhocodes/config-array/0.13.0:
-    resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
+  /@humanwhocodes/config-array/0.11.14:
+    resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
     engines: {node: '>=10.10.0'}
     deprecated: Use @eslint/config-array instead
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.7
+      debug: 4.3.5
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -2713,7 +2823,7 @@ packages:
     deprecated: Use @eslint/config-array instead
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.7
+      debug: 4.3.5
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -2762,14 +2872,14 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /@itwin/appui-abstract/4.9.5_@itwin+core-bentley@4.9.5:
-    resolution: {integrity: sha512-bFSe3Ewj5SGg5xW7VDjAr4znQQv8h/QkHhhcrTy2JmgRVONurz/PvyY1CeAiQL0wussrEU+t0vvd00zvLBWIgw==}
+  /@itwin/appui-abstract/4.7.4_@itwin+core-bentley@4.7.4:
+    resolution: {integrity: sha512-TdJyrPknK2BoptszkSoFaApyCD1sqi9S7EE8LvEJ8/yLObq7Kma1gno5NXpZ0DnJVWvE16TQv2aRh/Bu2T75xw==}
     peerDependencies:
-      '@itwin/core-bentley': ^4.9.5
+      '@itwin/core-bentley': ^4.7.4
     dependencies:
-      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-bentley': 4.7.4
 
-  /@itwin/appui-layout-react/4.8.3_zs6rif5h5jixp3mcoeld6e43pu:
+  /@itwin/appui-layout-react/4.8.3_jscgs7su4cyo55wt5klvj3iepa:
     resolution: {integrity: sha512-7jyEefXWeOXMxREE5+dON2IJ3KercWz7xkMvHSXzHZARjedHZRZKgrgMM5QETrEsRNDixxp0em23mIzwCpVSRg==}
     peerDependencies:
       '@itwin/appui-abstract': ^3.7.0 || ^4.0.0
@@ -2778,10 +2888,10 @@ packages:
       react: ^17.0.0 || ^18.0.0
       react-dom: ^17.0.0 || ^18.0.0
     dependencies:
-      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-react': 4.17.2_b5szh4swag42x6ykxwn6buimra
-      '@itwin/itwinui-icons-react': 2.9.0_nnrd3gsncyragczmpvfhocinkq
+      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-react': 4.15.1_bpptdsfauwdziiwg4uklizbr74
+      '@itwin/itwinui-icons-react': 2.8.0_nnrd3gsncyragczmpvfhocinkq
       '@itwin/itwinui-variables': 2.1.2
       classnames: 2.3.1
       immer: 9.0.6
@@ -2789,45 +2899,45 @@ packages:
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
       react-transition-group: 4.4.5_nnrd3gsncyragczmpvfhocinkq
-      ts-key-enum: 2.0.13
-      zustand: 4.5.5_esssjoahjgjy6wmb4kavvr2kri
+      ts-key-enum: 2.0.12
+      zustand: 4.5.4_djzcoonmr6xkxvxv5wbacldipi
     transitivePeerDependencies:
       - '@types/react'
 
-  /@itwin/appui-react/4.17.2_ggnmyqo32cg3w26befg4w43y64:
-    resolution: {integrity: sha512-l84r68gOhkkB1kTyP5PK5q7yasA3awj2xorMVZDOQ5GYJ+fTohDF8u8BTqarrhb6YxsGySTQuma7UTqdW9G6Ug==}
+  /@itwin/appui-react/4.15.1_yrqai5hl5gvsf4dek6el5aloii:
+    resolution: {integrity: sha512-WwIDI0YgUjnlZjjJBMjWfrNsdcQKvXlu1RAhE8/8FkWejmwhrB+B07+15E4tDvCBAQpEyl1TroQo4pnfOmLpDg==}
     peerDependencies:
       '@itwin/appui-abstract': ^3.7.0 || ^4.0.0
-      '@itwin/components-react': ^4.17.2
+      '@itwin/components-react': ^4.15.1
       '@itwin/core-bentley': ^3.7.0 || ^4.0.0
       '@itwin/core-common': ^3.7.0 || ^4.0.0
       '@itwin/core-frontend': ^3.7.0 || ^4.0.0
       '@itwin/core-geometry': ^3.7.0 || ^4.0.0
       '@itwin/core-quantity': ^3.7.0 || ^4.0.0
-      '@itwin/core-react': ^4.17.2
+      '@itwin/core-react': ^4.15.1
       '@itwin/core-telemetry': ^3.7.0 || ^4.0.0
-      '@itwin/imodel-components-react': ^4.17.2
+      '@itwin/imodel-components-react': ^4.15.1
       react: ^17.0.0 || ^18.0.0
       react-dom: ^17.0.0 || ^18.0.0
       react-redux: ^7.2.2
       redux: ^4.1.0
     dependencies:
       '@bentley/icons-generic': 1.0.34
-      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/components-react': 4.17.2_zs6rif5h5jixp3mcoeld6e43pu
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
-      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
-      '@itwin/core-geometry': 4.9.5
-      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/core-react': 4.17.2_b5szh4swag42x6ykxwn6buimra
-      '@itwin/core-telemetry': 4.9.5_@itwin+core-geometry@4.9.5
-      '@itwin/imodel-components-react': 4.17.2_inn3jcow7lwqfeofdqhb3etkfi
-      '@itwin/itwinui-icons-react': 2.9.0_nnrd3gsncyragczmpvfhocinkq
+      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/components-react': 4.15.1_jscgs7su4cyo55wt5klvj3iepa
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
+      '@itwin/core-geometry': 4.7.4
+      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/core-react': 4.15.1_bpptdsfauwdziiwg4uklizbr74
+      '@itwin/core-telemetry': 4.7.4_@itwin+core-geometry@4.7.4
+      '@itwin/imodel-components-react': 4.15.1_avm2jbcgpodgccdhk4zetypeem
+      '@itwin/itwinui-icons-react': 2.8.0_nnrd3gsncyragczmpvfhocinkq
       '@itwin/itwinui-illustrations-react': 2.1.0_nnrd3gsncyragczmpvfhocinkq
-      '@itwin/itwinui-react': 3.15.5_vsw25juzkyj7spaf6wjn5upvjq
+      '@itwin/itwinui-react': 3.12.2_psuonouaqi5wuc37nxyknoubym
       '@itwin/itwinui-react-v2': /@itwin/itwinui-react/2.12.26_nnrd3gsncyragczmpvfhocinkq
-      '@itwin/itwinui-variables': 3.3.0
+      '@itwin/itwinui-variables': 3.2.0
       classnames: 2.3.1
       immer: 9.0.6
       lodash: 4.17.21
@@ -2838,36 +2948,36 @@ packages:
       react-transition-group: 4.4.5_nnrd3gsncyragczmpvfhocinkq
       redux: 4.2.1
       rxjs: 7.8.1
-      ts-key-enum: 2.0.13
+      ts-key-enum: 2.0.12
       use-sync-external-store: 1.2.2_react@18.3.1
-      zustand: 4.5.5_esssjoahjgjy6wmb4kavvr2kri
+      zustand: 4.5.4_djzcoonmr6xkxvxv5wbacldipi
     transitivePeerDependencies:
       - '@types/react'
 
-  /@itwin/browser-authorization/1.1.3_uihgl3rfhguqy2f4jpx67fyjwm:
-    resolution: {integrity: sha512-ErFv6QWp4FOR6jRKjKXYqzYTk3+9rOpMRjzsJs+P4QN6AYYeVY38gsIqAsPC7aj8bHpbHPsT2uzo5vw1/aMjlg==}
+  /@itwin/browser-authorization/1.1.2_7i4fuy3zzvrtjsnyekcav72ie4:
+    resolution: {integrity: sha512-OP27aV5nCYX3t+ux7E2Kzs/YDeMBMLWJFsa/m/u0gStaa+ywccIPCy6yVXMT9S2iB9kaRPrkdtLE2SkrjHndBg==}
     peerDependencies:
       '@itwin/core-bentley': ^3.3.0 || ^4.0.0
     dependencies:
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
-      oidc-client-ts: 2.4.1
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      oidc-client-ts: 2.4.0
     transitivePeerDependencies:
       - '@itwin/core-geometry'
     dev: false
 
-  /@itwin/build-tools/4.9.5:
-    resolution: {integrity: sha512-cXFXEwUs96get8JDJJOCZ49ffnv5RmtI+boBB4WHXu1fOxR0frDflfQrn/QfM+8faesfZ2wj6NZCRd+ZNrwM4Q==}
+  /@itwin/build-tools/4.7.4:
+    resolution: {integrity: sha512-eYMHVgTRfl1f+XGGZOiCWLTXFhd5m2P7hmMl4sI/RLxZ09iibgi8Ze5tqG4jF6ZRA/MCykOEcB/VKiIehogzXA==}
     hasBin: true
     dependencies:
-      '@microsoft/api-extractor': 7.47.11
+      '@microsoft/api-extractor': 7.40.6
       chalk: 3.0.0
       cpx2: 3.0.2
       cross-spawn: 7.0.3
       fs-extra: 8.1.0
       glob: 10.4.5
-      mocha: 10.8.2
-      mocha-junit-reporter: 2.2.1_mocha@10.8.2
+      mocha: 10.6.0
+      mocha-junit-reporter: 2.2.1_mocha@10.6.0
       rimraf: 3.0.2
       tree-kill: 1.2.2
       typedoc: 0.25.13_typescript@5.3.3
@@ -2880,18 +2990,18 @@ packages:
       - supports-color
     dev: true
 
-  /@itwin/build-tools/4.9.5_@types+node@18.19.62:
-    resolution: {integrity: sha512-cXFXEwUs96get8JDJJOCZ49ffnv5RmtI+boBB4WHXu1fOxR0frDflfQrn/QfM+8faesfZ2wj6NZCRd+ZNrwM4Q==}
+  /@itwin/build-tools/4.7.4_@types+node@18.19.39:
+    resolution: {integrity: sha512-eYMHVgTRfl1f+XGGZOiCWLTXFhd5m2P7hmMl4sI/RLxZ09iibgi8Ze5tqG4jF6ZRA/MCykOEcB/VKiIehogzXA==}
     hasBin: true
     dependencies:
-      '@microsoft/api-extractor': 7.47.11_@types+node@18.19.62
+      '@microsoft/api-extractor': 7.40.6_@types+node@18.19.39
       chalk: 3.0.0
       cpx2: 3.0.2
       cross-spawn: 7.0.3
       fs-extra: 8.1.0
       glob: 10.4.5
-      mocha: 10.8.2
-      mocha-junit-reporter: 2.2.1_mocha@10.8.2
+      mocha: 10.6.0
+      mocha-junit-reporter: 2.2.1_mocha@10.6.0
       rimraf: 3.0.2
       tree-kill: 1.2.2
       typedoc: 0.25.13_typescript@5.3.3
@@ -2903,78 +3013,85 @@ packages:
       - '@types/node'
       - supports-color
     dev: true
+
+  /@itwin/cloud-agnostic-core/2.2.4:
+    resolution: {integrity: sha512-RDo8m4wmfNQJHQGsiwoFSAzuYFHDTDtgSWE8cAyuLTVRFAUZhoIU7CTvP2auUaa3+2DwAI2Bmh1hOIS6n7AMFg==}
+    peerDependencies:
+      inversify: ^6.0.1
+      reflect-metadata: ^0.1.13
+
+  /@itwin/cloud-agnostic-core/2.2.4_gteov7on4oycvgy3jqh4tz3uta:
+    resolution: {integrity: sha512-RDo8m4wmfNQJHQGsiwoFSAzuYFHDTDtgSWE8cAyuLTVRFAUZhoIU7CTvP2auUaa3+2DwAI2Bmh1hOIS6n7AMFg==}
+    peerDependencies:
+      inversify: ^6.0.1
+      reflect-metadata: ^0.1.13
+    dependencies:
+      inversify: 6.0.2
+      reflect-metadata: 0.1.14
 
   /@itwin/cloud-agnostic-core/2.2.5:
     resolution: {integrity: sha512-pLEWIjQ4Z1kos7z6RWu/kG2lTEyojr906WVGAXKouxA/BobWuUlb1HG1/Zw8+SovA284wauKhHJsydRhYeddIQ==}
     peerDependencies:
       inversify: ^6.0.1
       reflect-metadata: ^0.1.13
+    dev: false
 
-  /@itwin/cloud-agnostic-core/2.2.5_jfjmifiz2mjvngwcpuojiclrrm:
-    resolution: {integrity: sha512-pLEWIjQ4Z1kos7z6RWu/kG2lTEyojr906WVGAXKouxA/BobWuUlb1HG1/Zw8+SovA284wauKhHJsydRhYeddIQ==}
-    peerDependencies:
-      inversify: ^6.0.1
-      reflect-metadata: ^0.1.13
-    dependencies:
-      inversify: 6.0.3
-      reflect-metadata: 0.1.14
-
-  /@itwin/components-react/4.17.2_zs6rif5h5jixp3mcoeld6e43pu:
-    resolution: {integrity: sha512-EaElyMpBb/cZcJ5N6jjCd06Lv4zzkuD2g83+C3z129uAuTzmvpvHQwd3JnIiYVKWPhc9YefJaWgZpgNwQO/bhQ==}
+  /@itwin/components-react/4.15.1_jscgs7su4cyo55wt5klvj3iepa:
+    resolution: {integrity: sha512-MgqOwJoO+k+lyHC6NX2e7oGDftsvHAw2LYlQmG6HUwNGu8cLp5Qok7G0Ti+1yf2UtCrz5rA+dZQifB+IDQ1Afw==}
     peerDependencies:
       '@itwin/appui-abstract': ^3.7.0 || ^4.0.0
       '@itwin/core-bentley': ^3.7.0 || ^4.0.0
-      '@itwin/core-react': ^4.17.2
+      '@itwin/core-react': ^4.15.1
       react: ^17.0.0 || ^18.0.0
       react-dom: ^17.0.0 || ^18.0.0
     dependencies:
       '@bentley/icons-generic': 1.0.34
-      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-react': 4.17.2_b5szh4swag42x6ykxwn6buimra
-      '@itwin/itwinui-icons-react': 2.9.0_nnrd3gsncyragczmpvfhocinkq
-      '@itwin/itwinui-react': 3.15.5_vsw25juzkyj7spaf6wjn5upvjq
-      '@itwin/itwinui-variables': 3.3.0
+      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-react': 4.15.1_bpptdsfauwdziiwg4uklizbr74
+      '@itwin/itwinui-icons-react': 2.8.0_nnrd3gsncyragczmpvfhocinkq
+      '@itwin/itwinui-react': 3.12.2_psuonouaqi5wuc37nxyknoubym
+      '@itwin/itwinui-variables': 3.2.0
       classnames: 2.3.1
       immer: 9.0.6
       linkify-it: 2.2.0
       lodash: 4.17.21
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
+      react-highlight-words: 0.20.0_react@18.3.1
       react-window: 1.8.10_nnrd3gsncyragczmpvfhocinkq
       rxjs: 7.8.1
-      ts-key-enum: 2.0.13
+      ts-key-enum: 2.0.12
     transitivePeerDependencies:
       - '@types/react'
 
-  /@itwin/core-backend/4.9.5_r6lwpu3senlcflmx65u2gwowne:
-    resolution: {integrity: sha512-ea3P4ldooJGmBZq8Cj0yDtfdQWsGUiYpcn/Z9b1F+BP6oylwYhJA8Eyesc9zLswf+TDeY+G5avdivDeO7gskbw==}
+  /@itwin/core-backend/4.7.4_zzr6hivuljmnvzdhcyobjpaqme:
+    resolution: {integrity: sha512-pHWHZdgn3dIuOjiC0eJIo8F3MapkeZBTHIwLJr57M3BJH0kyJ8zRy5fWvK20lE985m6VR7a2SxGcybgRVv4sBg==}
     engines: {node: ^18.0.0 || ^20.0.0}
     peerDependencies:
-      '@itwin/core-bentley': ^4.9.5
-      '@itwin/core-common': ^4.9.5
-      '@itwin/core-geometry': ^4.9.5
+      '@itwin/core-bentley': ^4.7.4
+      '@itwin/core-common': ^4.7.4
+      '@itwin/core-geometry': ^4.7.4
       '@opentelemetry/api': ^1.0.4
     peerDependenciesMeta:
       '@opentelemetry/api':
         optional: true
     dependencies:
-      '@bentley/imodeljs-native': 4.9.35
-      '@itwin/cloud-agnostic-core': 2.2.5_jfjmifiz2mjvngwcpuojiclrrm
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
-      '@itwin/core-geometry': 4.9.5
-      '@itwin/core-telemetry': 4.9.5_@itwin+core-geometry@4.9.5
-      '@itwin/object-storage-azure': 2.2.5_jfjmifiz2mjvngwcpuojiclrrm
-      '@itwin/object-storage-core': 2.2.5_jfjmifiz2mjvngwcpuojiclrrm
-      form-data: 2.5.2
+      '@bentley/imodeljs-native': 4.7.29
+      '@itwin/cloud-agnostic-core': 2.2.4_gteov7on4oycvgy3jqh4tz3uta
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/core-geometry': 4.7.4
+      '@itwin/core-telemetry': 4.7.4_@itwin+core-geometry@4.7.4
+      '@itwin/object-storage-azure': 2.2.4_gteov7on4oycvgy3jqh4tz3uta
+      '@itwin/object-storage-core': 2.2.4_gteov7on4oycvgy3jqh4tz3uta
+      form-data: 2.5.1
       fs-extra: 8.1.0
-      inversify: 6.0.3
+      inversify: 6.0.2
       json5: 2.2.3
-      linebreak: 1.1.0
       multiparty: 4.2.3
       reflect-metadata: 0.1.14
-      semver: 7.6.3
+      semver: 7.6.2
       touch: 3.1.1
       ws: 7.5.10
     transitivePeerDependencies:
@@ -2983,34 +3100,34 @@ packages:
       - supports-color
       - utf-8-validate
 
-  /@itwin/core-bentley/4.9.5:
-    resolution: {integrity: sha512-2cFqJnWKdGyNgZziqYHg4KkYVXD3+f4WQ5xhVPkEYffcOpXXz4yFh8nDOZmhgOLAmJo6KDH2x+uNJembcX6wjQ==}
+  /@itwin/core-bentley/4.7.4:
+    resolution: {integrity: sha512-iwMNTRTV2xtuJVa1QGWyn+XudrLssemvkmaGc3hJXCasqSB8bQfFTYSrYoiNxcjdv9N9i3r27XtC0XNIoL8tTg==}
 
-  /@itwin/core-common/4.9.5_uihgl3rfhguqy2f4jpx67fyjwm:
-    resolution: {integrity: sha512-k3Pfyvm7q17m0ohQpWfBTOsdKCkPNgC0fQCpebs8WMFimoYuuxC2BJwUqKMyRcvesI+eT3pOHJ94DM4PH8i2uw==}
+  /@itwin/core-common/4.7.4_7i4fuy3zzvrtjsnyekcav72ie4:
+    resolution: {integrity: sha512-0Xd2E877gXVDP18YMCzsQU/XdTg6VoPFTwT6zlqTQ5XP6nEIZVQzwR/n3egCLc6bdSY0KoiG8RPajK9p7NqV8g==}
     peerDependencies:
-      '@itwin/core-bentley': ^4.9.5
-      '@itwin/core-geometry': ^4.9.5
+      '@itwin/core-bentley': ^4.7.4
+      '@itwin/core-geometry': ^4.7.4
     dependencies:
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-geometry': 4.9.5
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-geometry': 4.7.4
       flatbuffers: 1.12.0
       js-base64: 3.7.7
 
-  /@itwin/core-electron/4.9.5_xnnzauzbsosxbhso2acbfdnloq:
-    resolution: {integrity: sha512-0CvmxO1z50xMr+DIS1bc0fPNV+toCwCI0hw/DbMMEuLypt+/rJukm9/44YJybORiC68fYA7e7qbk1Mm/NIkWWg==}
+  /@itwin/core-electron/4.7.4_hworozxoblmw2cyo32mpk5ebjm:
+    resolution: {integrity: sha512-5G50nqdJw+sih4eR3AjdzK/Q/DVzglxO33THVBu414MVDjaGoemWkUnpQFn3zFMxXWVeJHwCbZG/44hylsATvA==}
     engines: {node: ^18.0.0 || ^20.0.0}
     peerDependencies:
-      '@itwin/core-backend': ^4.9.5
-      '@itwin/core-bentley': ^4.9.5
-      '@itwin/core-common': ^4.9.5
-      '@itwin/core-frontend': ^4.9.5
-      electron: '>=23.0.0 <33.0.0'
+      '@itwin/core-backend': ^4.7.4
+      '@itwin/core-bentley': ^4.7.4
+      '@itwin/core-common': ^4.7.4
+      '@itwin/core-frontend': ^4.7.4
+      electron: '>=23.0.0 <31.0.0'
     dependencies:
-      '@itwin/core-backend': 4.9.5_r6lwpu3senlcflmx65u2gwowne
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
-      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
+      '@itwin/core-backend': 4.7.4_zzr6hivuljmnvzdhcyobjpaqme
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
       '@openid/appauth': 1.3.2
       electron: 24.8.8
       open: 7.4.2
@@ -3018,11 +3135,11 @@ packages:
     transitivePeerDependencies:
       - debug
 
-  /@itwin/core-extension/4.9.5_kyionygyo673et7f54wxvz6g2i:
-    resolution: {integrity: sha512-SXoV5ZkK1tRqtxQ2AnRY2J9LYf72pmQNcssw9s9/nTr4cZ6WAPlJWOEE1tiq8zNdm167EzXhQ8dYPQ7DxJoAAQ==}
+  /@itwin/core-extension/4.7.4_ieegwyxugmwu7xrlokpbnlonea:
+    resolution: {integrity: sha512-q73YF9aLQv6bwTQzBUW3bSyxwoYzVhhD8wgUMqovBAEkeYCEfBheQt49lMpuWIzYE2lfh+jt7dAKCcp/0cYE1g==}
     dependencies:
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
-      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
     transitivePeerDependencies:
       - '@itwin/appui-abstract'
       - '@itwin/core-bentley'
@@ -3035,27 +3152,27 @@ packages:
       - reflect-metadata
     dev: false
 
-  /@itwin/core-frontend/4.9.5_ncnujt6vgqk6xsxosc75g3boci:
-    resolution: {integrity: sha512-fzpVHaCPyf7gACwZNTF2Ov+4idzGF40U0qS8g2Xa8Vm1aaj/jcjFjZDjpmv/db6nYU2Cc30zY3nkmsNWG1bZgA==}
+  /@itwin/core-frontend/4.7.4_phc4rse3pm3zzqfro3xbf2awbu:
+    resolution: {integrity: sha512-ZFfT5DQfwAO7xyYMhBN2o24bEHWnDYhZF6zilQn288Q5BeEkkh/fxLp2erAsCoNCvFAcrkjuBu4tZbLOVNPsKQ==}
     peerDependencies:
-      '@itwin/appui-abstract': ^4.9.5
-      '@itwin/core-bentley': ^4.9.5
-      '@itwin/core-common': ^4.9.5
-      '@itwin/core-geometry': ^4.9.5
-      '@itwin/core-orbitgt': ^4.9.5
-      '@itwin/core-quantity': ^4.9.5
+      '@itwin/appui-abstract': ^4.7.4
+      '@itwin/core-bentley': ^4.7.4
+      '@itwin/core-common': ^4.7.4
+      '@itwin/core-geometry': ^4.7.4
+      '@itwin/core-orbitgt': ^4.7.4
+      '@itwin/core-quantity': ^4.7.4
     dependencies:
-      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/cloud-agnostic-core': 2.2.5
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
-      '@itwin/core-geometry': 4.9.5
-      '@itwin/core-i18n': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/core-orbitgt': 4.9.5
-      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/core-telemetry': 4.9.5_@itwin+core-geometry@4.9.5
-      '@itwin/object-storage-core': 2.2.5
-      '@itwin/webgl-compatibility': 4.9.5
+      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/cloud-agnostic-core': 2.2.4
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/core-geometry': 4.7.4
+      '@itwin/core-i18n': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/core-orbitgt': 4.7.4
+      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/core-telemetry': 4.7.4_@itwin+core-geometry@4.7.4
+      '@itwin/object-storage-core': 2.2.4
+      '@itwin/webgl-compatibility': 4.7.4
       '@loaders.gl/core': 3.4.15
       '@loaders.gl/draco': 3.4.15
       fuse.js: 3.6.1
@@ -3067,50 +3184,50 @@ packages:
       - inversify
       - reflect-metadata
 
-  /@itwin/core-geometry/4.9.5:
-    resolution: {integrity: sha512-o2fe6/yuxo+9I9JS7o1nytv+CZ8XL8a1vVaDRwqqPAMwnHh7qwHgGfD7WuGyn7/NHbjPNv9Srrb9rtOMua8ryg==}
+  /@itwin/core-geometry/4.7.4:
+    resolution: {integrity: sha512-s8t8Kn7SjLqyfOiMhMekmf4Unwmi7ILEvIHODT/Mym8w5lYP43RFQpV0M3Rzm8uYQcF10+r7C+MrpIyRQqL58w==}
     dependencies:
-      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-bentley': 4.7.4
       flatbuffers: 1.12.0
 
-  /@itwin/core-i18n/4.9.5_@itwin+core-bentley@4.9.5:
-    resolution: {integrity: sha512-fwSc2XqdTTVJpPGvraZ/s5ShTjaa5XxGR4IfD2d2JdF6lJ9FML5SdMizO5Mu0cJUZyGz9lDRWlvPpgBF0lu7IQ==}
+  /@itwin/core-i18n/4.7.4_@itwin+core-bentley@4.7.4:
+    resolution: {integrity: sha512-mux7dJk84X0Fsswah3n/LNlJcFyPqeXZG+YvtKV5GYaVg2LQOM+fIDL5/fjTiZNFWWKaqMHnA7r2BINwJk/R8g==}
     peerDependencies:
-      '@itwin/core-bentley': ^4.9.5
+      '@itwin/core-bentley': ^4.7.4
     dependencies:
-      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-bentley': 4.7.4
       i18next: 21.10.0
       i18next-browser-languagedetector: 6.1.8
       i18next-http-backend: 1.4.5
     transitivePeerDependencies:
       - encoding
 
-  /@itwin/core-markup/4.9.5_rsqcs3hzbyxjzpttbshdocpt74:
-    resolution: {integrity: sha512-XisxVLU3LXrwtrREmmqjhXb5SkmGCrC0pJbpb6afHQPj5BeKM70DdSRtArZvBJYmHRCNG+in2FGARiL3tTtA9w==}
+  /@itwin/core-markup/4.7.4_aa3bt7vk4zzsxcvhcdi4ojlcwe:
+    resolution: {integrity: sha512-8MHRlaj3MSUNmcYol69lrfveln07JtgGHfAfKaJpE5bq4CDTXekUPZULOmFI8ysM4R2QhFg9ixaTlbFtpZwuag==}
     peerDependencies:
-      '@itwin/core-bentley': ^4.9.5
-      '@itwin/core-common': ^4.9.5
-      '@itwin/core-frontend': ^4.9.5
-      '@itwin/core-geometry': ^4.9.5
+      '@itwin/core-bentley': ^4.7.4
+      '@itwin/core-common': ^4.7.4
+      '@itwin/core-frontend': ^4.7.4
+      '@itwin/core-geometry': ^4.7.4
     dependencies:
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
-      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
-      '@itwin/core-geometry': 4.9.5
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
+      '@itwin/core-geometry': 4.7.4
       '@svgdotjs/svg.js': 3.0.13
 
-  /@itwin/core-orbitgt/4.9.5:
-    resolution: {integrity: sha512-P3SVR1GrfbCSz330IqDF52HMp50V8VhpCEiBk33SiiqUsISvdfXmt75UhvGDM07KAYF5gvQ+HKO62z5A1+GZmw==}
+  /@itwin/core-orbitgt/4.7.4:
+    resolution: {integrity: sha512-f5PVvdRlUragskdDgpw4Q2vVUkFdYfqDr+9Py1Uq3uhKdcGl8s6RaMBJ+o41GgBbGu/3/5oSEMF19iFCZMsz9A==}
 
-  /@itwin/core-quantity/4.9.5_@itwin+core-bentley@4.9.5:
-    resolution: {integrity: sha512-Dc0zcR/XLu5+aYDmxE4/mukiklKXDtfR0b2SD9h9MQJOeUz0zu6u1o5ozS3WTY8aCJAYSsu0KFS8JJrmLwuoPg==}
+  /@itwin/core-quantity/4.7.4_@itwin+core-bentley@4.7.4:
+    resolution: {integrity: sha512-CrwTMq8X41MNa2uC+h2XnpkggVXRiqOu8j0mMaG3yVd3//YIEdRDyd23zilFrshdkSChFeTQhFQvm/gPMKgWww==}
     peerDependencies:
-      '@itwin/core-bentley': ^4.9.5
+      '@itwin/core-bentley': ^4.7.4
     dependencies:
-      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-bentley': 4.7.4
 
-  /@itwin/core-react/4.17.2_b5szh4swag42x6ykxwn6buimra:
-    resolution: {integrity: sha512-wXAiFoBrBYEY82JTn0waUcVecpz11SesXxd8zgwl56JAdEJm8aTQx09zm6dbZHC6miBAOgwZqF5IzVzBJZGHGw==}
+  /@itwin/core-react/4.15.1_bpptdsfauwdziiwg4uklizbr74:
+    resolution: {integrity: sha512-agy8StVVAtCshiheNoOQGxgUJzk00ilN5jCA/RfanmA9kx0EQ0FOePFjhbPNDaWY56RCgpYrlFwUv9bh8S5Rvw==}
     peerDependencies:
       '@itwin/appui-abstract': ^3.7.0 || ^4.0.0
       '@itwin/core-bentley': ^3.7.0 || ^4.0.0
@@ -3118,96 +3235,97 @@ packages:
       react-dom: ^17.0.0 || ^18.0.0
     dependencies:
       '@bentley/icons-generic': 1.0.34
-      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/itwinui-icons-react': 2.9.0_nnrd3gsncyragczmpvfhocinkq
-      '@itwin/itwinui-react': 3.15.5_vsw25juzkyj7spaf6wjn5upvjq
-      '@itwin/itwinui-variables': 3.3.0
+      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/itwinui-icons-react': 2.8.0_nnrd3gsncyragczmpvfhocinkq
+      '@itwin/itwinui-react': 3.12.2_psuonouaqi5wuc37nxyknoubym
+      '@itwin/itwinui-variables': 3.2.0
       classnames: 2.3.1
-      dompurify: 2.5.7
+      dompurify: 2.5.6
       lodash: 4.17.21
       react: 18.3.1
       react-autosuggest: 10.1.0_react@18.3.1
       react-dom: 18.3.1_react@18.3.1
       resize-observer-polyfill: 1.5.1
-      ts-key-enum: 2.0.13
+      ts-key-enum: 2.0.12
     transitivePeerDependencies:
       - '@types/react'
 
-  /@itwin/core-telemetry/4.9.5_@itwin+core-geometry@4.9.5:
-    resolution: {integrity: sha512-MBFQRj8rIlE1BfpzJzAmBhGT1dFQ1BclrVmt1vSTkkjj2XBqL/0WH4/0ij6xVN90LepFfTCQcBeiptc1amIZQA==}
+  /@itwin/core-telemetry/4.7.4_@itwin+core-geometry@4.7.4:
+    resolution: {integrity: sha512-4z0M4t8ONET66Mg3xRzRQrY2v4p5dNxrfOTghxFEbRWg7iocYN+YLrLXJCQyyAFaJhKaNCq9slqB/sqcaEjZCw==}
     dependencies:
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
     transitivePeerDependencies:
       - '@itwin/core-geometry'
 
-  /@itwin/core-webpack-tools/3.8.0_webpack@5.95.0:
+  /@itwin/core-webpack-tools/3.8.0_webpack@5.92.1:
     resolution: {integrity: sha512-2QsexfnbO2a+ZpFvtq8qlTUrmXfVCDpaKpbsFOq8eAriRI+J8BlPmr4Y/l1zJlfTXD0dRkDcKl1iYCw1Sj5R1g==}
     peerDependencies:
       webpack: ^5.76.0
     dependencies:
       chalk: 3.0.0
-      copy-webpack-plugin: 11.0.0_webpack@5.95.0
-      file-loader: 6.2.0_webpack@5.95.0
+      copy-webpack-plugin: 11.0.0_webpack@5.92.1
+      file-loader: 6.2.0_webpack@5.92.1
       findup: 0.1.5
       fs-extra: 8.1.0
       glob: 7.2.3
       lodash: 4.17.21
       resolve: 1.19.0
-      source-map-loader: 4.0.2_webpack@5.95.0
-      webpack: 5.95.0
+      source-map-loader: 4.0.2_webpack@5.92.1
+      webpack: 5.92.1
     dev: true
 
-  /@itwin/ecschema-metadata/4.9.5_ht7pcu4cvk5h6sxcpkl7x76mje:
-    resolution: {integrity: sha512-rYIh56N/Ob7lFpdimAvCH/pov44eWcUznRnpWbsfBKNyqTW8SAazr09Bdsf8rLbldOQOe2oav0i7JYvbOF5f7Q==}
+  /@itwin/ecschema-metadata/4.7.4_jokiwfzdpldlrb2ppvojwoxovq:
+    resolution: {integrity: sha512-YuLWJc34yj4g4vrjRWdu2Zv07LmV3/6kSsOoX2QivRNd+gu8z1ThcC+s++VZmzvIP8k9nGs1T3SKN86pz2K8uw==}
     peerDependencies:
-      '@itwin/core-bentley': ^4.9.5
-      '@itwin/core-quantity': ^4.9.5
+      '@itwin/core-bentley': ^4.7.4
+      '@itwin/core-quantity': ^4.7.4
     dependencies:
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
+      almost-equal: 1.1.0
 
-  /@itwin/ecschema-rpcinterface-common/4.9.5_ubcdmbjl4iri5lyyvzc2dtfxiq:
-    resolution: {integrity: sha512-XGuOJpJARewWZ8lDpftxViKvxsFCQCsk2XLmcbyIq/+CYHVdeEHqtiTq7SJ+F9a+5JC/oyvqDJI022uKJ/GFRA==}
+  /@itwin/ecschema-rpcinterface-common/4.7.4_bcf6l4a62o6ayq645yaljtfq2i:
+    resolution: {integrity: sha512-ivN3l5OUy4xjv7tJTFYr9/+Vv1BuP9ut3D2sahgupEDQmHKqJP8ptY3QsfYKvb0sSn5wU1XtbRKZzWHgpTZORg==}
     peerDependencies:
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5
-      '@itwin/core-geometry': 4.9.5
-      '@itwin/ecschema-metadata': 4.9.5
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4
+      '@itwin/core-geometry': 4.7.4
+      '@itwin/ecschema-metadata': 4.7.4
     dependencies:
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
-      '@itwin/core-geometry': 4.9.5
-      '@itwin/ecschema-metadata': 4.9.5_ht7pcu4cvk5h6sxcpkl7x76mje
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/core-geometry': 4.7.4
+      '@itwin/ecschema-metadata': 4.7.4_jokiwfzdpldlrb2ppvojwoxovq
     dev: false
 
-  /@itwin/ecschema-rpcinterface-impl/4.9.5_wkhnl5tbdp3ufasrx26orysshe:
-    resolution: {integrity: sha512-vgIDcHdcipQA4cEYpgm8dEOMvwunQdrCu1CxMCAANriKnbBcNE+YgREDaTQLCvki/MZL2ckrP/4/BHWsd+IOSw==}
+  /@itwin/ecschema-rpcinterface-impl/4.7.4_5hmlesdtddppohhn2hwm7h44ha:
+    resolution: {integrity: sha512-pAdxXBIsDlNdAv0hPqE9COJGMtMZA3yu7yUtxoiem0acRcL8sY2GVM3FGWg012ho8nbKTMMhdK6bpExQ2hI1MA==}
     peerDependencies:
-      '@itwin/core-backend': 4.9.5
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5
-      '@itwin/core-geometry': 4.9.5
-      '@itwin/ecschema-metadata': 4.9.5
-      '@itwin/ecschema-rpcinterface-common': 4.9.5
+      '@itwin/core-backend': 4.7.4
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4
+      '@itwin/core-geometry': 4.7.4
+      '@itwin/ecschema-metadata': 4.7.4
+      '@itwin/ecschema-rpcinterface-common': 4.7.4
     dependencies:
-      '@itwin/core-backend': 4.9.5_r6lwpu3senlcflmx65u2gwowne
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
-      '@itwin/core-geometry': 4.9.5
-      '@itwin/ecschema-metadata': 4.9.5_ht7pcu4cvk5h6sxcpkl7x76mje
-      '@itwin/ecschema-rpcinterface-common': 4.9.5_ubcdmbjl4iri5lyyvzc2dtfxiq
+      '@itwin/core-backend': 4.7.4_zzr6hivuljmnvzdhcyobjpaqme
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/core-geometry': 4.7.4
+      '@itwin/ecschema-metadata': 4.7.4_jokiwfzdpldlrb2ppvojwoxovq
+      '@itwin/ecschema-rpcinterface-common': 4.7.4_bcf6l4a62o6ayq645yaljtfq2i
     dev: false
 
-  /@itwin/electron-authorization/0.15.0_a56cjor36hmzwips5mhrqrpbva:
+  /@itwin/electron-authorization/0.15.0_4vf3fjdy4loqcqolj5aeocucyi:
     resolution: {integrity: sha512-NdKsZTlvXlfCWI847nG2vbbFyHtmejnwqixaxR7ZfS8HuVzdO8sbFMqp8NaJmBpLJ4P7IA3WWWEM5Hsb4AteZg==}
     peerDependencies:
       '@itwin/core-bentley': ^3.3.0 || ^4.0.0
       electron: '>=23.0.0 <25.0.0'
     dependencies:
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
       '@openid/appauth': 1.3.2
       electron: 24.8.8
       electron-store: 8.2.0
@@ -3216,29 +3334,29 @@ packages:
       - '@itwin/core-geometry'
       - debug
 
-  /@itwin/express-server/4.9.5_ghqkdihqtcgmxbakiynn72u3oi:
-    resolution: {integrity: sha512-HTVl410Y+LwLo14aLTZ1V5dae5OWFowwFIVmmharmcGRZcu/RWQauZvep+IVE9kHUJWvP9YzEiGeqNe2WLZuHQ==}
+  /@itwin/express-server/4.7.4_7f6lob4dy5xhizoy2hu6gtyoy4:
+    resolution: {integrity: sha512-Frmkv1eA/Nia85qOPGJKlA1+3B5PltCU2g1W8qZn9o9wEzz4KLSmtOwYW+yXa62D9fHXZY9os5Iu8Ekz1jE8Wg==}
     engines: {node: ^18.0.0 || ^20.0.0}
     peerDependencies:
-      '@itwin/core-backend': 4.9.5
-      '@itwin/core-common': 4.9.5
+      '@itwin/core-backend': 4.7.4
+      '@itwin/core-common': 4.7.4
     dependencies:
-      '@itwin/core-backend': 4.9.5_r6lwpu3senlcflmx65u2gwowne
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
-      express: 4.21.1
-      express-ws: 5.0.2_express@4.21.1
+      '@itwin/core-backend': 4.7.4_zzr6hivuljmnvzdhcyobjpaqme
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      express: 4.19.2
+      express-ws: 5.0.2_express@4.19.2
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
     dev: false
 
-  /@itwin/frontend-devtools/4.9.5_orynrjj7mkimir6kjmara2i7dq:
-    resolution: {integrity: sha512-/2yuOPeXMaVsBd8X5MKu8Qe7WGIu+713fctw+GW8VQloMXTeIuZXFg10OyDSBw185yYz1K+oyE/P5pcpir/cmQ==}
+  /@itwin/frontend-devtools/4.7.4_7jxo73lwmrfxldbvkntwilqkhe:
+    resolution: {integrity: sha512-FEvmW05uF1ip8caV5mM+6Wv7jHRYxXaZRFeKNLPqFLtCKdapNT6glOcxtuiRBNHf7hLLhqkfUxU2PEbnbv2fjw==}
     dependencies:
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
-      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
-      '@itwin/core-geometry': 4.9.5
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
+      '@itwin/core-geometry': 4.7.4
       file-saver: 2.0.5
     transitivePeerDependencies:
       - '@itwin/appui-abstract'
@@ -3256,7 +3374,7 @@ packages:
       react: ^16.13.0 || ^17.0.2
       react-dom: ^16.13.0 || ^17.0.2
     dependencies:
-      '@itwin/itwinui-icons-react': 2.9.0_nnrd3gsncyragczmpvfhocinkq
+      '@itwin/itwinui-icons-react': 2.8.0_nnrd3gsncyragczmpvfhocinkq
       '@itwin/itwinui-react': 2.12.26_nnrd3gsncyragczmpvfhocinkq
       classnames: 2.5.1
       react: 18.3.1
@@ -3264,53 +3382,53 @@ packages:
       react-intersection-observer: 8.34.0_react@18.3.1
     dev: false
 
-  /@itwin/imodel-components-react/4.17.2_inn3jcow7lwqfeofdqhb3etkfi:
-    resolution: {integrity: sha512-Wj2BfE2h3xIbaiM8KBt/dOuMoVmYhR+FtLS2T0U4VqhoK1E5QtNZqTMPNuyCF7NlfIXX9x0Bg7ZS8nw26vPaZw==}
+  /@itwin/imodel-components-react/4.15.1_avm2jbcgpodgccdhk4zetypeem:
+    resolution: {integrity: sha512-IPMsMQRvadcGdE72vAlv6HQCrdc9oAE5TlFXen5S49XyOeqvCht6k8Eyec6Gt9i+StYYG3Owi5kbJiDuZioOOA==}
     peerDependencies:
       '@itwin/appui-abstract': ^3.7.0 || ^4.0.0
-      '@itwin/components-react': ^4.17.2
+      '@itwin/components-react': ^4.15.1
       '@itwin/core-bentley': ^3.7.0 || ^4.0.0
       '@itwin/core-common': ^3.7.0 || ^4.0.0
       '@itwin/core-frontend': ^3.7.0 || ^4.0.0
       '@itwin/core-geometry': ^3.7.0 || ^4.0.0
       '@itwin/core-quantity': ^3.7.0 || ^4.0.0
-      '@itwin/core-react': ^4.17.2
+      '@itwin/core-react': ^4.15.1
       react: ^17.0.0 || ^18.0.0
       react-dom: ^17.0.0 || ^18.0.0
     dependencies:
       '@bentley/icons-generic': 1.0.34
-      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/components-react': 4.17.2_zs6rif5h5jixp3mcoeld6e43pu
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
-      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
-      '@itwin/core-geometry': 4.9.5
-      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/core-react': 4.17.2_b5szh4swag42x6ykxwn6buimra
-      '@itwin/itwinui-icons-react': 2.9.0_nnrd3gsncyragczmpvfhocinkq
-      '@itwin/itwinui-react': 3.15.5_vsw25juzkyj7spaf6wjn5upvjq
-      '@itwin/itwinui-variables': 3.3.0
+      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/components-react': 4.15.1_jscgs7su4cyo55wt5klvj3iepa
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
+      '@itwin/core-geometry': 4.7.4
+      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/core-react': 4.15.1_bpptdsfauwdziiwg4uklizbr74
+      '@itwin/itwinui-icons-react': 2.8.0_nnrd3gsncyragczmpvfhocinkq
+      '@itwin/itwinui-react': 3.12.2_psuonouaqi5wuc37nxyknoubym
+      '@itwin/itwinui-variables': 3.2.0
       classnames: 2.3.1
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
-      ts-key-enum: 2.0.13
+      ts-key-enum: 2.0.12
     transitivePeerDependencies:
       - '@types/react'
 
-  /@itwin/imodels-access-backend/5.2.3_3pcl427xpsrwbipdq34svx7mdu:
-    resolution: {integrity: sha512-et2bNOgZWRS7UCChphdf9gTHjUqOj9Pig4xG8VFmKxVc3q+qSNzkvz7ZEbv4NYGg54sq743jxyIeeE8A6/B9aA==}
+  /@itwin/imodels-access-backend/5.2.1_4z423c7twni3c7p4vwjttw7w4q:
+    resolution: {integrity: sha512-A913LDaA6K0va71s3hhqpiIHNUcX7TAIcOt1Qqvu84P57/DdR45fh3+bI0dWY4DqzD3Cu7cnFL9Qw1xSh3qP9w==}
     peerDependencies:
       '@itwin/core-backend': ^4.0.0
       '@itwin/core-bentley': ^4.0.0
       '@itwin/core-common': ^4.0.0
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@itwin/core-backend': 4.9.5_r6lwpu3senlcflmx65u2gwowne
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
-      '@itwin/imodels-access-common': 5.2.3_zddnpq3p4agzvhpjqixaraohjy
-      '@itwin/imodels-client-authoring': 5.9.0
-      axios: 1.7.7
+      '@itwin/core-backend': 4.7.4_zzr6hivuljmnvzdhcyobjpaqme
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/imodels-access-common': 5.2.1_hex34t7wgxyaranr6ig5prg5pi
+      '@itwin/imodels-client-authoring': 5.8.1
+      axios: 1.7.4
     transitivePeerDependencies:
       - debug
       - inversify
@@ -3318,38 +3436,38 @@ packages:
       - supports-color
     dev: false
 
-  /@itwin/imodels-access-common/5.2.3_zddnpq3p4agzvhpjqixaraohjy:
-    resolution: {integrity: sha512-HP3oEe2715rr0EyExBkUgLxrCB6YbkkgiIQc4e8I0zzv/sW+7yygZOC/K/hd+/roTFkdNsiT+W446Bh5cnVuOg==}
+  /@itwin/imodels-access-common/5.2.1_hex34t7wgxyaranr6ig5prg5pi:
+    resolution: {integrity: sha512-8pb9P12e5Tmb9nRUz+T9fnFdEdWmFsrYSdjCP+CwBZD8V/G1oeTlk7280YPNyl9XaIZwHhHsocECBsr1yqTM9Q==}
     peerDependencies:
       '@itwin/core-bentley': ^4.0.0
       '@itwin/core-common': ^4.0.0
     dependencies:
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
-      '@itwin/imodels-client-management': 5.9.0
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/imodels-client-management': 5.8.1
     transitivePeerDependencies:
       - debug
 
-  /@itwin/imodels-access-frontend/5.2.3_x7r3qyjan52efy6jnvzj72woaa:
-    resolution: {integrity: sha512-jcfP4WvsTkRfP5r6MYE7FtEN4dw4f249G5TzltAOZGXCtiJjMvCgJ6JKnp6Bz95ZfLgSjZTkhowZGthOTLvuqA==}
+  /@itwin/imodels-access-frontend/5.2.1_r7pomf6q3izykcd6xffknqbpim:
+    resolution: {integrity: sha512-L2G7R4OAUFSNPkA7hwJcyRkYAvVhi/3nk8SMzfHyBY8FqymXNpjnhGqyKMbbVzNEZFtGU0yQfL/T/3AmarTuVg==}
     peerDependencies:
       '@itwin/core-bentley': ^4.0.0
       '@itwin/core-common': ^4.0.0
       '@itwin/core-frontend': ^4.0.0
     dependencies:
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
-      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
-      '@itwin/imodels-access-common': 5.2.3_zddnpq3p4agzvhpjqixaraohjy
-      '@itwin/imodels-client-management': 5.9.0
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
+      '@itwin/imodels-access-common': 5.2.1_hex34t7wgxyaranr6ig5prg5pi
+      '@itwin/imodels-client-management': 5.8.1
     transitivePeerDependencies:
       - debug
 
-  /@itwin/imodels-client-authoring/5.9.0:
-    resolution: {integrity: sha512-f34dKHccffjyukcBTF7bVZuoOvUi61z6sZ43YLcju/K7WS8dUdtkxaoGYe1Ub3lXg/irsAcBnVIr0j8NNYr+Gg==}
+  /@itwin/imodels-client-authoring/5.8.1:
+    resolution: {integrity: sha512-iRjzQ7xbp9bjEBFTOSYPjUergw9gwB7MAXr7n/VvOkL4UMan6VuQTqgGKDHamelUFbPcXu8ujU225F7QWRUlCQ==}
     dependencies:
-      '@azure/storage-blob': 12.25.0
-      '@itwin/imodels-client-management': 5.9.0
+      '@azure/storage-blob': 12.23.0
+      '@itwin/imodels-client-management': 5.8.1
       '@itwin/object-storage-azure': 2.2.5
       '@itwin/object-storage-core': 2.2.5
     transitivePeerDependencies:
@@ -3359,10 +3477,10 @@ packages:
       - supports-color
     dev: false
 
-  /@itwin/imodels-client-management/5.9.0:
-    resolution: {integrity: sha512-bmnpST6Eq0D+CsBsLkOBqcxhRYdC9uJ2oONuIVcl1Ii91R82cXMx284UjtsKtXBzO/YKOhXWHFnQTdxQEa/x3w==}
+  /@itwin/imodels-client-management/5.8.1:
+    resolution: {integrity: sha512-1L+oJeVColwMaq5fuAuserzABHOKhfEQKBIZnZgPyx93zeOP6ZbBYVnXjgrYBsPKJAJyvAgN/uMD4qdJX/vpIQ==}
     dependencies:
-      axios: 1.7.7
+      axios: 1.7.4
     transitivePeerDependencies:
       - debug
 
@@ -3370,8 +3488,8 @@ packages:
     resolution: {integrity: sha512-5zXM5WtaXt6X0oWJyjU9ICVMJyvfhXi3qkubwycCdFvH45qnSesmlhaZ5Z1D7I00fXLKdIukwqwTYfUkACZ57A==}
     dev: false
 
-  /@itwin/itwinui-icons-react/2.9.0_nnrd3gsncyragczmpvfhocinkq:
-    resolution: {integrity: sha512-48oxHUuqEaJOwVRFED0yssfIriX/IQrHd67ffxvEAu7yW1f5a/qFDyImAlwjlzr+4+obBMweshJ8sI+OgziyvA==}
+  /@itwin/itwinui-icons-react/2.8.0_nnrd3gsncyragczmpvfhocinkq:
+    resolution: {integrity: sha512-FMXUrDFC7U827/QJNE603+FL6OvIngFss5B9YTSCXcrWuwVLAzJ+sFb+RQ/I1sc19qujYBkZ9asNqlHXM2O4Cg==}
     peerDependencies:
       react: '>=16.8.6'
       react-dom: '>=16.8.6'
@@ -3422,18 +3540,17 @@ packages:
       react-transition-group: 4.4.5_nnrd3gsncyragczmpvfhocinkq
       tippy.js: 6.3.7
 
-  /@itwin/itwinui-react/3.15.5_vsw25juzkyj7spaf6wjn5upvjq:
-    resolution: {integrity: sha512-AqoFWFGwgZUrGzxn1J8Ea/DKOcXUt0haLjZBQ3lPeCmO6tNQow9NrbHWn+B9KiMAENADwgS9ElqTseDrSRksig==}
+  /@itwin/itwinui-react/3.12.2_psuonouaqi5wuc37nxyknoubym:
+    resolution: {integrity: sha512-ARRr8rx3YlBkL02gJ59wt7qVK93/qpB91neXMnXTJ1QkADIl32fUtzOXvx3nlgt9RzBnoj3NbswIm75HQd/joQ==}
     peerDependencies:
       react: '>= 17.0.0 < 19.0.0'
       react-dom: '>=17.0.0 < 19.0.0'
     dependencies:
-      '@floating-ui/react': 0.26.26_nnrd3gsncyragczmpvfhocinkq
+      '@floating-ui/react': 0.26.19_nnrd3gsncyragczmpvfhocinkq
       '@itwin/itwinui-illustrations-react': 2.1.0_nnrd3gsncyragczmpvfhocinkq
-      '@swc/helpers': 0.5.13
-      '@tanstack/react-virtual': 3.10.8_nnrd3gsncyragczmpvfhocinkq
+      '@swc/helpers': 0.5.11
       classnames: 2.5.1
-      jotai: 2.10.1_ryhct6r6jz2fex4xfo2quarxhi
+      jotai: 2.9.0_3vdbhqr2ncalcx7opnshezpx3q
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
       react-table: 7.8.0_react@18.3.1
@@ -3448,10 +3565,10 @@ packages:
   /@itwin/itwinui-variables/2.1.2:
     resolution: {integrity: sha512-bwaoiqJdPvMCEhccXh5jE/uF83IoHaHofURZV62t9BEhKXW0LF+iaAwCPC+G4Sttgs6tUtqEGsPqj5RnbdipsQ==}
 
-  /@itwin/itwinui-variables/3.3.0:
-    resolution: {integrity: sha512-bnMlOaX+0Bh+bFdXD1KWBcsgeQTJDvaOY7HXI3ZIADRFy4qnx70DmRMp7w+ZA1FxrX2XTQNjt+kmcphaXTPGCw==}
+  /@itwin/itwinui-variables/3.2.0:
+    resolution: {integrity: sha512-YuJ3IyqRRynQRKPiTz6odF8hVxmAVABxitrqj2VZ1ZtKRVO6EyrWMgZP90cYF1l0EjqzOxG71focaHcZH5C6Ow==}
 
-  /@itwin/measure-tools-react/0.13.0_i7qwmeovtjabsqcqehc6iw7vpa:
+  /@itwin/measure-tools-react/0.13.0_hhvtoxm2vupiyzv3tuuiwwirjq:
     resolution: {integrity: sha512-Gdog3IxNUR+bU5LZ7FDvUOVUbPOdPrWA0xPfrhhk5bQ7benzT9poU/kZx4R2tAvH/UmJ1/wn80ZLiXCNsJtCBQ==}
     peerDependencies:
       '@itwin/appui-abstract': ^4.0.0
@@ -3468,20 +3585,36 @@ packages:
       redux: ^4.2.1
     dependencies:
       '@bentley/icons-generic-webfont': 1.0.34
-      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/appui-layout-react': 4.8.3_zs6rif5h5jixp3mcoeld6e43pu
-      '@itwin/appui-react': 4.17.2_ggnmyqo32cg3w26befg4w43y64
-      '@itwin/components-react': 4.17.2_zs6rif5h5jixp3mcoeld6e43pu
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
-      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
-      '@itwin/core-geometry': 4.9.5
-      '@itwin/core-react': 4.17.2_b5szh4swag42x6ykxwn6buimra
-      '@itwin/core-telemetry': 4.9.5_@itwin+core-geometry@4.9.5
+      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/appui-layout-react': 4.8.3_jscgs7su4cyo55wt5klvj3iepa
+      '@itwin/appui-react': 4.15.1_yrqai5hl5gvsf4dek6el5aloii
+      '@itwin/components-react': 4.15.1_jscgs7su4cyo55wt5klvj3iepa
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
+      '@itwin/core-geometry': 4.7.4
+      '@itwin/core-react': 4.15.1_bpptdsfauwdziiwg4uklizbr74
+      '@itwin/core-telemetry': 4.7.4_@itwin+core-geometry@4.7.4
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
       redux: 4.2.1
     dev: false
+
+  /@itwin/object-storage-azure/2.2.4_gteov7on4oycvgy3jqh4tz3uta:
+    resolution: {integrity: sha512-mJjX090FBR//tqQfCjV01qYQsiU0wv2x+XTDx8sA+b8mQqYUHdCgeD55ZLecCQRihU0Aebd1qw3PadrLuv0GeQ==}
+    peerDependencies:
+      inversify: ^6.0.1
+      reflect-metadata: ^0.1.13
+    dependencies:
+      '@azure/core-paging': 1.6.2
+      '@azure/storage-blob': 12.23.0
+      '@itwin/cloud-agnostic-core': 2.2.4_gteov7on4oycvgy3jqh4tz3uta
+      '@itwin/object-storage-core': 2.2.4_gteov7on4oycvgy3jqh4tz3uta
+      inversify: 6.0.2
+      reflect-metadata: 0.1.14
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   /@itwin/object-storage-azure/2.2.5:
     resolution: {integrity: sha512-LvnQupvyK28UhIimnEnZqKoBRSMwl3cw8wJ30mYu0UD5c+xuKAaphFCy79QXF2mENqC68uh0JKrFbaSAphwDHQ==}
@@ -3490,7 +3623,7 @@ packages:
       reflect-metadata: ^0.1.13
     dependencies:
       '@azure/core-paging': 1.6.2
-      '@azure/storage-blob': 12.25.0
+      '@azure/storage-blob': 12.23.0
       '@itwin/cloud-agnostic-core': 2.2.5
       '@itwin/object-storage-core': 2.2.5
     transitivePeerDependencies:
@@ -3498,21 +3631,29 @@ packages:
       - supports-color
     dev: false
 
-  /@itwin/object-storage-azure/2.2.5_jfjmifiz2mjvngwcpuojiclrrm:
-    resolution: {integrity: sha512-LvnQupvyK28UhIimnEnZqKoBRSMwl3cw8wJ30mYu0UD5c+xuKAaphFCy79QXF2mENqC68uh0JKrFbaSAphwDHQ==}
+  /@itwin/object-storage-core/2.2.4:
+    resolution: {integrity: sha512-aZ4NRWFuukKrYdlF/kPepQ5JnpOe/DR3XlI5QwV/y4SV6HZaGyNj4iLL9DEUnCNGTMwTtTRAhOMsc8agqV0Eng==}
     peerDependencies:
       inversify: ^6.0.1
       reflect-metadata: ^0.1.13
     dependencies:
-      '@azure/core-paging': 1.6.2
-      '@azure/storage-blob': 12.25.0
-      '@itwin/cloud-agnostic-core': 2.2.5_jfjmifiz2mjvngwcpuojiclrrm
-      '@itwin/object-storage-core': 2.2.5_jfjmifiz2mjvngwcpuojiclrrm
-      inversify: 6.0.3
+      '@itwin/cloud-agnostic-core': 2.2.4
+      axios: 1.7.4
+    transitivePeerDependencies:
+      - debug
+
+  /@itwin/object-storage-core/2.2.4_gteov7on4oycvgy3jqh4tz3uta:
+    resolution: {integrity: sha512-aZ4NRWFuukKrYdlF/kPepQ5JnpOe/DR3XlI5QwV/y4SV6HZaGyNj4iLL9DEUnCNGTMwTtTRAhOMsc8agqV0Eng==}
+    peerDependencies:
+      inversify: ^6.0.1
+      reflect-metadata: ^0.1.13
+    dependencies:
+      '@itwin/cloud-agnostic-core': 2.2.4_gteov7on4oycvgy3jqh4tz3uta
+      axios: 1.7.4
+      inversify: 6.0.2
       reflect-metadata: 0.1.14
     transitivePeerDependencies:
       - debug
-      - supports-color
 
   /@itwin/object-storage-core/2.2.5:
     resolution: {integrity: sha512-IaGryht2Sg2piCVyrnzfTnxSClhi2k8Xv+OxFD2ARvd+J2o3XFgo5EJBezNe1gVz60+9tuqlczIU6blxfbX05g==}
@@ -3521,60 +3662,48 @@ packages:
       reflect-metadata: ^0.1.13
     dependencies:
       '@itwin/cloud-agnostic-core': 2.2.5
-      axios: 1.7.7
+      axios: 1.7.4
     transitivePeerDependencies:
       - debug
+    dev: false
 
-  /@itwin/object-storage-core/2.2.5_jfjmifiz2mjvngwcpuojiclrrm:
-    resolution: {integrity: sha512-IaGryht2Sg2piCVyrnzfTnxSClhi2k8Xv+OxFD2ARvd+J2o3XFgo5EJBezNe1gVz60+9tuqlczIU6blxfbX05g==}
+  /@itwin/presentation-backend/4.7.4_nztxufmverfbgaq2tic42bdzqu:
+    resolution: {integrity: sha512-kQzkSH003/mig1r3tVLhyzqinqQBIHfaxw1f9d1pfeSEw4XDzWgDjc0q40rnREh0moQdOnHZ50VJNzsl6SwZLg==}
     peerDependencies:
-      inversify: ^6.0.1
-      reflect-metadata: ^0.1.13
+      '@itwin/core-backend': ^4.7.4
+      '@itwin/core-bentley': ^4.7.4
+      '@itwin/core-common': ^4.7.4
+      '@itwin/core-quantity': ^4.7.4
+      '@itwin/ecschema-metadata': ^4.7.4
+      '@itwin/presentation-common': ^4.7.4
     dependencies:
-      '@itwin/cloud-agnostic-core': 2.2.5_jfjmifiz2mjvngwcpuojiclrrm
-      axios: 1.7.7
-      inversify: 6.0.3
-      reflect-metadata: 0.1.14
-    transitivePeerDependencies:
-      - debug
-
-  /@itwin/presentation-backend/4.9.5_6poatpavnnrtfvnacw25xntdke:
-    resolution: {integrity: sha512-Grb1f30l4u30sT9/V+KHx1gfWmj+irjNWeo13BPC1nh2EVcklZdBQaSxQynoBZUZDlPzYpucwf+KBMHnM4YOEQ==}
-    peerDependencies:
-      '@itwin/core-backend': ^4.9.5
-      '@itwin/core-bentley': ^4.9.5
-      '@itwin/core-common': ^4.9.5
-      '@itwin/core-quantity': ^4.9.5
-      '@itwin/ecschema-metadata': ^4.9.5
-      '@itwin/presentation-common': ^4.9.5
-    dependencies:
-      '@itwin/core-backend': 4.9.5_r6lwpu3senlcflmx65u2gwowne
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
-      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/ecschema-metadata': 4.9.5_ht7pcu4cvk5h6sxcpkl7x76mje
-      '@itwin/presentation-common': 4.9.5_752sgixgtdkx2uobp37xqv5rci
+      '@itwin/core-backend': 4.7.4_zzr6hivuljmnvzdhcyobjpaqme
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/ecschema-metadata': 4.7.4_jokiwfzdpldlrb2ppvojwoxovq
+      '@itwin/presentation-common': 4.7.4_jrcxtioaccikuahb3i3h6f5rhe
       object-hash: 1.3.1
       rxjs: 7.8.1
       rxjs-for-await: 1.0.0_rxjs@7.8.1
-      semver: 7.6.3
+      semver: 7.6.2
     dev: false
 
-  /@itwin/presentation-common/4.9.5_752sgixgtdkx2uobp37xqv5rci:
-    resolution: {integrity: sha512-8apEmM7f7apGzxpR93BLiJ4vber36sjjXdc+fHg2tS5M+lHJiLnaQtV+IS/kKnbFu5nhJS22SBlmme8Giz4aWQ==}
+  /@itwin/presentation-common/4.7.4_jrcxtioaccikuahb3i3h6f5rhe:
+    resolution: {integrity: sha512-Qujt2KSrYVS/OzVsRn6psuI7WqNM54FAaAHc+eq+XEIy+fffe+u3+D0GgjSVNN9g53y1Uo3+KqMWU0HxQ2yqWA==}
     peerDependencies:
-      '@itwin/core-bentley': ^4.9.5
-      '@itwin/core-common': ^4.9.5
-      '@itwin/core-quantity': ^4.9.5
-      '@itwin/ecschema-metadata': ^4.9.5
+      '@itwin/core-bentley': ^4.7.4
+      '@itwin/core-common': ^4.7.4
+      '@itwin/core-quantity': ^4.7.4
+      '@itwin/ecschema-metadata': ^4.7.4
     dependencies:
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
-      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/ecschema-metadata': 4.9.5_ht7pcu4cvk5h6sxcpkl7x76mje
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/ecschema-metadata': 4.7.4_jokiwfzdpldlrb2ppvojwoxovq
 
-  /@itwin/presentation-components/5.6.0_hb7vovirygu74f3smprdxccedu:
-    resolution: {integrity: sha512-bm3niBLKxO8KLjLETtXss74f0VBo4lAZinv2Oa4pfruU6wxYKmQURZ5Syha95lpDSYbahpcS69ioJG2SDHvshg==}
+  /@itwin/presentation-components/5.4.1_coeiqitrdc3kbyoxwt3ak4fycm:
+    resolution: {integrity: sha512-o1ysqcbyVAWHyYTGVisFNfbix7GJdXp69c3QAeX/Xv2K0AS1ce2qYDEQCGwxwL1qIseIBbq9pZXADYjf9GH2bQ==}
     peerDependencies:
       '@itwin/appui-abstract': ^4.4.0
       '@itwin/components-react': ^4.9.0
@@ -3591,72 +3720,82 @@ packages:
       react: ^17.0.0 || ^18.0.0
       react-dom: ^17.0.0 || ^18.0.0
     dependencies:
-      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/components-react': 4.17.2_zs6rif5h5jixp3mcoeld6e43pu
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
-      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
-      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/core-react': 4.17.2_b5szh4swag42x6ykxwn6buimra
-      '@itwin/ecschema-metadata': 4.9.5_ht7pcu4cvk5h6sxcpkl7x76mje
-      '@itwin/imodel-components-react': 4.17.2_inn3jcow7lwqfeofdqhb3etkfi
-      '@itwin/itwinui-icons-react': 2.9.0_nnrd3gsncyragczmpvfhocinkq
-      '@itwin/itwinui-illustrations-react': 2.1.0_nnrd3gsncyragczmpvfhocinkq
-      '@itwin/presentation-common': 4.9.5_752sgixgtdkx2uobp37xqv5rci
-      '@itwin/presentation-frontend': 4.9.5_cfzxbnb6dite7ncbt3vw277mvu
-      classnames: 2.5.1
-      fast-deep-equal: 3.1.3
-      fast-sort: 3.4.1
-      micro-memoize: 4.1.2
-      react: 18.3.1
-      react-dom: 18.3.1_react@18.3.1
-      react-error-boundary: 4.1.2_react@18.3.1
-      rxjs: 7.8.1
-    dev: true
-
-  /@itwin/presentation-components/5.6.0_pgm6v4yzke2vvcj2rwx47ufaoy:
-    resolution: {integrity: sha512-bm3niBLKxO8KLjLETtXss74f0VBo4lAZinv2Oa4pfruU6wxYKmQURZ5Syha95lpDSYbahpcS69ioJG2SDHvshg==}
-    peerDependencies:
-      '@itwin/appui-abstract': ^4.4.0
-      '@itwin/components-react': ^4.9.0
-      '@itwin/core-bentley': ^4.4.0
-      '@itwin/core-common': ^4.4.0
-      '@itwin/core-frontend': ^4.4.0
-      '@itwin/core-quantity': ^4.4.0
-      '@itwin/core-react': ^4.9.0
-      '@itwin/ecschema-metadata': ^4.4.0
-      '@itwin/imodel-components-react': ^4.9.0
-      '@itwin/itwinui-react': ^3.0.0
-      '@itwin/presentation-common': ^4.4.0
-      '@itwin/presentation-frontend': ^4.4.0
-      react: ^17.0.0 || ^18.0.0
-      react-dom: ^17.0.0 || ^18.0.0
-    dependencies:
-      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/components-react': 4.17.2_zs6rif5h5jixp3mcoeld6e43pu
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
-      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
-      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/core-react': 4.17.2_b5szh4swag42x6ykxwn6buimra
-      '@itwin/ecschema-metadata': 4.9.5_ht7pcu4cvk5h6sxcpkl7x76mje
-      '@itwin/imodel-components-react': 4.17.2_inn3jcow7lwqfeofdqhb3etkfi
-      '@itwin/itwinui-icons-react': 2.9.0_nnrd3gsncyragczmpvfhocinkq
+      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/components-react': 4.15.1_jscgs7su4cyo55wt5klvj3iepa
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
+      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/core-react': 4.15.1_bpptdsfauwdziiwg4uklizbr74
+      '@itwin/ecschema-metadata': 4.7.4_jokiwfzdpldlrb2ppvojwoxovq
+      '@itwin/imodel-components-react': 4.15.1_avm2jbcgpodgccdhk4zetypeem
+      '@itwin/itwinui-icons-react': 2.8.0_nnrd3gsncyragczmpvfhocinkq
       '@itwin/itwinui-illustrations-react': 2.1.0_nnrd3gsncyragczmpvfhocinkq
       '@itwin/itwinui-react': 2.12.26_nnrd3gsncyragczmpvfhocinkq
-      '@itwin/presentation-common': 4.9.5_752sgixgtdkx2uobp37xqv5rci
-      '@itwin/presentation-frontend': 4.9.5_cfzxbnb6dite7ncbt3vw277mvu
+      '@itwin/presentation-common': 4.7.4_jrcxtioaccikuahb3i3h6f5rhe
+      '@itwin/presentation-frontend': 4.7.4_lbci6e5ivpkspr33wpe53pcp5i
       classnames: 2.5.1
       fast-deep-equal: 3.1.3
-      fast-sort: 3.4.1
+      fast-sort: 3.4.0
       micro-memoize: 4.1.2
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
-      react-error-boundary: 4.1.2_react@18.3.1
+      react-error-boundary: 4.0.13_react@18.3.1
+      react-select: 5.7.0_psuonouaqi5wuc37nxyknoubym
+      react-select-async-paginate: 0.7.2_kipqsbdvtmv5eumhayztwa7ftm
       rxjs: 7.8.1
+    transitivePeerDependencies:
+      - '@types/react'
+      - supports-color
 
-  /@itwin/presentation-core-interop/0.2.7_tm7n22tj7qb4kxylpvuy237mmy:
-    resolution: {integrity: sha512-HBf8335imHgiXiAvtUmStHJzaYt0O4cXJYRZyjX9nMvy9P4Y0ne2gSlugYOUx4FOq1hMJ6qsnpyI89vWVb1Fjw==}
+  /@itwin/presentation-components/5.4.1_tr757zhbqqbt4rcaxvlnctg2de:
+    resolution: {integrity: sha512-o1ysqcbyVAWHyYTGVisFNfbix7GJdXp69c3QAeX/Xv2K0AS1ce2qYDEQCGwxwL1qIseIBbq9pZXADYjf9GH2bQ==}
+    peerDependencies:
+      '@itwin/appui-abstract': ^4.4.0
+      '@itwin/components-react': ^4.9.0
+      '@itwin/core-bentley': ^4.4.0
+      '@itwin/core-common': ^4.4.0
+      '@itwin/core-frontend': ^4.4.0
+      '@itwin/core-quantity': ^4.4.0
+      '@itwin/core-react': ^4.9.0
+      '@itwin/ecschema-metadata': ^4.4.0
+      '@itwin/imodel-components-react': ^4.9.0
+      '@itwin/itwinui-react': ^3.0.0
+      '@itwin/presentation-common': ^4.4.0
+      '@itwin/presentation-frontend': ^4.4.0
+      react: ^17.0.0 || ^18.0.0
+      react-dom: ^17.0.0 || ^18.0.0
+    dependencies:
+      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/components-react': 4.15.1_jscgs7su4cyo55wt5klvj3iepa
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
+      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/core-react': 4.15.1_bpptdsfauwdziiwg4uklizbr74
+      '@itwin/ecschema-metadata': 4.7.4_jokiwfzdpldlrb2ppvojwoxovq
+      '@itwin/imodel-components-react': 4.15.1_avm2jbcgpodgccdhk4zetypeem
+      '@itwin/itwinui-icons-react': 2.8.0_nnrd3gsncyragczmpvfhocinkq
+      '@itwin/itwinui-illustrations-react': 2.1.0_nnrd3gsncyragczmpvfhocinkq
+      '@itwin/presentation-common': 4.7.4_jrcxtioaccikuahb3i3h6f5rhe
+      '@itwin/presentation-frontend': 4.7.4_lbci6e5ivpkspr33wpe53pcp5i
+      classnames: 2.5.1
+      fast-deep-equal: 3.1.3
+      fast-sort: 3.4.0
+      micro-memoize: 4.1.2
+      react: 18.3.1
+      react-dom: 18.3.1_react@18.3.1
+      react-error-boundary: 4.0.13_react@18.3.1
+      react-select: 5.7.0_psuonouaqi5wuc37nxyknoubym
+      react-select-async-paginate: 0.7.2_kipqsbdvtmv5eumhayztwa7ftm
+      rxjs: 7.8.1
+    transitivePeerDependencies:
+      - '@types/react'
+      - supports-color
+    dev: true
+
+  /@itwin/presentation-core-interop/0.2.4_rll2n26bhzrezeyt23jhdcbtsy:
+    resolution: {integrity: sha512-udofwj3KXjDIgW2FxJ/hblUNk/VQBZff/3eLjZUP3q2Jl6N116w0AqTP00aL/5p1RP2+E1yebP6gSno2iRS/EQ==}
     peerDependencies:
       '@itwin/core-bentley': ^4.1.0
       '@itwin/core-common': ^4.1.0
@@ -3664,31 +3803,31 @@ packages:
       '@itwin/core-quantity': ^4.1.0
       '@itwin/ecschema-metadata': ^4.1.0
     dependencies:
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
-      '@itwin/core-geometry': 4.9.5
-      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/ecschema-metadata': 4.9.5_ht7pcu4cvk5h6sxcpkl7x76mje
-      '@itwin/presentation-shared': 0.5.0
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/core-geometry': 4.7.4
+      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/ecschema-metadata': 4.7.4_jokiwfzdpldlrb2ppvojwoxovq
+      '@itwin/presentation-shared': 0.3.2
       rxjs: 7.8.1
     dev: false
 
-  /@itwin/presentation-frontend/4.9.5_cfzxbnb6dite7ncbt3vw277mvu:
-    resolution: {integrity: sha512-e9gZqAQaotuzeAtW0avTZvYBbY/np6B3jZjHvlo+E3e0wpgqWi+UK0bg5GbMToa2lq6wLO7Xj0xnhbHMxOS34A==}
+  /@itwin/presentation-frontend/4.7.4_lbci6e5ivpkspr33wpe53pcp5i:
+    resolution: {integrity: sha512-o5ub8zPC8dkNOAwUGJMt0F0C8zUIqQyBRSGNJH5BJZE1tBnZlMzuEW4aY5fynesJSEoGUwoCMyjB8PtAZN54ug==}
     peerDependencies:
-      '@itwin/core-bentley': ^4.9.5
-      '@itwin/core-common': ^4.9.5
-      '@itwin/core-frontend': ^4.9.5
-      '@itwin/core-quantity': ^4.9.5
-      '@itwin/ecschema-metadata': ^4.9.5
-      '@itwin/presentation-common': ^4.9.5
+      '@itwin/core-bentley': ^4.7.4
+      '@itwin/core-common': ^4.7.4
+      '@itwin/core-frontend': ^4.7.4
+      '@itwin/core-quantity': ^4.7.4
+      '@itwin/ecschema-metadata': ^4.7.4
+      '@itwin/presentation-common': ^4.7.4
     dependencies:
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
-      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
-      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/ecschema-metadata': 4.9.5_ht7pcu4cvk5h6sxcpkl7x76mje
-      '@itwin/presentation-common': 4.9.5_752sgixgtdkx2uobp37xqv5rci
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
+      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/ecschema-metadata': 4.7.4_jokiwfzdpldlrb2ppvojwoxovq
+      '@itwin/presentation-common': 4.7.4_jrcxtioaccikuahb3i3h6f5rhe
       '@itwin/unified-selection': 0.1.0
       rxjs: 7.8.1
       rxjs-for-await: 1.0.0_rxjs@7.8.1
@@ -3696,71 +3835,55 @@ packages:
   /@itwin/presentation-shared/0.3.2:
     resolution: {integrity: sha512-wrb1JiHsQmK/RhdpfQmDUkgbrGz2Y3VzpmA8R3Jr9lYuaW46f6BrlpUemY+V6tE9Gl5enkOMoLPDxYymKPiERA==}
     dependencies:
-      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-bentley': 4.7.4
     dev: false
 
-  /@itwin/presentation-shared/0.4.1:
-    resolution: {integrity: sha512-F/IBTZoMvCn23QJRkFwuXGHrDTNGuibKSHjLa7bFQqU9yZjbjkyQklBYxppdrvkZNh4VS2QjCt+I88g85bxpDw==}
-    dependencies:
-      '@itwin/core-bentley': 4.9.5
-    dev: false
-
-  /@itwin/presentation-shared/0.5.0:
-    resolution: {integrity: sha512-8mFpRE3Fzr9xKz3JnWQ/Wa36+v/2EtxYorKFUwna9f6XbRtRdzlNcI46ROjKkuDeJuDQZSTzSKew9FwR7EcVgg==}
-    dependencies:
-      '@itwin/core-bentley': 4.9.5
-    dev: false
-
-  /@itwin/property-grid-react/1.13.0_ogdchnjgcc3nlmep57rhegv4nu:
-    resolution: {integrity: sha512-rdGDkrD054B9czwkfb7Rahwb1ScC/Es9DFD2JjPDEgLO/qk3juDbq9y9akynhP0kPOisHYCo/bjbm12spGr/sg==}
+  /@itwin/property-grid-react/1.10.0_qjr4doayn7cutuokumbiwhomja:
+    resolution: {integrity: sha512-n5o+NnH8tGvLTkEHls6uZ7SmHBFby5LkZCVAcrY6cFsVD+tceIOZzgiIJbsEp/+OANGY3AnkAdg76yOrVQAxOg==}
     peerDependencies:
       '@itwin/appui-abstract': ^4.0.0
       '@itwin/appui-react': ^4.3.0
       '@itwin/components-react': ^4.3.0
       '@itwin/core-bentley': ^4.0.0
-      '@itwin/core-common': ^4.0.0
       '@itwin/core-frontend': ^4.0.0
       '@itwin/core-react': ^4.3.0
-      '@itwin/presentation-common': ^4.0.0
       '@itwin/presentation-components': ^4.0.0 || ^5.0.0
       '@itwin/presentation-frontend': ^4.0.0
       react: ^17.0.0 || ^18.0.0
       react-dom: ^17.0.0 || ^18.0.0
     dependencies:
-      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/appui-react': 4.17.2_ggnmyqo32cg3w26befg4w43y64
-      '@itwin/components-react': 4.17.2_zs6rif5h5jixp3mcoeld6e43pu
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
-      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
-      '@itwin/core-react': 4.17.2_b5szh4swag42x6ykxwn6buimra
-      '@itwin/itwinui-icons-react': 2.9.0_nnrd3gsncyragczmpvfhocinkq
+      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/appui-react': 4.15.1_yrqai5hl5gvsf4dek6el5aloii
+      '@itwin/components-react': 4.15.1_jscgs7su4cyo55wt5klvj3iepa
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
+      '@itwin/core-react': 4.15.1_bpptdsfauwdziiwg4uklizbr74
+      '@itwin/itwinui-icons-react': 2.8.0_nnrd3gsncyragczmpvfhocinkq
       '@itwin/itwinui-illustrations-react': 2.1.0_nnrd3gsncyragczmpvfhocinkq
-      '@itwin/itwinui-react': 3.15.5_vsw25juzkyj7spaf6wjn5upvjq
-      '@itwin/presentation-common': 4.9.5_752sgixgtdkx2uobp37xqv5rci
-      '@itwin/presentation-components': 5.6.0_pgm6v4yzke2vvcj2rwx47ufaoy
-      '@itwin/presentation-frontend': 4.9.5_cfzxbnb6dite7ncbt3vw277mvu
+      '@itwin/itwinui-react': 3.12.2_psuonouaqi5wuc37nxyknoubym
+      '@itwin/presentation-components': 5.4.1_coeiqitrdc3kbyoxwt3ak4fycm
+      '@itwin/presentation-frontend': 4.7.4_lbci6e5ivpkspr33wpe53pcp5i
       classnames: 2.5.1
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
-      react-error-boundary: 4.1.2_react@18.3.1
+      react-error-boundary: 4.0.13_react@18.3.1
     transitivePeerDependencies:
       - '@types/react'
     dev: false
 
-  /@itwin/reality-data-client/1.2.1_@itwin+core-bentley@4.9.5:
+  /@itwin/reality-data-client/1.2.1_@itwin+core-bentley@4.7.4:
     resolution: {integrity: sha512-pNpnO1tbsM1HwyZcr6UkZLyMczNcYFHqsnREmjYJ4GIeCMdrWKGbH5ar4hyajqc/ZkV9zO4FXFMYgQx3yKK1zQ==}
     peerDependencies:
       '@itwin/core-bentley': ^4.0.0
     dependencies:
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/core-geometry': 4.9.5
-      axios: 1.7.7
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-geometry': 4.7.4
+      axios: 1.7.4
     transitivePeerDependencies:
       - debug
     dev: false
 
-  /@itwin/tree-widget-react/1.2.2_wdle7gtptdoktkpvzniwyk6jjq:
+  /@itwin/tree-widget-react/1.2.2_mwt5u2ylvl5wdlvny262vrwmma:
     resolution: {integrity: sha512-AJWgeK29NMC8zlHMfpIT0qbOLPQyJ1qmMX6AB/jaebjYipkBzG0HChrJN9vjcdMDcmCCPrnT1/uslQPTY1XUGw==}
     peerDependencies:
       '@itwin/appui-abstract': ^4.0.0
@@ -3773,46 +3896,46 @@ packages:
       react-dom: ^17.0.0
     dependencies:
       '@bentley/icons-generic': 1.0.34
-      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
-      '@itwin/appui-react': 4.17.2_ggnmyqo32cg3w26befg4w43y64
-      '@itwin/components-react': 4.17.2_zs6rif5h5jixp3mcoeld6e43pu
-      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
-      '@itwin/core-react': 4.17.2_b5szh4swag42x6ykxwn6buimra
-      '@itwin/itwinui-icons-react': 2.9.0_nnrd3gsncyragczmpvfhocinkq
+      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
+      '@itwin/appui-react': 4.15.1_yrqai5hl5gvsf4dek6el5aloii
+      '@itwin/components-react': 4.15.1_jscgs7su4cyo55wt5klvj3iepa
+      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
+      '@itwin/core-react': 4.15.1_bpptdsfauwdziiwg4uklizbr74
+      '@itwin/itwinui-icons-react': 2.8.0_nnrd3gsncyragczmpvfhocinkq
       '@itwin/itwinui-illustrations-react': 2.1.0_nnrd3gsncyragczmpvfhocinkq
       '@itwin/itwinui-react': 2.12.26_nnrd3gsncyragczmpvfhocinkq
-      '@itwin/presentation-components': 5.6.0_pgm6v4yzke2vvcj2rwx47ufaoy
+      '@itwin/presentation-components': 5.4.1_coeiqitrdc3kbyoxwt3ak4fycm
       classnames: 2.5.1
       i18next: 10.6.0
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
-      react-error-boundary: 4.1.2_react@18.3.1
+      react-error-boundary: 4.0.13_react@18.3.1
       rxjs: 7.8.1
     dev: false
 
   /@itwin/unified-selection/0.1.0:
     resolution: {integrity: sha512-1Pe2i3sw5dK4h394uC5wTRWvnXxeBZGv+t9LcG7tQr2L+l0Hv+Ryo5+yTN34kABEhMe2UwSHnBRU8jOGsiorIQ==}
 
-  /@itwin/unified-selection/0.4.6:
-    resolution: {integrity: sha512-uNklpeWLRLkacW8Zis3mkGjrjdzhiCOuQD9JtaoVifczf/2s82goDI9a+KyjtKvcBp/yzqMyL2KB1Z77p/0Bdw==}
+  /@itwin/unified-selection/0.4.5:
+    resolution: {integrity: sha512-zqVHCEDTkaLQlFFdvBqn6VjapQTg8TaaXuNYLAIqZ0kmDCMxaGzcqvw7rJ8XaC6yboHYUe1UcFNBtSizOtSDwQ==}
     dependencies:
-      '@itwin/core-bentley': 4.9.5
-      '@itwin/presentation-shared': 0.4.1
+      '@itwin/core-bentley': 4.7.4
+      '@itwin/presentation-shared': 0.3.2
       rxjs: 7.8.1
       rxjs-for-await: 1.0.0_rxjs@7.8.1
     dev: false
 
-  /@itwin/webgl-compatibility/4.9.5:
-    resolution: {integrity: sha512-eZ3lUsLSZ0iEdecTPnKczkU572gtcRxGs0p4gD7dsqMGewWDH6WzjxPocG2P495YaiBqf6V8qWnnpncUfjY7pg==}
+  /@itwin/webgl-compatibility/4.7.4:
+    resolution: {integrity: sha512-ZaVTHHrkbJoxYiMnWhN6+gru5yYcdhvrMb7jKVLxHhipHmJ3scCXNvZmEVkz0IVHVpTWodsApmfQnUYnLlbMQw==}
     dependencies:
-      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-bentley': 4.7.4
 
   /@jest/console/27.5.1:
     resolution: {integrity: sha512-kZ/tNpS3NXn0mlXXXPNuDZnb4c0oZ20r4K5eemM2k30ZC3G0T02nXUvyhf5YdbXWHPEJLc9qGLxEZ216MdL+Zg==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       chalk: 4.1.2
       jest-message-util: 27.5.1
       jest-util: 27.5.1
@@ -3824,7 +3947,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.3
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       chalk: 4.1.2
       jest-message-util: 28.1.3
       jest-util: 28.1.3
@@ -3836,7 +3959,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -3857,7 +3980,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.8.1
@@ -3876,7 +3999,7 @@ packages:
       jest-util: 27.5.1
       jest-validate: 27.5.1
       jest-watcher: 27.5.1
-      micromatch: 4.0.8
+      micromatch: 4.0.7
       rimraf: 3.0.2
       slash: 3.0.0
       strip-ansi: 6.0.1
@@ -3902,14 +4025,14 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0_@types+node@18.19.62
+      jest-config: 29.7.0_@types+node@18.19.39
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -3921,7 +4044,7 @@ packages:
       jest-util: 29.7.0
       jest-validate: 29.7.0
       jest-watcher: 29.7.0
-      micromatch: 4.0.8
+      micromatch: 4.0.7
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-ansi: 6.0.1
@@ -3937,7 +4060,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       jest-mock: 27.5.1
     dev: true
 
@@ -3947,7 +4070,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       jest-mock: 29.7.0
     dev: true
 
@@ -3974,7 +4097,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@sinonjs/fake-timers': 8.1.0
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
@@ -3986,7 +4109,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -4027,7 +4150,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -4066,7 +4189,7 @@ packages:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -4176,7 +4299,7 @@ packages:
     resolution: {integrity: sha512-ipON6WtYgl/1329g5AIJVbUuEh0wZVbdpGwC99Jw4LwuoBNS95MVphU6zOeD9pDkon+LLbFL7lOQRapbB8SCHw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.24.7
       '@jest/types': 27.5.1
       babel-plugin-istanbul: 6.1.1
       chalk: 4.1.2
@@ -4186,7 +4309,7 @@ packages:
       jest-haste-map: 27.5.1
       jest-regex-util: 27.5.1
       jest-util: 27.5.1
-      micromatch: 4.0.8
+      micromatch: 4.0.7
       pirates: 4.0.6
       slash: 3.0.0
       source-map: 0.6.1
@@ -4199,7 +4322,7 @@ packages:
     resolution: {integrity: sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.24.7
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
       babel-plugin-istanbul: 6.1.1
@@ -4210,7 +4333,7 @@ packages:
       jest-haste-map: 29.7.0
       jest-regex-util: 29.6.3
       jest-util: 29.7.0
-      micromatch: 4.0.8
+      micromatch: 4.0.7
       pirates: 4.0.6
       slash: 3.0.0
       write-file-atomic: 4.0.2
@@ -4233,7 +4356,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       '@types/yargs': 15.0.19
       chalk: 4.1.2
     dev: true
@@ -4244,7 +4367,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       '@types/yargs': 16.0.9
       chalk: 4.1.2
     dev: true
@@ -4256,8 +4379,8 @@ packages:
       '@jest/schemas': 28.1.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 18.19.62
-      '@types/yargs': 17.0.33
+      '@types/node': 18.19.39
+      '@types/yargs': 17.0.32
       chalk: 4.1.2
     dev: true
 
@@ -4268,8 +4391,8 @@ packages:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 18.19.62
-      '@types/yargs': 17.0.33
+      '@types/node': 18.19.39
+      '@types/yargs': 17.0.32
       chalk: 4.1.2
     dev: true
 
@@ -4280,17 +4403,14 @@ packages:
       '@jridgewell/set-array': 1.2.1
       '@jridgewell/sourcemap-codec': 1.5.0
       '@jridgewell/trace-mapping': 0.3.25
-    dev: true
 
   /@jridgewell/resolve-uri/3.1.2:
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
-    dev: true
 
   /@jridgewell/set-array/1.2.1:
     resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
     engines: {node: '>=6.0.0'}
-    dev: true
 
   /@jridgewell/source-map/0.3.6:
     resolution: {integrity: sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==}
@@ -4301,14 +4421,12 @@ packages:
 
   /@jridgewell/sourcemap-codec/1.5.0:
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
-    dev: true
 
   /@jridgewell/trace-mapping/0.3.25:
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
-    dev: true
 
   /@leichtgewicht/ip-codec/2.0.5:
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
@@ -4317,7 +4435,7 @@ packages:
   /@loaders.gl/core/3.4.15:
     resolution: {integrity: sha512-rPOOTuusWlRRNMWg7hymZBoFmPCXWThsA5ZYRfqqXnsgVeQIi8hzcAhJ7zDUIFAd/OSR8ravtqb0SH+3k6MOFQ==}
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.24.7
       '@loaders.gl/loader-utils': 3.4.15
       '@loaders.gl/worker-utils': 3.4.15
       '@probe.gl/log': 3.6.0
@@ -4325,7 +4443,7 @@ packages:
   /@loaders.gl/draco/3.4.15:
     resolution: {integrity: sha512-SStmyP0ZnS4JbWZb2NhrfiHW65uy3pVTTzQDTgXfkR5cD9oDAEu4nCaHbQ8x38/m39FHliCPgS9b1xWvLKQo8w==}
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.24.7
       '@loaders.gl/loader-utils': 3.4.15
       '@loaders.gl/schema': 3.4.15
       '@loaders.gl/worker-utils': 3.4.15
@@ -4334,7 +4452,7 @@ packages:
   /@loaders.gl/loader-utils/3.4.15:
     resolution: {integrity: sha512-uUx6tCaky6QgCRkqCNuuXiUfpTzKV+ZlJOf6C9bKp62lpvFOv9AwqoXmL23j8nfsENdlzsX3vPhc3en6QQyksA==}
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.24.7
       '@loaders.gl/worker-utils': 3.4.15
       '@probe.gl/stats': 3.6.0
 
@@ -4346,81 +4464,79 @@ packages:
   /@loaders.gl/worker-utils/3.4.15:
     resolution: {integrity: sha512-zUUepOYRYmcYIcr/c4Mchox9h5fBFNkD81rsGnLlZyq19QvyHzN+93SVxrLc078gw93t2RKrVcOOZY13zT3t1w==}
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.24.7
 
-  /@microsoft/api-extractor-model/7.29.8:
-    resolution: {integrity: sha512-t3Z/xcO6TRbMcnKGVMs4uMzv/gd5j0NhMiJIGjD4cJMeFJ1Hf8wnLSx37vxlRlL0GWlGJhnFgxvnaL6JlS+73g==}
+  /@microsoft/api-extractor-model/7.28.13:
+    resolution: {integrity: sha512-39v/JyldX4MS9uzHcdfmjjfS6cYGAoXV+io8B5a338pkHiSt+gy2eXQ0Q7cGFJ7quSa1VqqlMdlPrB6sLR/cAw==}
     dependencies:
-      '@microsoft/tsdoc': 0.15.0
-      '@microsoft/tsdoc-config': 0.17.0
-      '@rushstack/node-core-library': 5.9.0
+      '@microsoft/tsdoc': 0.14.2
+      '@microsoft/tsdoc-config': 0.16.2
+      '@rushstack/node-core-library': 4.0.2
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  /@microsoft/api-extractor-model/7.29.8_@types+node@18.19.62:
-    resolution: {integrity: sha512-t3Z/xcO6TRbMcnKGVMs4uMzv/gd5j0NhMiJIGjD4cJMeFJ1Hf8wnLSx37vxlRlL0GWlGJhnFgxvnaL6JlS+73g==}
+  /@microsoft/api-extractor-model/7.28.13_@types+node@18.19.39:
+    resolution: {integrity: sha512-39v/JyldX4MS9uzHcdfmjjfS6cYGAoXV+io8B5a338pkHiSt+gy2eXQ0Q7cGFJ7quSa1VqqlMdlPrB6sLR/cAw==}
     dependencies:
-      '@microsoft/tsdoc': 0.15.0
-      '@microsoft/tsdoc-config': 0.17.0
-      '@rushstack/node-core-library': 5.9.0_@types+node@18.19.62
+      '@microsoft/tsdoc': 0.14.2
+      '@microsoft/tsdoc-config': 0.16.2
+      '@rushstack/node-core-library': 4.0.2_@types+node@18.19.39
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  /@microsoft/api-extractor/7.47.11:
-    resolution: {integrity: sha512-lrudfbPub5wzBhymfFtgZKuBvXxoSIAdrvS2UbHjoMT2TjIEddq6Z13pcve7A03BAouw0x8sW8G4txdgfiSwpQ==}
+  /@microsoft/api-extractor/7.40.6:
+    resolution: {integrity: sha512-9N+XCIQB94Di+ETTzNGLqjgQydslynHou7QPgDhl5gZ+B/Q5hTv5jtqBglTUnTrC0trHdG5/YKN07ehGKlSb5g==}
     hasBin: true
     dependencies:
-      '@microsoft/api-extractor-model': 7.29.8
-      '@microsoft/tsdoc': 0.15.0
-      '@microsoft/tsdoc-config': 0.17.0
-      '@rushstack/node-core-library': 5.9.0
-      '@rushstack/rig-package': 0.5.3
-      '@rushstack/terminal': 0.14.2
-      '@rushstack/ts-command-line': 4.23.0
+      '@microsoft/api-extractor-model': 7.28.13
+      '@microsoft/tsdoc': 0.14.2
+      '@microsoft/tsdoc-config': 0.16.2
+      '@rushstack/node-core-library': 4.0.2
+      '@rushstack/rig-package': 0.5.2
+      '@rushstack/terminal': 0.9.0
+      '@rushstack/ts-command-line': 4.17.3
       lodash: 4.17.21
-      minimatch: 3.0.8
       resolve: 1.22.8
       semver: 7.5.4
       source-map: 0.6.1
-      typescript: 5.4.2
+      typescript: 5.3.3
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  /@microsoft/api-extractor/7.47.11_@types+node@18.19.62:
-    resolution: {integrity: sha512-lrudfbPub5wzBhymfFtgZKuBvXxoSIAdrvS2UbHjoMT2TjIEddq6Z13pcve7A03BAouw0x8sW8G4txdgfiSwpQ==}
+  /@microsoft/api-extractor/7.40.6_@types+node@18.19.39:
+    resolution: {integrity: sha512-9N+XCIQB94Di+ETTzNGLqjgQydslynHou7QPgDhl5gZ+B/Q5hTv5jtqBglTUnTrC0trHdG5/YKN07ehGKlSb5g==}
     hasBin: true
     dependencies:
-      '@microsoft/api-extractor-model': 7.29.8_@types+node@18.19.62
-      '@microsoft/tsdoc': 0.15.0
-      '@microsoft/tsdoc-config': 0.17.0
-      '@rushstack/node-core-library': 5.9.0_@types+node@18.19.62
-      '@rushstack/rig-package': 0.5.3
-      '@rushstack/terminal': 0.14.2_@types+node@18.19.62
-      '@rushstack/ts-command-line': 4.23.0_@types+node@18.19.62
+      '@microsoft/api-extractor-model': 7.28.13_@types+node@18.19.39
+      '@microsoft/tsdoc': 0.14.2
+      '@microsoft/tsdoc-config': 0.16.2
+      '@rushstack/node-core-library': 4.0.2_@types+node@18.19.39
+      '@rushstack/rig-package': 0.5.2
+      '@rushstack/terminal': 0.9.0_@types+node@18.19.39
+      '@rushstack/ts-command-line': 4.17.3_@types+node@18.19.39
       lodash: 4.17.21
-      minimatch: 3.0.8
       resolve: 1.22.8
       semver: 7.5.4
       source-map: 0.6.1
-      typescript: 5.4.2
+      typescript: 5.3.3
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  /@microsoft/tsdoc-config/0.17.0:
-    resolution: {integrity: sha512-v/EYRXnCAIHxOHW+Plb6OWuUoMotxTN0GLatnpOb1xq0KuTNw/WI3pamJx/UbsoJP5k9MCw1QxvvhPcF9pH3Zg==}
+  /@microsoft/tsdoc-config/0.16.2:
+    resolution: {integrity: sha512-OGiIzzoBLgWWR0UdRJX98oYO+XKGf7tiK4Zk6tQ/E4IJqGCe7dvkTvgDZV5cFJUzLGDOjeAXrnZoA6QkVySuxw==}
     dependencies:
-      '@microsoft/tsdoc': 0.15.0
-      ajv: 8.12.0
+      '@microsoft/tsdoc': 0.14.2
+      ajv: 6.12.6
       jju: 1.4.0
-      resolve: 1.22.8
+      resolve: 1.19.0
     dev: true
 
-  /@microsoft/tsdoc/0.15.0:
-    resolution: {integrity: sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA==}
+  /@microsoft/tsdoc/0.14.2:
+    resolution: {integrity: sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==}
     dev: true
 
   /@nicolo-ribaudo/eslint-scope-5-internals/5.1.1-v1:
@@ -4454,144 +4570,13 @@ packages:
     resolution: {integrity: sha512-NoOejniaqzOEbHg3RcBZtTriYqhqpQFgTC4lDNaRbgRCnpz6n8PlxWlCbh2N1K5qKawfxRP29/Wiho3FrXQ3Qw==}
     dependencies:
       '@types/base64-js': 1.3.2
-      '@types/jquery': 3.5.32
+      '@types/jquery': 3.5.30
       base64-js: 1.5.1
-      follow-redirects: 1.15.9
-      form-data: 4.0.1
+      follow-redirects: 1.15.6
+      form-data: 4.0.0
       opener: 1.5.2
     transitivePeerDependencies:
       - debug
-
-  /@parcel/watcher-android-arm64/2.4.1:
-    resolution: {integrity: sha512-LOi/WTbbh3aTn2RYddrO8pnapixAziFl6SMxHM69r3tvdSm94JtCenaKgk1GRg5FJ5wpMCpHeW+7yqPlvZv7kg==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@parcel/watcher-darwin-arm64/2.4.1:
-    resolution: {integrity: sha512-ln41eihm5YXIY043vBrrHfn94SIBlqOWmoROhsMVTSXGh0QahKGy77tfEywQ7v3NywyxBBkGIfrWRHm0hsKtzA==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@parcel/watcher-darwin-x64/2.4.1:
-    resolution: {integrity: sha512-yrw81BRLjjtHyDu7J61oPuSoeYWR3lDElcPGJyOvIXmor6DEo7/G2u1o7I38cwlcoBHQFULqF6nesIX3tsEXMg==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@parcel/watcher-freebsd-x64/2.4.1:
-    resolution: {integrity: sha512-TJa3Pex/gX3CWIx/Co8k+ykNdDCLx+TuZj3f3h7eOjgpdKM+Mnix37RYsYU4LHhiYJz3DK5nFCCra81p6g050w==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@parcel/watcher-linux-arm-glibc/2.4.1:
-    resolution: {integrity: sha512-4rVYDlsMEYfa537BRXxJ5UF4ddNwnr2/1O4MHM5PjI9cvV2qymvhwZSFgXqbS8YoTk5i/JR0L0JDs69BUn45YA==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@parcel/watcher-linux-arm64-glibc/2.4.1:
-    resolution: {integrity: sha512-BJ7mH985OADVLpbrzCLgrJ3TOpiZggE9FMblfO65PlOCdG++xJpKUJ0Aol74ZUIYfb8WsRlUdgrZxKkz3zXWYA==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@parcel/watcher-linux-arm64-musl/2.4.1:
-    resolution: {integrity: sha512-p4Xb7JGq3MLgAfYhslU2SjoV9G0kI0Xry0kuxeG/41UfpjHGOhv7UoUDAz/jb1u2elbhazy4rRBL8PegPJFBhA==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@parcel/watcher-linux-x64-glibc/2.4.1:
-    resolution: {integrity: sha512-s9O3fByZ/2pyYDPoLM6zt92yu6P4E39a03zvO0qCHOTjxmt3GHRMLuRZEWhWLASTMSrrnVNWdVI/+pUElJBBBg==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@parcel/watcher-linux-x64-musl/2.4.1:
-    resolution: {integrity: sha512-L2nZTYR1myLNST0O632g0Dx9LyMNHrn6TOt76sYxWLdff3cB22/GZX2UPtJnaqQPdCRoszoY5rcOj4oMTtp5fQ==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@parcel/watcher-win32-arm64/2.4.1:
-    resolution: {integrity: sha512-Uq2BPp5GWhrq/lcuItCHoqxjULU1QYEcyjSO5jqqOK8RNFDBQnenMMx4gAl3v8GiWa59E9+uDM7yZ6LxwUIfRg==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@parcel/watcher-win32-ia32/2.4.1:
-    resolution: {integrity: sha512-maNRit5QQV2kgHFSYwftmPBxiuK5u4DXjbXx7q6eKjq5dsLXZ4FJiVvlcw35QXzk0KrUecJmuVFbj4uV9oYrcw==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@parcel/watcher-win32-x64/2.4.1:
-    resolution: {integrity: sha512-+DvS92F9ezicfswqrvIRM2njcYJbd5mb9CUgtrHCHmvn7pPPa+nMDRu1o1bYYz/l5IB2NVGNJWiH7h1E58IF2A==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@parcel/watcher/2.4.1:
-    resolution: {integrity: sha512-HNjmfLQEVRZmHRET336f20H/8kOozUGwk7yajvsonjNxbj2wBTK1WsQuHkD5yYh9RxFGL2EyDHryOihOwUoKDA==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      detect-libc: 1.0.3
-      is-glob: 4.0.3
-      micromatch: 4.0.8
-      node-addon-api: 7.1.1
-    optionalDependencies:
-      '@parcel/watcher-android-arm64': 2.4.1
-      '@parcel/watcher-darwin-arm64': 2.4.1
-      '@parcel/watcher-darwin-x64': 2.4.1
-      '@parcel/watcher-freebsd-x64': 2.4.1
-      '@parcel/watcher-linux-arm-glibc': 2.4.1
-      '@parcel/watcher-linux-arm64-glibc': 2.4.1
-      '@parcel/watcher-linux-arm64-musl': 2.4.1
-      '@parcel/watcher-linux-x64-glibc': 2.4.1
-      '@parcel/watcher-linux-x64-musl': 2.4.1
-      '@parcel/watcher-win32-arm64': 2.4.1
-      '@parcel/watcher-win32-ia32': 2.4.1
-      '@parcel/watcher-win32-x64': 2.4.1
-    dev: true
 
   /@pkgjs/parseargs/0.11.0:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -4600,7 +4585,7 @@ packages:
     dev: true
     optional: true
 
-  /@pmmmwh/react-refresh-webpack-plugin/0.5.15_e3ej43g5iw5szlea4i3o2x6iq4:
+  /@pmmmwh/react-refresh-webpack-plugin/0.5.15_zciuhk7ajont242gc253fauh24:
     resolution: {integrity: sha512-LFWllMA55pzB9D34w/wXUCf8+c+IYKuJDgxiZ3qMhl64KRMBHYM1I3VdGaD2BV5FNPV2/S2596bppxHbv2ZydQ==}
     engines: {node: '>= 10.13'}
     peerDependencies:
@@ -4627,15 +4612,15 @@ packages:
         optional: true
     dependencies:
       ansi-html: 0.0.9
-      core-js-pure: 3.39.0
+      core-js-pure: 3.37.1
       error-stack-parser: 2.1.4
       html-entities: 2.5.2
       loader-utils: 2.0.4
       react-refresh: 0.11.0
       schema-utils: 4.2.0
       source-map: 0.7.4
-      webpack: 5.95.0
-      webpack-dev-server: 4.15.2_webpack@5.95.0
+      webpack: 5.92.1
+      webpack-dev-server: 4.15.2_webpack@5.92.1
     dev: true
 
   /@popperjs/core/2.11.8:
@@ -4644,25 +4629,25 @@ packages:
   /@probe.gl/env/3.6.0:
     resolution: {integrity: sha512-4tTZYUg/8BICC3Yyb9rOeoKeijKbZHRXBEKObrfPmX4sQmYB15ZOUpoVBhAyJkOYVAM8EkPci6Uw5dLCwx2BEQ==}
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.24.7
 
   /@probe.gl/log/3.6.0:
     resolution: {integrity: sha512-hjpyenpEvOdowgZ1qMeCJxfRD4JkKdlXz0RC14m42Un62NtOT+GpWyKA4LssT0+xyLULCByRAtG2fzZorpIAcA==}
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.24.7
       '@probe.gl/env': 3.6.0
 
   /@probe.gl/stats/3.6.0:
     resolution: {integrity: sha512-JdALQXB44OP4kUBN/UrQgzbJe4qokbVF4Y8lkIA8iVCFnjVowWIgkD/z/0QO65yELT54tTrtepw1jScjKB+rhQ==}
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.24.7
 
-  /@remix-run/router/1.20.0:
-    resolution: {integrity: sha512-mUnk8rPJBI9loFDZ+YzPGdeniYK+FTmRD1TMCz7ev2SNIozyKKpnGgsxO34u6Z4z/t0ITuu7voi/AshfsGsgFg==}
+  /@remix-run/router/1.17.1:
+    resolution: {integrity: sha512-mCOMec4BKd6BRGBZeSnGiIgwsbLGp3yhVqAD8H+PxiRNEHgDpZb8J1TnrSDlg97t0ySKMQJTHCWBCmBpSmkF6Q==}
     engines: {node: '>=14.0.0'}
     dev: false
 
-  /@rollup/plugin-babel/5.3.1_jv6xoz77vs757ecddpkzporema:
+  /@rollup/plugin-babel/5.3.1_je4nbmfg47mhbnn75kmajdcj7i:
     resolution: {integrity: sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
@@ -4673,40 +4658,40 @@ packages:
       '@types/babel__core':
         optional: true
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-module-imports': 7.25.9
-      '@rollup/pluginutils': 3.1.0_rollup@2.79.2
-      rollup: 2.79.2
+      '@babel/core': 7.24.7
+      '@babel/helper-module-imports': 7.24.7
+      '@rollup/pluginutils': 3.1.0_rollup@2.79.1
+      rollup: 2.79.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@rollup/plugin-node-resolve/11.2.1_rollup@2.79.2:
+  /@rollup/plugin-node-resolve/11.2.1_rollup@2.79.1:
     resolution: {integrity: sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.79.2
+      '@rollup/pluginutils': 3.1.0_rollup@2.79.1
       '@types/resolve': 1.17.1
       builtin-modules: 3.3.0
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.8
-      rollup: 2.79.2
+      rollup: 2.79.1
     dev: true
 
-  /@rollup/plugin-replace/2.4.2_rollup@2.79.2:
+  /@rollup/plugin-replace/2.4.2_rollup@2.79.1:
     resolution: {integrity: sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==}
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.79.2
+      '@rollup/pluginutils': 3.1.0_rollup@2.79.1
       magic-string: 0.25.9
-      rollup: 2.79.2
+      rollup: 2.79.1
     dev: true
 
-  /@rollup/pluginutils/3.1.0_rollup@2.79.2:
+  /@rollup/pluginutils/3.1.0_rollup@2.79.1:
     resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
@@ -4715,90 +4700,82 @@ packages:
       '@types/estree': 0.0.39
       estree-walker: 1.0.1
       picomatch: 2.3.1
-      rollup: 2.79.2
+      rollup: 2.79.1
     dev: true
 
-  /@rtsao/scc/1.1.0:
-    resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+  /@rushstack/eslint-patch/1.10.3:
+    resolution: {integrity: sha512-qC/xYId4NMebE6w/V33Fh9gWxLgURiNYgVNObbJl2LZv0GUUItCcCqC5axQSwRaAgaxl2mELq1rMzlswaQ0Zxg==}
     dev: true
 
-  /@rushstack/eslint-patch/1.10.4:
-    resolution: {integrity: sha512-WJgX9nzTqknM393q1QJDJmoW28kUfEnybeTfVNcNAPnIx210RXm2DiXiHzfNPJNIUUb1tJnz/l4QGtJ30PgWmA==}
-    dev: true
-
-  /@rushstack/node-core-library/5.9.0:
-    resolution: {integrity: sha512-MMsshEWkTbXqxqFxD4gcIUWQOCeBChlGczdZbHfqmNZQFLHB3yWxDFSMHFUdu2/OB9NUk7Awn5qRL+rws4HQNg==}
+  /@rushstack/node-core-library/4.0.2:
+    resolution: {integrity: sha512-hyES82QVpkfQMeBMteQUnrhASL/KHPhd7iJ8euduwNJG4mu2GSOKybf0rOEjOm1Wz7CwJEUm9y0yD7jg2C1bfg==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
     dependencies:
-      ajv: 8.13.0
-      ajv-draft-04: 1.0.0_ajv@8.13.0
-      ajv-formats: 3.0.1
       fs-extra: 7.0.1
       import-lazy: 4.0.0
       jju: 1.4.0
       resolve: 1.22.8
       semver: 7.5.4
+      z-schema: 5.0.5
     dev: true
 
-  /@rushstack/node-core-library/5.9.0_@types+node@18.19.62:
-    resolution: {integrity: sha512-MMsshEWkTbXqxqFxD4gcIUWQOCeBChlGczdZbHfqmNZQFLHB3yWxDFSMHFUdu2/OB9NUk7Awn5qRL+rws4HQNg==}
+  /@rushstack/node-core-library/4.0.2_@types+node@18.19.39:
+    resolution: {integrity: sha512-hyES82QVpkfQMeBMteQUnrhASL/KHPhd7iJ8euduwNJG4mu2GSOKybf0rOEjOm1Wz7CwJEUm9y0yD7jg2C1bfg==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
     dependencies:
-      '@types/node': 18.19.62
-      ajv: 8.13.0
-      ajv-draft-04: 1.0.0_ajv@8.13.0
-      ajv-formats: 3.0.1
+      '@types/node': 18.19.39
       fs-extra: 7.0.1
       import-lazy: 4.0.0
       jju: 1.4.0
       resolve: 1.22.8
       semver: 7.5.4
+      z-schema: 5.0.5
     dev: true
 
-  /@rushstack/rig-package/0.5.3:
-    resolution: {integrity: sha512-olzSSjYrvCNxUFZowevC3uz8gvKr3WTpHQ7BkpjtRpA3wK+T0ybep/SRUMfr195gBzJm5gaXw0ZMgjIyHqJUow==}
+  /@rushstack/rig-package/0.5.2:
+    resolution: {integrity: sha512-mUDecIJeH3yYGZs2a48k+pbhM6JYwWlgjs2Ca5f2n1G2/kgdgP9D/07oglEGf6mRyXEnazhEENeYTSNDRCwdqA==}
     dependencies:
       resolve: 1.22.8
       strip-json-comments: 3.1.1
     dev: true
 
-  /@rushstack/terminal/0.14.2:
-    resolution: {integrity: sha512-2fC1wqu1VCExKC0/L+0noVcFQEXEnoBOtCIex1TOjBzEDWcw8KzJjjj7aTP6mLxepG0XIyn9OufeFb6SFsa+sg==}
+  /@rushstack/terminal/0.9.0:
+    resolution: {integrity: sha512-49RnIDooriXyqcd7mGyjh9CmjOjf/Vn8PkOQXHa1CS0/RrrynCJLFhRDkswf7gGXZW+6UhROOE8wTmbOrfUTSA==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
     dependencies:
-      '@rushstack/node-core-library': 5.9.0
-      supports-color: 8.1.1
+      '@rushstack/node-core-library': 4.0.2
+      colors: 1.2.5
     dev: true
 
-  /@rushstack/terminal/0.14.2_@types+node@18.19.62:
-    resolution: {integrity: sha512-2fC1wqu1VCExKC0/L+0noVcFQEXEnoBOtCIex1TOjBzEDWcw8KzJjjj7aTP6mLxepG0XIyn9OufeFb6SFsa+sg==}
+  /@rushstack/terminal/0.9.0_@types+node@18.19.39:
+    resolution: {integrity: sha512-49RnIDooriXyqcd7mGyjh9CmjOjf/Vn8PkOQXHa1CS0/RrrynCJLFhRDkswf7gGXZW+6UhROOE8wTmbOrfUTSA==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
     dependencies:
-      '@rushstack/node-core-library': 5.9.0_@types+node@18.19.62
-      '@types/node': 18.19.62
-      supports-color: 8.1.1
+      '@rushstack/node-core-library': 4.0.2_@types+node@18.19.39
+      '@types/node': 18.19.39
+      colors: 1.2.5
     dev: true
 
-  /@rushstack/ts-command-line/4.23.0:
-    resolution: {integrity: sha512-jYREBtsxduPV6ptNq8jOKp9+yx0ld1Tb/Tkdnlj8gTjazl1sF3DwX2VbluyYrNd0meWIL0bNeer7WDf5tKFjaQ==}
+  /@rushstack/ts-command-line/4.17.3:
+    resolution: {integrity: sha512-/PtTYW38A8iUviuCmQSccHfmx3uBh4Jm5YRPU2aTgYEgwT2jtg60vAbwnkMYkyaT1AbWpjZM3xq5uHYPURvStw==}
     dependencies:
-      '@rushstack/terminal': 0.14.2
+      '@rushstack/terminal': 0.9.0
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -4806,16 +4783,19 @@ packages:
       - '@types/node'
     dev: true
 
-  /@rushstack/ts-command-line/4.23.0_@types+node@18.19.62:
-    resolution: {integrity: sha512-jYREBtsxduPV6ptNq8jOKp9+yx0ld1Tb/Tkdnlj8gTjazl1sF3DwX2VbluyYrNd0meWIL0bNeer7WDf5tKFjaQ==}
+  /@rushstack/ts-command-line/4.17.3_@types+node@18.19.39:
+    resolution: {integrity: sha512-/PtTYW38A8iUviuCmQSccHfmx3uBh4Jm5YRPU2aTgYEgwT2jtg60vAbwnkMYkyaT1AbWpjZM3xq5uHYPURvStw==}
     dependencies:
-      '@rushstack/terminal': 0.14.2_@types+node@18.19.62
+      '@rushstack/terminal': 0.9.0_@types+node@18.19.39
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
     transitivePeerDependencies:
       - '@types/node'
     dev: true
+
+  /@seznam/compose-react-refs/1.0.6:
+    resolution: {integrity: sha512-izzOXQfeQLonzrIQb8u6LQ8dk+ymz3WXTIXjvOlTXHq6sbzROg3NWU+9TTAOpEoK9Bth24/6F/XrfHJ5yR5n6Q==}
 
   /@sinclair/typebox/0.24.51:
     resolution: {integrity: sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==}
@@ -4853,29 +4833,29 @@ packages:
       '@sinonjs/commons': 1.8.6
     dev: true
 
-  /@stylelint/postcss-css-in-js/0.37.3_7ddkth4qkj3urzklvpilix4jii:
+  /@stylelint/postcss-css-in-js/0.37.3_lrpgrolfvll3p4c7yzuvfga3qm:
     resolution: {integrity: sha512-scLk3cSH1H9KggSniseb2KNAU5D9FWc3H7BxCSAIdtU9OWIyw0zkEZ9qEKHryRM+SExYXRKNb7tOOVNAsQ3iwg==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       postcss: '>=7.0.0'
       postcss-syntax: '>=0.36.2'
     dependencies:
-      '@babel/core': 7.26.0
-      postcss: 8.4.47
-      postcss-syntax: 0.36.2_postcss@8.4.47
+      '@babel/core': 7.24.7
+      postcss: 8.4.39
+      postcss-syntax: 0.36.2_postcss@8.4.39
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@stylelint/postcss-markdown/0.36.2_7ddkth4qkj3urzklvpilix4jii:
+  /@stylelint/postcss-markdown/0.36.2_lrpgrolfvll3p4c7yzuvfga3qm:
     resolution: {integrity: sha512-2kGbqUVJUGE8dM+bMzXG/PYUWKkjLIkRLWNh39OaADkiabDRdw8ATFCgbMz5xdIcvwspPAluSL7uY+ZiTWdWmQ==}
     deprecated: 'Use the original unforked package instead: postcss-markdown'
     peerDependencies:
       postcss: '>=7.0.0'
       postcss-syntax: '>=0.36.2'
     dependencies:
-      postcss: 8.4.47
-      postcss-syntax: 0.36.2_postcss@8.4.47
+      postcss: 8.4.39
+      postcss-syntax: 0.36.2_postcss@8.4.39
       remark: 13.0.0
       unist-util-find-all-after: 3.0.2
     transitivePeerDependencies:
@@ -4894,101 +4874,101 @@ packages:
   /@svgdotjs/svg.js/3.0.13:
     resolution: {integrity: sha512-Ix3dobG2DvdK5f2SHtZdiiLwi+G0RDuDfwA4tZ1eqTGoiopia8JIfeWGeA0h2frFHcLDXnYvNiVGtW4y6cSDig==}
 
-  /@svgr/babel-plugin-add-jsx-attribute/6.5.1_@babel+core@7.26.0:
+  /@svgr/babel-plugin-add-jsx-attribute/6.5.1_@babel+core@7.24.7:
     resolution: {integrity: sha512-9PYGcXrAxitycIjRmZB+Q0JaN07GZIWaTBIGQzfaZv+qr1n8X1XUEJ5rZ/vx6OVD9RRYlrNnXWExQXcmZeD/BQ==}
     engines: {node: '>=10'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.24.7
     dev: true
 
-  /@svgr/babel-plugin-remove-jsx-attribute/8.0.0_@babel+core@7.26.0:
+  /@svgr/babel-plugin-remove-jsx-attribute/8.0.0_@babel+core@7.24.7:
     resolution: {integrity: sha512-BcCkm/STipKvbCl6b7QFrMh/vx00vIP63k2eM66MfHJzPr6O2U0jYEViXkHJWqXqQYjdeA9cuCl5KWmlwjDvbA==}
     engines: {node: '>=14'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.24.7
     dev: true
 
-  /@svgr/babel-plugin-remove-jsx-empty-expression/8.0.0_@babel+core@7.26.0:
+  /@svgr/babel-plugin-remove-jsx-empty-expression/8.0.0_@babel+core@7.24.7:
     resolution: {integrity: sha512-5BcGCBfBxB5+XSDSWnhTThfI9jcO5f0Ai2V24gZpG+wXF14BzwxxdDb4g6trdOux0rhibGs385BeFMSmxtS3uA==}
     engines: {node: '>=14'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.24.7
     dev: true
 
-  /@svgr/babel-plugin-replace-jsx-attribute-value/6.5.1_@babel+core@7.26.0:
+  /@svgr/babel-plugin-replace-jsx-attribute-value/6.5.1_@babel+core@7.24.7:
     resolution: {integrity: sha512-8DPaVVE3fd5JKuIC29dqyMB54sA6mfgki2H2+swh+zNJoynC8pMPzOkidqHOSc6Wj032fhl8Z0TVn1GiPpAiJg==}
     engines: {node: '>=10'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.24.7
     dev: true
 
-  /@svgr/babel-plugin-svg-dynamic-title/6.5.1_@babel+core@7.26.0:
+  /@svgr/babel-plugin-svg-dynamic-title/6.5.1_@babel+core@7.24.7:
     resolution: {integrity: sha512-FwOEi0Il72iAzlkaHrlemVurgSQRDFbk0OC8dSvD5fSBPHltNh7JtLsxmZUhjYBZo2PpcU/RJvvi6Q0l7O7ogw==}
     engines: {node: '>=10'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.24.7
     dev: true
 
-  /@svgr/babel-plugin-svg-em-dimensions/6.5.1_@babel+core@7.26.0:
+  /@svgr/babel-plugin-svg-em-dimensions/6.5.1_@babel+core@7.24.7:
     resolution: {integrity: sha512-gWGsiwjb4tw+ITOJ86ndY/DZZ6cuXMNE/SjcDRg+HLuCmwpcjOktwRF9WgAiycTqJD/QXqL2f8IzE2Rzh7aVXA==}
     engines: {node: '>=10'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.24.7
     dev: true
 
-  /@svgr/babel-plugin-transform-react-native-svg/6.5.1_@babel+core@7.26.0:
+  /@svgr/babel-plugin-transform-react-native-svg/6.5.1_@babel+core@7.24.7:
     resolution: {integrity: sha512-2jT3nTayyYP7kI6aGutkyfJ7UMGtuguD72OjeGLwVNyfPRBD8zQthlvL+fAbAKk5n9ZNcvFkp/b1lZ7VsYqVJg==}
     engines: {node: '>=10'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.24.7
     dev: true
 
-  /@svgr/babel-plugin-transform-svg-component/6.5.1_@babel+core@7.26.0:
+  /@svgr/babel-plugin-transform-svg-component/6.5.1_@babel+core@7.24.7:
     resolution: {integrity: sha512-a1p6LF5Jt33O3rZoVRBqdxL350oge54iZWHNI6LJB5tQ7EelvD/Mb1mfBiZNAan0dt4i3VArkFRjA4iObuNykQ==}
     engines: {node: '>=12'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.24.7
     dev: true
 
-  /@svgr/babel-preset/6.5.1_@babel+core@7.26.0:
+  /@svgr/babel-preset/6.5.1_@babel+core@7.24.7:
     resolution: {integrity: sha512-6127fvO/FF2oi5EzSQOAjo1LE3OtNVh11R+/8FXa+mHx1ptAaS4cknIjnUA7e6j6fwGGJ17NzaTJFUwOV2zwCw==}
     engines: {node: '>=10'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.26.0
-      '@svgr/babel-plugin-add-jsx-attribute': 6.5.1_@babel+core@7.26.0
-      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0_@babel+core@7.26.0
-      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0_@babel+core@7.26.0
-      '@svgr/babel-plugin-replace-jsx-attribute-value': 6.5.1_@babel+core@7.26.0
-      '@svgr/babel-plugin-svg-dynamic-title': 6.5.1_@babel+core@7.26.0
-      '@svgr/babel-plugin-svg-em-dimensions': 6.5.1_@babel+core@7.26.0
-      '@svgr/babel-plugin-transform-react-native-svg': 6.5.1_@babel+core@7.26.0
-      '@svgr/babel-plugin-transform-svg-component': 6.5.1_@babel+core@7.26.0
+      '@babel/core': 7.24.7
+      '@svgr/babel-plugin-add-jsx-attribute': 6.5.1_@babel+core@7.24.7
+      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0_@babel+core@7.24.7
+      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0_@babel+core@7.24.7
+      '@svgr/babel-plugin-replace-jsx-attribute-value': 6.5.1_@babel+core@7.24.7
+      '@svgr/babel-plugin-svg-dynamic-title': 6.5.1_@babel+core@7.24.7
+      '@svgr/babel-plugin-svg-em-dimensions': 6.5.1_@babel+core@7.24.7
+      '@svgr/babel-plugin-transform-react-native-svg': 6.5.1_@babel+core@7.24.7
+      '@svgr/babel-plugin-transform-svg-component': 6.5.1_@babel+core@7.24.7
     dev: true
 
   /@svgr/core/6.5.1:
     resolution: {integrity: sha512-/xdLSWxK5QkqG524ONSjvg3V/FkNyCv538OIBdQqPNaAta3AsXj/Bd2FbvR87yMbXO2hFSWiAe/Q6IkVPDw+mw==}
     engines: {node: '>=10'}
     dependencies:
-      '@babel/core': 7.26.0
-      '@svgr/babel-preset': 6.5.1_@babel+core@7.26.0
+      '@babel/core': 7.24.7
+      '@svgr/babel-preset': 6.5.1_@babel+core@7.24.7
       '@svgr/plugin-jsx': 6.5.1_@svgr+core@6.5.1
       camelcase: 6.3.0
       cosmiconfig: 7.1.0
@@ -5000,7 +4980,7 @@ packages:
     resolution: {integrity: sha512-1hnUxxjd83EAxbL4a0JDJoD3Dao3hmjvyvyEV8PzWmLK3B9m9NPlW7GKjFyoWE8nM7HnXzPcmmSyOW8yOddSXw==}
     engines: {node: '>=10'}
     dependencies:
-      '@babel/types': 7.26.0
+      '@babel/types': 7.24.7
       entities: 4.5.0
     dev: true
 
@@ -5010,8 +4990,8 @@ packages:
     peerDependencies:
       '@svgr/core': ^6.0.0
     dependencies:
-      '@babel/core': 7.26.0
-      '@svgr/babel-preset': 6.5.1_@babel+core@7.26.0
+      '@babel/core': 7.24.7
+      '@svgr/babel-preset': 6.5.1_@babel+core@7.24.7
       '@svgr/core': 6.5.1
       '@svgr/hast-util-to-babel-ast': 6.5.1
       svg-parser: 2.0.4
@@ -5035,11 +5015,11 @@ packages:
     resolution: {integrity: sha512-cQ/AsnBkXPkEK8cLbv4Dm7JGXq2XrumKnL1dRpJD9rIO2fTIlJI9a1uCciYG1F2aUsox/hJQyNGbt3soDxSRkA==}
     engines: {node: '>=10'}
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/plugin-transform-react-constant-elements': 7.25.9_@babel+core@7.26.0
-      '@babel/preset-env': 7.26.0_@babel+core@7.26.0
-      '@babel/preset-react': 7.25.9_@babel+core@7.26.0
-      '@babel/preset-typescript': 7.26.0_@babel+core@7.26.0
+      '@babel/core': 7.24.7
+      '@babel/plugin-transform-react-constant-elements': 7.24.7_@babel+core@7.24.7
+      '@babel/preset-env': 7.24.7_@babel+core@7.24.7
+      '@babel/preset-react': 7.24.7_@babel+core@7.24.7
+      '@babel/preset-typescript': 7.24.7_@babel+core@7.24.7
       '@svgr/core': 6.5.1
       '@svgr/plugin-jsx': 6.5.1_@svgr+core@6.5.1
       '@svgr/plugin-svgo': 6.5.1_@svgr+core@6.5.1
@@ -5047,10 +5027,10 @@ packages:
       - supports-color
     dev: true
 
-  /@swc/helpers/0.5.13:
-    resolution: {integrity: sha512-UoKGxQ3r5kYI9dALKJapMmuK+1zWM/H17Z1+iwnNmzcJRnfFuevZs375TA5rW31pu4BS4NoSy1fRsexDXfWn5w==}
+  /@swc/helpers/0.5.11:
+    resolution: {integrity: sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==}
     dependencies:
-      tslib: 2.8.0
+      tslib: 2.6.3
 
   /@szmarczak/http-timer/4.0.6:
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
@@ -5058,25 +5038,12 @@ packages:
     dependencies:
       defer-to-connect: 2.0.1
 
-  /@tanstack/react-virtual/3.10.8_nnrd3gsncyragczmpvfhocinkq:
-    resolution: {integrity: sha512-VbzbVGSsZlQktyLrP5nxE+vE1ZR+U0NFAWPbJLoG2+DKPwd2D7dVICTVIIaYlJqX1ZCEnYDbaOpmMwbsyhBoIA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@tanstack/virtual-core': 3.10.8
-      react: 18.3.1
-      react-dom: 18.3.1_react@18.3.1
-
-  /@tanstack/virtual-core/3.10.8:
-    resolution: {integrity: sha512-PBu00mtt95jbKFi6Llk9aik8bnR3tR/oQP1o3TSi+iG//+Q2RTIzCEgKkHG8BB86kxMNW6O8wku+Lmi+QFR6jA==}
-
   /@testing-library/dom/9.3.4:
     resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
     engines: {node: '>=14'}
     dependencies:
-      '@babel/code-frame': 7.26.2
-      '@babel/runtime': 7.26.0
+      '@babel/code-frame': 7.24.7
+      '@babel/runtime': 7.24.7
       '@types/aria-query': 5.0.4
       aria-query: 5.1.3
       chalk: 4.1.2
@@ -5089,7 +5056,7 @@ packages:
     resolution: {integrity: sha512-j31Bn0rQo12fhCWOUWy9fl7wtqkp7In/YP2p5ZFyRuiiB9Qs3g+hS4gAmDWONbAHcRmVooNJ5eOHQDCOmUFXHg==}
     engines: {node: '>=8', npm: '>=6'}
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.24.7
       chalk: 2.4.2
       css: 2.2.4
       css.escape: 1.5.1
@@ -5107,9 +5074,9 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.24.7
       '@testing-library/dom': 9.3.4
-      '@types/react-dom': 18.3.1
+      '@types/react-dom': 18.3.0
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
     dev: true
@@ -5156,8 +5123,8 @@ packages:
   /@types/babel__core/7.20.5:
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
     dependencies:
-      '@babel/parser': 7.26.2
-      '@babel/types': 7.26.0
+      '@babel/parser': 7.24.7
+      '@babel/types': 7.24.7
       '@types/babel__generator': 7.6.8
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.20.6
@@ -5166,20 +5133,20 @@ packages:
   /@types/babel__generator/7.6.8:
     resolution: {integrity: sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==}
     dependencies:
-      '@babel/types': 7.26.0
+      '@babel/types': 7.24.7
     dev: true
 
   /@types/babel__template/7.4.4:
     resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
     dependencies:
-      '@babel/parser': 7.26.2
-      '@babel/types': 7.26.0
+      '@babel/parser': 7.24.7
+      '@babel/types': 7.24.7
     dev: true
 
   /@types/babel__traverse/7.20.6:
     resolution: {integrity: sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==}
     dependencies:
-      '@babel/types': 7.26.0
+      '@babel/types': 7.24.7
     dev: true
 
   /@types/base64-js/1.3.2:
@@ -5189,13 +5156,13 @@ packages:
     resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
     dev: true
 
   /@types/bonjour/3.5.13:
     resolution: {integrity: sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==}
     dependencies:
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
     dev: true
 
   /@types/cacheable-request/6.0.3:
@@ -5203,30 +5170,37 @@ packages:
     dependencies:
       '@types/http-cache-semantics': 4.0.4
       '@types/keyv': 3.1.4
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       '@types/responselike': 1.0.3
 
   /@types/connect-history-api-fallback/1.5.4:
     resolution: {integrity: sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==}
     dependencies:
-      '@types/express-serve-static-core': 5.0.1
-      '@types/node': 18.19.62
+      '@types/express-serve-static-core': 4.19.5
+      '@types/node': 18.19.39
     dev: true
 
   /@types/connect/3.4.38:
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
     dependencies:
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
     dev: true
 
   /@types/electron-devtools-installer/2.2.5:
     resolution: {integrity: sha512-DhH8z0dadKuDolvH4TiW40Vp7H3VyZbOoZv98hhBaUfnxmvvcXTjkZjzw/54xvAmuG4KFzExOGAiVLg3jM2ojQ==}
     dev: true
 
-  /@types/eslint/8.56.12:
-    resolution: {integrity: sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==}
+  /@types/eslint-scope/3.7.7:
+    resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/eslint': 8.56.10
+      '@types/estree': 1.0.5
+    dev: true
+
+  /@types/eslint/8.56.10:
+    resolution: {integrity: sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==}
+    dependencies:
+      '@types/estree': 1.0.5
       '@types/json-schema': 7.0.15
     dev: true
 
@@ -5234,24 +5208,15 @@ packages:
     resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
     dev: true
 
-  /@types/estree/1.0.6:
-    resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
+  /@types/estree/1.0.5:
+    resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
     dev: true
 
-  /@types/express-serve-static-core/4.19.6:
-    resolution: {integrity: sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==}
+  /@types/express-serve-static-core/4.19.5:
+    resolution: {integrity: sha512-y6W03tvrACO72aijJ5uF02FRq5cgDR9lUxddQ8vyF+GvmjJQqbzDcJngEjURc+ZsG31VI3hODNZJ2URj86pzmg==}
     dependencies:
-      '@types/node': 18.19.62
-      '@types/qs': 6.9.16
-      '@types/range-parser': 1.2.7
-      '@types/send': 0.17.4
-    dev: true
-
-  /@types/express-serve-static-core/5.0.1:
-    resolution: {integrity: sha512-CRICJIl0N5cXDONAdlTv5ShATZ4HEwk6kDDIW2/w9qOWKg+NU/5F8wYRWCrONad0/UKkloNSmmyN/wX4rtpbVA==}
-    dependencies:
-      '@types/node': 18.19.62
-      '@types/qs': 6.9.16
+      '@types/node': 18.19.39
+      '@types/qs': 6.9.15
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
     dev: true
@@ -5260,8 +5225,8 @@ packages:
     resolution: {integrity: sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==}
     dependencies:
       '@types/body-parser': 1.19.5
-      '@types/express-serve-static-core': 4.19.6
-      '@types/qs': 6.9.16
+      '@types/express-serve-static-core': 4.19.5
+      '@types/qs': 6.9.15
       '@types/serve-static': 1.15.7
     dev: true
 
@@ -5271,13 +5236,13 @@ packages:
   /@types/graceful-fs/4.1.9:
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
     dependencies:
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
     dev: true
 
   /@types/hoist-non-react-statics/3.3.5:
     resolution: {integrity: sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==}
     dependencies:
-      '@types/react': 18.3.12
+      '@types/react': 18.3.3
       hoist-non-react-statics: 3.3.2
 
   /@types/html-minifier-terser/6.1.0:
@@ -5291,10 +5256,10 @@ packages:
     resolution: {integrity: sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==}
     dev: true
 
-  /@types/http-proxy/1.17.15:
-    resolution: {integrity: sha512-25g5atgiVNTIv0LBDTg1H74Hvayx0ajtJPLLcYE3whFv75J0pWNtOBzaXJQgDTmrX1bx5U9YC2w/n65BN1HwRQ==}
+  /@types/http-proxy/1.17.14:
+    resolution: {integrity: sha512-SSrD0c1OQzlFX7pGu1eXxSEjemej64aaNPRhhVYUGqXh0BtldAAx37MG8btcumvpgKyZp1F5Gn3JkktdxiFv6w==}
     dependencies:
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
     dev: true
 
   /@types/istanbul-lib-coverage/2.0.6:
@@ -5327,17 +5292,17 @@ packages:
       pretty-format: 26.6.2
     dev: true
 
-  /@types/jquery/3.5.32:
-    resolution: {integrity: sha512-b9Xbf4CkMqS02YH8zACqN1xzdxc3cO735Qe5AbSUFmyOiaWAbcpqh9Wna+Uk0vgACvoQHpWDg2rGdHkYPLmCiQ==}
+  /@types/jquery/3.5.30:
+    resolution: {integrity: sha512-nbWKkkyb919DOUxjmRVk8vwtDb0/k8FKncmUKFi+NY+QXqWltooxTrswvz4LspQwxvLdvzBN1TImr6cw3aQx2A==}
     dependencies:
-      '@types/sizzle': 2.3.9
+      '@types/sizzle': 2.3.8
 
   /@types/jsdom/20.0.1:
     resolution: {integrity: sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==}
     dependencies:
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       '@types/tough-cookie': 4.0.5
-      parse5: 7.2.1
+      parse5: 7.1.2
     dev: true
 
   /@types/json-schema/7.0.15:
@@ -5351,22 +5316,22 @@ packages:
   /@types/keyv/3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
 
   /@types/lodash.isequal/4.5.8:
     resolution: {integrity: sha512-uput6pg4E/tj2LGxCZo9+y27JNyB2OZuuI/T5F+ylVDYuqICLG2/ktjxx0v6GvVntAf8TvEzeQLcV0ffRirXuA==}
     dependencies:
-      '@types/lodash': 4.17.13
+      '@types/lodash': 4.17.6
     dev: true
 
-  /@types/lodash/4.17.13:
-    resolution: {integrity: sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg==}
+  /@types/lodash/4.17.6:
+    resolution: {integrity: sha512-OpXEVoCKSS3lQqjx9GGGOapBeuW5eUboYHRlHP9urXPX25IKZ6AnP5ZRxtVf63iieUbsHxLn8NQ5Nlftc6yzAA==}
     dev: true
 
   /@types/mdast/3.0.15:
     resolution: {integrity: sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==}
     dependencies:
-      '@types/unist': 2.0.11
+      '@types/unist': 2.0.10
     dev: true
 
   /@types/mime/1.3.5:
@@ -5380,11 +5345,11 @@ packages:
   /@types/node-forge/1.3.11:
     resolution: {integrity: sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==}
     dependencies:
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
     dev: true
 
-  /@types/node/18.19.62:
-    resolution: {integrity: sha512-UOGhw+yZV/icyM0qohQVh3ktpY40Sp7tdTW7HxG3pTd7AiMrlFlAJNUrGK9t5mdW0+ViQcFV74zCSIx9ZJpncA==}
+  /@types/node/18.19.39:
+    resolution: {integrity: sha512-nPwTRDKUctxw3di5b4TfT3I0sWDiWoPQCZjXhvdkINntwr8lcoVCKsTgnXeRubKIlfnV+eN/HYk6Jb40tbcEAQ==}
     dependencies:
       undici-types: 5.26.5
 
@@ -5394,58 +5359,62 @@ packages:
 
   /@types/parse-json/4.0.2:
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
-    dev: true
 
   /@types/prettier/2.7.3:
     resolution: {integrity: sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==}
     dev: true
 
-  /@types/prop-types/15.7.13:
-    resolution: {integrity: sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==}
+  /@types/prop-types/15.7.12:
+    resolution: {integrity: sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==}
 
-  /@types/qs/6.9.16:
-    resolution: {integrity: sha512-7i+zxXdPD0T4cKDuxCUXJ4wHcsJLwENa6Z3dCu8cfCK743OGy5Nu1RmAGqDPsoTDINVEcdXKRvR/zre+P2Ku1A==}
+  /@types/qs/6.9.15:
+    resolution: {integrity: sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==}
     dev: true
 
   /@types/range-parser/1.2.7:
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
     dev: true
 
-  /@types/react-dom/18.3.1:
-    resolution: {integrity: sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==}
+  /@types/react-dom/18.3.0:
+    resolution: {integrity: sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==}
     dependencies:
-      '@types/react': 18.3.12
+      '@types/react': 18.3.3
     dev: true
 
-  /@types/react-redux/7.1.34:
-    resolution: {integrity: sha512-GdFaVjEbYv4Fthm2ZLvj1VSCedV7TqE5y1kNwnjSdBOTXuRSgowux6J8TAct15T3CKBr63UMk+2CO7ilRhyrAQ==}
+  /@types/react-redux/7.1.33:
+    resolution: {integrity: sha512-NF8m5AjWCkert+fosDsN3hAlHzpjSiXlVy9EgQEmLoBhaNXbmyeGs/aj5dQzKuF+/q+S7JQagorGDW8pJ28Hmg==}
     dependencies:
       '@types/hoist-non-react-statics': 3.3.5
-      '@types/react': 18.3.12
+      '@types/react': 18.3.3
       hoist-non-react-statics: 3.3.2
       redux: 4.2.1
 
   /@types/react-table/7.7.20:
     resolution: {integrity: sha512-ahMp4pmjVlnExxNwxyaDrFgmKxSbPwU23sGQw2gJK4EhCvnvmib2s/O/+y1dfV57dXOwpr2plfyBol+vEHbi2w==}
     dependencies:
-      '@types/react': 18.3.12
+      '@types/react': 18.3.3
 
-  /@types/react/18.3.12:
-    resolution: {integrity: sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==}
+  /@types/react-transition-group/4.4.10:
+    resolution: {integrity: sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==}
     dependencies:
-      '@types/prop-types': 15.7.13
+      '@types/react': 18.3.3
+
+  /@types/react/18.3.3:
+    resolution: {integrity: sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==}
+    dependencies:
+      '@types/prop-types': 15.7.12
       csstype: 3.1.3
 
   /@types/resolve/1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
     dependencies:
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
     dev: true
 
   /@types/responselike/1.0.3:
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
     dependencies:
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
 
   /@types/retry/0.12.0:
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
@@ -5459,7 +5428,7 @@ packages:
     resolution: {integrity: sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==}
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
     dev: true
 
   /@types/serve-index/1.9.4:
@@ -5472,17 +5441,17 @@ packages:
     resolution: {integrity: sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==}
     dependencies:
       '@types/http-errors': 2.0.4
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       '@types/send': 0.17.4
     dev: true
 
-  /@types/sizzle/2.3.9:
-    resolution: {integrity: sha512-xzLEyKB50yqCUPUJkIsrVvoWNfFUbIZI+RspLWt8u+tIW/BetMBZtgV2LY/2o+tYH8dRvQ+eoPf3NdhQCcLE2w==}
+  /@types/sizzle/2.3.8:
+    resolution: {integrity: sha512-0vWLNK2D5MT9dg0iOo8GlKguPAU02QjmZitPEsXRuJXU/OGIOt9vT9Fc26wtYuavLxtO45v9PGleoL9Z0k1LHg==}
 
   /@types/sockjs/0.3.36:
     resolution: {integrity: sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==}
     dependencies:
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
     dev: true
 
   /@types/stack-utils/2.0.3:
@@ -5497,14 +5466,14 @@ packages:
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
     dev: true
 
-  /@types/unist/2.0.11:
-    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+  /@types/unist/2.0.10:
+    resolution: {integrity: sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==}
     dev: true
 
-  /@types/ws/8.5.12:
-    resolution: {integrity: sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==}
+  /@types/ws/8.5.10:
+    resolution: {integrity: sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==}
     dependencies:
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
     dev: true
 
   /@types/yargs-parser/21.0.3:
@@ -5529,8 +5498,8 @@ packages:
       '@types/yargs-parser': 21.0.3
     dev: true
 
-  /@types/yargs/17.0.33:
-    resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
+  /@types/yargs/17.0.32:
+    resolution: {integrity: sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==}
     dependencies:
       '@types/yargs-parser': 21.0.3
     dev: true
@@ -5539,7 +5508,7 @@ packages:
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
     requiresBuild: true
     dependencies:
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
     optional: true
 
   /@typescript-eslint/eslint-plugin/4.33.0_ffi3uiz42rv3jyhs6cr7p7qqry:
@@ -5556,18 +5525,18 @@ packages:
       '@typescript-eslint/experimental-utils': 4.33.0_eslint@7.32.0
       '@typescript-eslint/parser': 4.33.0_eslint@7.32.0
       '@typescript-eslint/scope-manager': 4.33.0
-      debug: 4.3.7
+      debug: 4.3.5
       eslint: 7.32.0
       functional-red-black-tree: 1.0.1
-      ignore: 5.3.2
+      ignore: 5.3.1
       regexpp: 3.2.0
-      semver: 7.6.3
+      semver: 7.6.2
       tsutils: 3.21.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.62.0_imxewgebu4zsddg3peaq2zpmd4:
+  /@typescript-eslint/eslint-plugin/5.62.0_6642sdbk46myawr2npa4taenme:
     resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5578,17 +5547,17 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 5.62.0_iefaljtug4ytsd5a3rfvfodvxa
+      '@eslint-community/regexpp': 4.11.0
+      '@typescript-eslint/parser': 5.62.0_lhzdwpbtv2n477nxjcr5ny2fnm
       '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0_iefaljtug4ytsd5a3rfvfodvxa
-      '@typescript-eslint/utils': 5.62.0_iefaljtug4ytsd5a3rfvfodvxa
-      debug: 4.3.7
-      eslint: 8.57.1
+      '@typescript-eslint/type-utils': 5.62.0_lhzdwpbtv2n477nxjcr5ny2fnm
+      '@typescript-eslint/utils': 5.62.0_lhzdwpbtv2n477nxjcr5ny2fnm
+      debug: 4.3.5
+      eslint: 8.57.0
       graphemer: 1.4.0
-      ignore: 5.3.2
+      ignore: 5.3.1
       natural-compare-lite: 1.4.0
-      semver: 7.6.3
+      semver: 7.6.2
       tsutils: 3.21.0_typescript@5.0.4
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -5630,14 +5599,14 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/experimental-utils/5.62.0_iefaljtug4ytsd5a3rfvfodvxa:
+  /@typescript-eslint/experimental-utils/5.62.0_lhzdwpbtv2n477nxjcr5ny2fnm:
     resolution: {integrity: sha512-RTXpeB3eMkpoclG3ZHft6vG/Z30azNHuqY6wKPBHlVMZFuEvrtlEDe8gMqDb+SO+9hjC/pLekeSCryf9vMZlCw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.62.0_iefaljtug4ytsd5a3rfvfodvxa
-      eslint: 8.57.1
+      '@typescript-eslint/utils': 5.62.0_lhzdwpbtv2n477nxjcr5ny2fnm
+      eslint: 8.57.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -5656,13 +5625,13 @@ packages:
       '@typescript-eslint/scope-manager': 4.33.0
       '@typescript-eslint/types': 4.33.0
       '@typescript-eslint/typescript-estree': 4.33.0
-      debug: 4.3.7
+      debug: 4.3.5
       eslint: 7.32.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.62.0_iefaljtug4ytsd5a3rfvfodvxa:
+  /@typescript-eslint/parser/5.62.0_lhzdwpbtv2n477nxjcr5ny2fnm:
     resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5675,8 +5644,8 @@ packages:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0_typescript@5.0.4
-      debug: 4.3.7
-      eslint: 8.57.1
+      debug: 4.3.5
+      eslint: 8.57.0
       typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
@@ -5698,7 +5667,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.62.0
     dev: true
 
-  /@typescript-eslint/type-utils/5.62.0_iefaljtug4ytsd5a3rfvfodvxa:
+  /@typescript-eslint/type-utils/5.62.0_lhzdwpbtv2n477nxjcr5ny2fnm:
     resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5709,9 +5678,9 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0_typescript@5.0.4
-      '@typescript-eslint/utils': 5.62.0_iefaljtug4ytsd5a3rfvfodvxa
-      debug: 4.3.7
-      eslint: 8.57.1
+      '@typescript-eslint/utils': 5.62.0_lhzdwpbtv2n477nxjcr5ny2fnm
+      debug: 4.3.5
+      eslint: 8.57.0
       tsutils: 3.21.0_typescript@5.0.4
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -5744,11 +5713,11 @@ packages:
     dependencies:
       '@typescript-eslint/types': 3.10.1
       '@typescript-eslint/visitor-keys': 3.10.1
-      debug: 4.3.7
+      debug: 4.3.5
       glob: 7.2.3
       is-glob: 4.0.3
       lodash: 4.17.21
-      semver: 7.6.3
+      semver: 7.6.2
       tsutils: 3.21.0
     transitivePeerDependencies:
       - supports-color
@@ -5765,10 +5734,10 @@ packages:
     dependencies:
       '@typescript-eslint/types': 4.33.0
       '@typescript-eslint/visitor-keys': 4.33.0
-      debug: 4.3.7
+      debug: 4.3.5
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.6.3
+      semver: 7.6.2
       tsutils: 3.21.0
     transitivePeerDependencies:
       - supports-color
@@ -5785,31 +5754,31 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.7
+      debug: 4.3.5
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.6.3
+      semver: 7.6.2
       tsutils: 3.21.0_typescript@5.0.4
       typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.62.0_iefaljtug4ytsd5a3rfvfodvxa:
+  /@typescript-eslint/utils/5.62.0_lhzdwpbtv2n477nxjcr5ny2fnm:
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.1_eslint@8.57.1
+      '@eslint-community/eslint-utils': 4.4.0_eslint@8.57.0
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0_typescript@5.0.4
-      eslint: 8.57.1
+      eslint: 8.57.0
       eslint-scope: 5.1.1
-      semver: 7.6.3
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -5841,6 +5810,13 @@ packages:
   /@ungap/structured-clone/1.2.0:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
     dev: true
+
+  /@vtaits/use-lazy-ref/0.1.3_react@18.3.1:
+    resolution: {integrity: sha512-ZTLuFBHSivPcgWrwkXe5ExVt6R3/ybD+N0yFPy4ClzCztk/9bUD/1udKQ/jd7eCal+lapSrRWXbffqI9jkpDlg==}
+    peerDependencies:
+      react: ^16.14.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.3.1
 
   /@webassemblyjs/ast/1.12.1:
     resolution: {integrity: sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==}
@@ -5982,16 +5958,16 @@ packages:
   /acorn-globals/7.0.1:
     resolution: {integrity: sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==}
     dependencies:
-      acorn: 8.14.0
-      acorn-walk: 8.3.4
+      acorn: 8.12.1
+      acorn-walk: 8.3.3
     dev: true
 
-  /acorn-import-attributes/1.9.5_acorn@8.14.0:
+  /acorn-import-attributes/1.9.5_acorn@8.12.1:
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
     peerDependencies:
       acorn: ^8
     dependencies:
-      acorn: 8.14.0
+      acorn: 8.12.1
     dev: true
 
   /acorn-jsx/5.3.2_acorn@7.4.1:
@@ -6002,12 +5978,12 @@ packages:
       acorn: 7.4.1
     dev: true
 
-  /acorn-jsx/5.3.2_acorn@8.14.0:
+  /acorn-jsx/5.3.2_acorn@8.12.1:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      acorn: 8.14.0
+      acorn: 8.12.1
     dev: true
 
   /acorn-walk/7.2.0:
@@ -6015,11 +5991,11 @@ packages:
     engines: {node: '>=0.4.0'}
     dev: true
 
-  /acorn-walk/8.3.4:
-    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+  /acorn-walk/8.3.3:
+    resolution: {integrity: sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==}
     engines: {node: '>=0.4.0'}
     dependencies:
-      acorn: 8.14.0
+      acorn: 8.12.1
     dev: true
 
   /acorn/7.4.1:
@@ -6028,8 +6004,8 @@ packages:
     hasBin: true
     dev: true
 
-  /acorn/8.14.0:
-    resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
+  /acorn/8.12.1:
+    resolution: {integrity: sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: true
@@ -6051,7 +6027,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.7
+      debug: 4.3.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6060,7 +6036,7 @@ packages:
     resolution: {integrity: sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==}
     engines: {node: '>= 14'}
     dependencies:
-      debug: 4.3.7
+      debug: 4.3.5
     transitivePeerDependencies:
       - supports-color
 
@@ -6072,33 +6048,13 @@ packages:
       indent-string: 4.0.0
     dev: true
 
-  /ajv-draft-04/1.0.0_ajv@8.13.0:
-    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
-    peerDependencies:
-      ajv: ^8.5.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
-    dependencies:
-      ajv: 8.13.0
-    dev: true
-
   /ajv-formats/2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependenciesMeta:
       ajv:
         optional: true
     dependencies:
-      ajv: 8.17.1
-
-  /ajv-formats/3.0.1:
-    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
-    peerDependenciesMeta:
-      ajv:
-        optional: true
-    dependencies:
-      ajv: 8.13.0
-    dev: true
+      ajv: 8.16.0
 
   /ajv-keywords/3.5.2_ajv@6.12.6:
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
@@ -6108,12 +6064,12 @@ packages:
       ajv: 6.12.6
     dev: true
 
-  /ajv-keywords/5.1.0_ajv@8.17.1:
+  /ajv-keywords/5.1.0_ajv@8.16.0:
     resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
     peerDependencies:
       ajv: ^8.8.2
     dependencies:
-      ajv: 8.17.1
+      ajv: 8.16.0
       fast-deep-equal: 3.1.3
     dev: true
 
@@ -6135,22 +6091,16 @@ packages:
       uri-js: 4.4.1
     dev: true
 
-  /ajv/8.13.0:
-    resolution: {integrity: sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==}
+  /ajv/8.16.0:
+    resolution: {integrity: sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==}
     dependencies:
       fast-deep-equal: 3.1.3
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
       uri-js: 4.4.1
-    dev: true
 
-  /ajv/8.17.1:
-    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-uri: 3.0.3
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
+  /almost-equal/1.1.0:
+    resolution: {integrity: sha512-0V/PkoculFl5+0Lp47JoxUcO0xSxhIBvm+BxHdD/OgXNmdRpRHCFnKVuUoWyS9EzQP+otSGv0m9Lb4yVkQBn2A==}
 
   /ansi-align/3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
@@ -6197,8 +6147,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /ansi-regex/6.1.0:
-    resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
+  /ansi-regex/6.0.1:
+    resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
     engines: {node: '>=12'}
     dev: true
 
@@ -6216,7 +6166,6 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       color-convert: 1.9.3
-    dev: true
 
   /ansi-styles/4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -6269,11 +6218,6 @@ packages:
     resolution: {integrity: sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==}
     dependencies:
       deep-equal: 2.2.3
-    dev: true
-
-  /aria-query/5.3.2:
-    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
-    engines: {node: '>= 0.4'}
     dev: true
 
   /arr-diff/4.0.0:
@@ -6368,6 +6312,15 @@ packages:
       es-shim-unscopables: 1.0.2
     dev: true
 
+  /array.prototype.toreversed/1.1.2:
+    resolution: {integrity: sha512-wwDCoT4Ck4Cz7sLtgUmzR5UV3YF5mFHUlbChCzZBQZ+0m2cl/DH3tKgvphv1nKgFsJ48oCSg6p91q2Vm0I/ZMA==}
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+      es-abstract: 1.23.3
+      es-shim-unscopables: 1.0.2
+    dev: true
+
   /array.prototype.tosorted/1.1.4:
     resolution: {integrity: sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==}
     engines: {node: '>= 0.4'}
@@ -6422,8 +6375,8 @@ packages:
       lodash: 4.17.21
     dev: true
 
-  /async/3.2.6:
-    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
+  /async/3.2.5:
+    resolution: {integrity: sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==}
     dev: true
 
   /asynckit/0.4.0:
@@ -6444,19 +6397,19 @@ packages:
     resolution: {integrity: sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w==}
     engines: {node: '>=10.12.0'}
 
-  /autoprefixer/10.4.20_postcss@8.4.47:
-    resolution: {integrity: sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==}
+  /autoprefixer/10.4.19_postcss@8.4.39:
+    resolution: {integrity: sha512-BaENR2+zBZ8xXhM4pUaKUxlVdxZ0EZhjvbopwnXmxRUfqDmwSpC2lAi/QXvx7NRdPCo1WKEcEF6mV64si1z4Ew==}
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      browserslist: 4.24.2
-      caniuse-lite: 1.0.30001676
+      browserslist: 4.23.2
+      caniuse-lite: 1.0.30001641
       fraction.js: 4.3.7
       normalize-range: 0.1.2
-      picocolors: 1.1.1
-      postcss: 8.4.47
+      picocolors: 1.0.1
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
@@ -6464,12 +6417,12 @@ packages:
     resolution: {integrity: sha512-eM9d/swFopRt5gdJ7jrpCwgvEMIayITpojhkkSMRsFHYuH5bkSQ4p/9qTEHtmNudUZh22Tehu7I6CxAW0IXTKA==}
     hasBin: true
     dependencies:
-      browserslist: 4.24.2
-      caniuse-lite: 1.0.30001676
+      browserslist: 4.23.2
+      caniuse-lite: 1.0.30001641
       normalize-range: 0.1.2
       num2fraction: 1.2.2
       picocolors: 0.2.1
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
@@ -6480,37 +6433,38 @@ packages:
       possible-typed-array-names: 1.0.0
     dev: true
 
-  /axe-core/4.10.2:
-    resolution: {integrity: sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==}
+  /axe-core/4.9.1:
+    resolution: {integrity: sha512-QbUdXJVTpvUTHU7871ppZkdOLBeGUKBQWHkHrvN2V9IQWGMt61zf3B45BtzjxEJzYuj0JBjBZP/hmYS/R9pmAw==}
     engines: {node: '>=4'}
     dev: true
 
-  /axios/1.7.7:
-    resolution: {integrity: sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==}
+  /axios/1.7.4:
+    resolution: {integrity: sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==}
     dependencies:
-      follow-redirects: 1.15.9
-      form-data: 4.0.1
+      follow-redirects: 1.15.6
+      form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
 
-  /axobject-query/4.1.0:
-    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
-    engines: {node: '>= 0.4'}
+  /axobject-query/3.1.1:
+    resolution: {integrity: sha512-goKlv8DZrK9hUh975fnHzhNIO4jUnFCfv/dszV5VwUGDFjI6vQ2VwoyjYjYNEbBE8AH87TduWP5uyDR1D+Iteg==}
+    dependencies:
+      deep-equal: 2.2.3
     dev: true
 
-  /babel-jest/27.5.1_@babel+core@7.26.0:
+  /babel-jest/27.5.1_@babel+core@7.24.7:
     resolution: {integrity: sha512-cdQ5dXjGRd0IBRATiQ4mZGlGlRE8kJpjPOixdNRdT+m3UcNqmYWN6rK6nvtXYfY3D76cb8s/O1Ss8ea24PIwcg==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     peerDependencies:
       '@babel/core': ^7.8.0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.24.7
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
       '@types/babel__core': 7.20.5
       babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 27.5.1_@babel+core@7.26.0
+      babel-preset-jest: 27.5.1_@babel+core@7.24.7
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
@@ -6518,17 +6472,17 @@ packages:
       - supports-color
     dev: true
 
-  /babel-jest/29.7.0_@babel+core@7.26.0:
+  /babel-jest/29.7.0_@babel+core@7.24.7:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       '@babel/core': ^7.8.0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.24.7
       '@jest/transform': 29.7.0
       '@types/babel__core': 7.20.5
       babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 29.6.3_@babel+core@7.26.0
+      babel-preset-jest: 29.6.3_@babel+core@7.24.7
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
@@ -6536,19 +6490,19 @@ packages:
       - supports-color
     dev: true
 
-  /babel-loader/8.4.1_i3bi27r3gwde5aemtthvmmugoi:
-    resolution: {integrity: sha512-nXzRChX+Z1GoE6yWavBQg6jDslyFF3SDjl2paADuoQtQW10JqShJt62R6eJQ5m/pjJFDT8xgKIWSP85OY8eXeA==}
+  /babel-loader/8.3.0_z5hqyrl7ys5omqq6tawbtvekhm:
+    resolution: {integrity: sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==}
     engines: {node: '>= 8.9'}
     peerDependencies:
       '@babel/core': ^7.0.0
       webpack: '>=2'
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.24.7
       find-cache-dir: 3.3.2
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.95.0
+      webpack: 5.92.1
     dev: true
 
   /babel-plugin-import-remove-resource-query/1.0.0:
@@ -6559,7 +6513,7 @@ packages:
     resolution: {integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-plugin-utils': 7.24.7
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-instrument: 5.2.1
@@ -6572,8 +6526,8 @@ packages:
     resolution: {integrity: sha512-50wCwD5EMNW4aRpOwtqzyZHIewTYNxLA4nhB+09d8BIssfNfzBRhkBIHiaPv1Si226TQSvp8gxAJm2iY2qs2hQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@babel/template': 7.25.9
-      '@babel/types': 7.26.0
+      '@babel/template': 7.24.7
+      '@babel/types': 7.24.7
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.6
     dev: true
@@ -6582,8 +6536,8 @@ packages:
     resolution: {integrity: sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@babel/template': 7.25.9
-      '@babel/types': 7.26.0
+      '@babel/template': 7.24.7
+      '@babel/types': 7.24.7
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.6
     dev: true
@@ -6592,51 +6546,50 @@ packages:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
     engines: {node: '>=10', npm: '>=6'}
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.24.7
       cosmiconfig: 7.1.0
       resolve: 1.22.8
-    dev: true
 
-  /babel-plugin-named-asset-import/0.3.8_@babel+core@7.26.0:
+  /babel-plugin-named-asset-import/0.3.8_@babel+core@7.24.7:
     resolution: {integrity: sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q==}
     peerDependencies:
       '@babel/core': ^7.1.0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.24.7
     dev: true
 
-  /babel-plugin-polyfill-corejs2/0.4.11_@babel+core@7.26.0:
+  /babel-plugin-polyfill-corejs2/0.4.11_@babel+core@7.24.7:
     resolution: {integrity: sha512-sMEJ27L0gRHShOh5G54uAAPaiCOygY/5ratXuiyb2G46FmlSpc9eFCzYVyDiPxfNbwzA7mYahmjQc5q+CZQ09Q==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/compat-data': 7.26.2
-      '@babel/core': 7.26.0
-      '@babel/helper-define-polyfill-provider': 0.6.2_@babel+core@7.26.0
+      '@babel/compat-data': 7.24.7
+      '@babel/core': 7.24.7
+      '@babel/helper-define-polyfill-provider': 0.6.2_@babel+core@7.24.7
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /babel-plugin-polyfill-corejs3/0.10.6_@babel+core@7.26.0:
-    resolution: {integrity: sha512-b37+KR2i/khY5sKmWNVQAnitvquQbNdWy6lJdsr0kmquCKEEUgMKK4SboVM3HtfnZilfjr4MMQ7vY58FVWDtIA==}
+  /babel-plugin-polyfill-corejs3/0.10.4_@babel+core@7.24.7:
+    resolution: {integrity: sha512-25J6I8NGfa5YkCDogHRID3fVCadIR8/pGl1/spvCkzb6lVn6SR3ojpx9nOn9iEBcUsjY24AmdKm5khcfKdylcg==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-define-polyfill-provider': 0.6.2_@babel+core@7.26.0
-      core-js-compat: 3.39.0
+      '@babel/core': 7.24.7
+      '@babel/helper-define-polyfill-provider': 0.6.2_@babel+core@7.24.7
+      core-js-compat: 3.37.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /babel-plugin-polyfill-regenerator/0.6.2_@babel+core@7.26.0:
+  /babel-plugin-polyfill-regenerator/0.6.2_@babel+core@7.24.7:
     resolution: {integrity: sha512-2R25rQZWP63nGwaAswvDazbPXfrM3HwVoBXK6HcqeKrSrL/JqcC/rDcf95l4r7LXLyxDXc8uQDa064GubtCABg==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-define-polyfill-provider': 0.6.2_@babel+core@7.26.0
+      '@babel/core': 7.24.7
+      '@babel/helper-define-polyfill-provider': 0.6.2_@babel+core@7.24.7
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6645,68 +6598,65 @@ packages:
     resolution: {integrity: sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==}
     dev: true
 
-  /babel-preset-current-node-syntax/1.1.0_@babel+core@7.26.0:
-    resolution: {integrity: sha512-ldYss8SbBlWva1bs28q78Ju5Zq1F+8BrqBZZ0VFhLBvhh6lCpC2o3gDJi/5DRLs9FgYZCnmPYIVFU4lRXCkyUw==}
+  /babel-preset-current-node-syntax/1.0.1_@babel+core@7.24.7:
+    resolution: {integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.26.0
-      '@babel/plugin-syntax-bigint': 7.8.3_@babel+core@7.26.0
-      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.26.0
-      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.26.0
-      '@babel/plugin-syntax-import-attributes': 7.26.0_@babel+core@7.26.0
-      '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.26.0
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.26.0
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.26.0
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.26.0
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.26.0
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.26.0
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.26.0
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.26.0
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.26.0
-      '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.26.0
+      '@babel/core': 7.24.7
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.24.7
+      '@babel/plugin-syntax-bigint': 7.8.3_@babel+core@7.24.7
+      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.24.7
+      '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.24.7
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.24.7
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.24.7
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.24.7
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.24.7
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.24.7
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.24.7
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.24.7
+      '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.24.7
     dev: true
 
-  /babel-preset-jest/27.5.1_@babel+core@7.26.0:
+  /babel-preset-jest/27.5.1_@babel+core@7.24.7:
     resolution: {integrity: sha512-Nptf2FzlPCWYuJg41HBqXVT8ym6bXOevuCTbhxlUpjwtysGaIWFvDEjp4y+G7fl13FgOdjs7P/DmErqH7da0Ag==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.24.7
       babel-plugin-jest-hoist: 27.5.1
-      babel-preset-current-node-syntax: 1.1.0_@babel+core@7.26.0
+      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.24.7
     dev: true
 
-  /babel-preset-jest/29.6.3_@babel+core@7.26.0:
+  /babel-preset-jest/29.6.3_@babel+core@7.24.7:
     resolution: {integrity: sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.24.7
       babel-plugin-jest-hoist: 29.6.3
-      babel-preset-current-node-syntax: 1.1.0_@babel+core@7.26.0
+      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.24.7
     dev: true
 
   /babel-preset-react-app/10.0.1:
     resolution: {integrity: sha512-b0D9IZ1WhhCWkrTXyFuIIgqGzSkRIH5D5AmB0bXbzYAB1OBAwHcUeyWW2LorutLWF5btNo/N7r/cIdmvvKJlYg==}
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.26.0
-      '@babel/plugin-proposal-decorators': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.26.0
-      '@babel/plugin-proposal-numeric-separator': 7.18.6_@babel+core@7.26.0
-      '@babel/plugin-proposal-optional-chaining': 7.21.0_@babel+core@7.26.0
-      '@babel/plugin-proposal-private-methods': 7.18.6_@babel+core@7.26.0
-      '@babel/plugin-transform-flow-strip-types': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-react-display-name': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-transform-runtime': 7.25.9_@babel+core@7.26.0
-      '@babel/preset-env': 7.26.0_@babel+core@7.26.0
-      '@babel/preset-react': 7.25.9_@babel+core@7.26.0
-      '@babel/preset-typescript': 7.26.0_@babel+core@7.26.0
-      '@babel/runtime': 7.26.0
+      '@babel/core': 7.24.7
+      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.24.7
+      '@babel/plugin-proposal-decorators': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.24.7
+      '@babel/plugin-proposal-numeric-separator': 7.18.6_@babel+core@7.24.7
+      '@babel/plugin-proposal-optional-chaining': 7.21.0_@babel+core@7.24.7
+      '@babel/plugin-proposal-private-methods': 7.18.6_@babel+core@7.24.7
+      '@babel/plugin-transform-flow-strip-types': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-react-display-name': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-transform-runtime': 7.24.7_@babel+core@7.24.7
+      '@babel/preset-env': 7.24.7_@babel+core@7.24.7
+      '@babel/preset-react': 7.24.7_@babel+core@7.24.7
+      '@babel/preset-typescript': 7.24.7_@babel+core@7.24.7
+      '@babel/runtime': 7.24.7
       babel-plugin-macros: 3.1.0
       babel-plugin-transform-react-remove-prop-types: 0.4.24
     transitivePeerDependencies:
@@ -6737,10 +6687,6 @@ packages:
       mixin-deep: 1.3.2
       pascalcase: 0.1.1
     dev: true
-
-  /base64-js/0.0.8:
-    resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
-    engines: {node: '>= 0.4'}
 
   /base64-js/1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -6803,7 +6749,6 @@ packages:
 
   /boolean/3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     optional: true
 
   /boxen/7.0.0:
@@ -6848,15 +6793,15 @@ packages:
     resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
     dev: true
 
-  /browserslist/4.24.2:
-    resolution: {integrity: sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==}
+  /browserslist/4.23.2:
+    resolution: {integrity: sha512-qkqSyistMYdxAcw+CzbZwlBy8AGmS/eEWs+sEV5TnLRGDOL+C5M2EnH6tlZyg0YoAxGJAFKh61En9BR941GnHA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001676
-      electron-to-chromium: 1.5.49
-      node-releases: 2.0.18
-      update-browserslist-db: 1.1.1_browserslist@4.24.2
+      caniuse-lite: 1.0.30001641
+      electron-to-chromium: 1.4.823
+      node-releases: 2.0.14
+      update-browserslist-db: 1.1.0_browserslist@4.23.2
     dev: true
 
   /bs-logger/0.2.6:
@@ -6937,13 +6882,12 @@ packages:
   /callsites/3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
-    dev: true
 
   /camel-case/4.1.2:
     resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
     dependencies:
       pascal-case: 3.1.2
-      tslib: 2.8.0
+      tslib: 2.6.3
     dev: true
 
   /camelcase-css/2.0.1:
@@ -6978,14 +6922,14 @@ packages:
   /caniuse-api/3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
     dependencies:
-      browserslist: 4.24.2
-      caniuse-lite: 1.0.30001676
+      browserslist: 4.23.2
+      caniuse-lite: 1.0.30001641
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
     dev: true
 
-  /caniuse-lite/1.0.30001676:
-    resolution: {integrity: sha512-Qz6zwGCiPghQXGJvgQAem79esjitvJ+CxSbSQkW9H/UX5hg8XM88d4lp2W+MEQ81j+Hip58Il+jGVdazk1z9cw==}
+  /caniuse-lite/1.0.30001641:
+    resolution: {integrity: sha512-Phv5thgl67bHYo1TtMY/MurjkHhV4EDaCosezRXgZ8jzA/Ub+wjxAvbGvjoFENStinwi5kCyOYV3mi5tOGykwA==}
     dev: true
 
   /case-sensitive-paths-webpack-plugin/2.4.0:
@@ -7018,7 +6962,6 @@ packages:
       ansi-styles: 3.2.1
       escape-string-regexp: 1.0.5
       supports-color: 5.5.0
-    dev: true
 
   /chalk/3.0.0:
     resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
@@ -7086,13 +7029,6 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /chokidar/4.0.1:
-    resolution: {integrity: sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==}
-    engines: {node: '>= 14.16.0'}
-    dependencies:
-      readdirp: 4.0.2
-    dev: true
-
   /chrome-trace-event/1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
@@ -7103,8 +7039,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /cjs-module-lexer/1.4.1:
-    resolution: {integrity: sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==}
+  /cjs-module-lexer/1.3.1:
+    resolution: {integrity: sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q==}
     dev: true
 
   /class-utils/0.3.6:
@@ -7233,7 +7169,6 @@ packages:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
     dependencies:
       color-name: 1.1.3
-    dev: true
 
   /color-convert/2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -7244,7 +7179,6 @@ packages:
 
   /color-name/1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
-    dev: true
 
   /color-name/1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
@@ -7260,6 +7194,11 @@ packages:
 
   /colors/0.6.2:
     resolution: {integrity: sha512-OsSVtHK8Ir8r3+Fxw/b4jS1ZLPXkV6ZxDRJQzeD7qo0SqMXWrHDM71DgYzPMHY8SFJ0Ao+nNU2p1MmwdzKqPrw==}
+    engines: {node: '>=0.1.90'}
+    dev: true
+
+  /colors/1.2.5:
+    resolution: {integrity: sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==}
     engines: {node: '>=0.1.90'}
     dev: true
 
@@ -7298,6 +7237,13 @@ packages:
     engines: {node: '>= 12'}
     dev: true
 
+  /commander/9.5.0:
+    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
+    engines: {node: ^12.20.0 || >=14}
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /common-tags/1.8.2:
     resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
     engines: {node: '>=4.0.0'}
@@ -7315,7 +7261,7 @@ packages:
     resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
     engines: {node: '>= 0.6'}
     dependencies:
-      mime-db: 1.53.0
+      mime-db: 1.52.0
     dev: true
 
   /compression/1.7.4:
@@ -7345,7 +7291,7 @@ packages:
       lodash: 4.17.21
       read-pkg: 4.0.1
       rxjs: 6.6.7
-      spawn-command: 0.0.2
+      spawn-command: 0.0.2-1
       supports-color: 6.1.0
       tree-kill: 1.2.2
       yargs: 13.3.2
@@ -7355,7 +7301,7 @@ packages:
     resolution: {integrity: sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg==}
     engines: {node: '>=12'}
     dependencies:
-      ajv: 8.17.1
+      ajv: 8.16.0
       ajv-formats: 2.1.1
       atomically: 1.7.0
       debounce-fn: 4.0.0
@@ -7364,7 +7310,7 @@ packages:
       json-schema-typed: 7.0.3
       onetime: 5.1.2
       pkg-up: 3.1.0
-      semver: 7.6.3
+      semver: 7.6.2
 
   /confusing-browser-globals/1.0.11:
     resolution: {integrity: sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==}
@@ -7392,7 +7338,6 @@ packages:
 
   /convert-source-map/1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
-    dev: true
 
   /convert-source-map/2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -7401,8 +7346,8 @@ packages:
   /cookie-signature/1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
 
-  /cookie/0.7.1:
-    resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
+  /cookie/0.6.0:
+    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
 
   /copy-descriptor/0.1.1:
@@ -7410,7 +7355,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /copy-webpack-plugin/10.2.4_webpack@5.95.0:
+  /copy-webpack-plugin/10.2.4_webpack@5.92.1:
     resolution: {integrity: sha512-xFVltahqlsRcyyJqQbDY6EYTtyQZF9rf+JPjwHObLdPFMEISqkFkr7mFoVOC6BfYS/dNThyoQKvziugm+OnwBg==}
     engines: {node: '>= 12.20.0'}
     peerDependencies:
@@ -7422,10 +7367,10 @@ packages:
       normalize-path: 3.0.0
       schema-utils: 4.2.0
       serialize-javascript: 6.0.2
-      webpack: 5.95.0
+      webpack: 5.92.1
     dev: true
 
-  /copy-webpack-plugin/11.0.0_webpack@5.95.0:
+  /copy-webpack-plugin/11.0.0_webpack@5.92.1:
     resolution: {integrity: sha512-fX2MWpamkW0hZxMEg0+mYnA40LTosOSa5TqZ9GYIBzyJa9C3QUaMPSE2xAi/buNr8u89SfD9wHSQVBzrRa/SOQ==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -7437,7 +7382,7 @@ packages:
       normalize-path: 3.0.0
       schema-utils: 4.2.0
       serialize-javascript: 6.0.2
-      webpack: 5.95.0
+      webpack: 5.92.1
     dev: true
 
   /copyfiles/2.4.1:
@@ -7453,19 +7398,19 @@ packages:
       yargs: 16.2.0
     dev: true
 
-  /core-js-compat/3.39.0:
-    resolution: {integrity: sha512-VgEUx3VwlExr5no0tXlBt+silBvhTryPwCXRI2Id1PN8WTKu7MreethvddqOubrYxkFdv/RnYrqlv1sFNAUelw==}
+  /core-js-compat/3.37.1:
+    resolution: {integrity: sha512-9TNiImhKvQqSUkOvk/mMRZzOANTiEVC7WaBNhHcKM7x+/5E1l5NvsysR19zuDQScE8k+kfQXWRN3AtS/eOSHpg==}
     dependencies:
-      browserslist: 4.24.2
+      browserslist: 4.23.2
     dev: true
 
-  /core-js-pure/3.39.0:
-    resolution: {integrity: sha512-7fEcWwKI4rJinnK+wLTezeg2smbFFdSBP6E2kQZNbnzM2s1rpKQ6aaRteZSSg7FLU3P0HGGVo/gbpfanU36urg==}
+  /core-js-pure/3.37.1:
+    resolution: {integrity: sha512-J/r5JTHSmzTxbiYYrzXg9w1VpqrYt+gexenBE9pugeyhwPZTAEJddyiReJWsLO6uNQ8xJZFbod6XC7KKwatCiA==}
     requiresBuild: true
     dev: true
 
-  /core-js/3.39.0:
-    resolution: {integrity: sha512-raM0ew0/jJUqkJ0E6e8UDtl+y/7ktFivgWvqw8dNSQeNWoSDLvQ1H/RN3aPXB9tBd4/FhyR4RDPGhsNIMsAn7g==}
+  /core-js/3.37.1:
+    resolution: {integrity: sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==}
     requiresBuild: true
     dev: true
 
@@ -7493,7 +7438,6 @@ packages:
       parse-json: 5.2.0
       path-type: 4.0.0
       yaml: 1.10.2
-    dev: true
 
   /cpx2/3.0.2:
     resolution: {integrity: sha512-xVmdulZJVGSV+c8KkZ9IQY+RgyL9sGeVqScI2e7NtsEY9SVKcQXM4v0/9OLU0W0YtL9nmmqrtWjs5rpvgHn9Hg==}
@@ -7502,7 +7446,7 @@ packages:
     dependencies:
       co: 4.6.0
       debounce: 1.2.1
-      debug: 4.3.7
+      debug: 4.3.5
       duplexer: 0.1.2
       fs-extra: 10.1.0
       glob: 7.2.3
@@ -7522,12 +7466,12 @@ packages:
     hasBin: true
     dependencies:
       debounce: 1.2.1
-      debug: 4.3.7
+      debug: 4.3.5
       duplexer: 0.1.2
       fs-extra: 10.1.0
-      glob-gitignore: 1.0.15
+      glob-gitignore: 1.0.14
       glob2base: 0.0.12
-      ignore: 5.3.2
+      ignore: 5.3.1
       minimatch: 3.1.2
       p-map: 4.0.0
       resolve: 1.22.8
@@ -7538,7 +7482,7 @@ packages:
       - supports-color
     dev: true
 
-  /create-jest/29.7.0_@types+node@18.19.62:
+  /create-jest/29.7.0_@types+node@18.19.39:
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -7547,7 +7491,7 @@ packages:
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0_@types+node@18.19.62
+      jest-config: 29.7.0_@types+node@18.19.39
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -7608,38 +7552,38 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /css-blank-pseudo/3.0.3_postcss@8.4.47:
+  /css-blank-pseudo/3.0.3_postcss@8.4.39:
     resolution: {integrity: sha512-VS90XWtsHGqoM0t4KpH053c4ehxZ2E6HtGI7x68YFV0pTo/QmkV/YFA+NnlvK8guxZVNWGQhVNJGC39Q8XF4OQ==}
     engines: {node: ^12 || ^14 || >=16}
     hasBin: true
     peerDependencies:
       postcss: ^8.4
     dependencies:
-      postcss: 8.4.47
-      postcss-selector-parser: 6.1.2
+      postcss: 8.4.39
+      postcss-selector-parser: 6.1.0
     dev: true
 
-  /css-declaration-sorter/6.4.1_postcss@8.4.47:
+  /css-declaration-sorter/6.4.1_postcss@8.4.39:
     resolution: {integrity: sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g==}
     engines: {node: ^10 || ^12 || >=14}
     peerDependencies:
       postcss: ^8.0.9
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
     dev: true
 
-  /css-has-pseudo/3.0.4_postcss@8.4.47:
+  /css-has-pseudo/3.0.4_postcss@8.4.39:
     resolution: {integrity: sha512-Vse0xpR1K9MNlp2j5w1pgWIJtm1a8qS0JwS9goFYcImjlHEmywP9VUF05aGBXzGpDJF86QXk4L0ypBmwPhGArw==}
     engines: {node: ^12 || ^14 || >=16}
     hasBin: true
     peerDependencies:
       postcss: ^8.4
     dependencies:
-      postcss: 8.4.47
-      postcss-selector-parser: 6.1.2
+      postcss: 8.4.39
+      postcss-selector-parser: 6.1.0
     dev: true
 
-  /css-loader/6.11.0_webpack@5.95.0:
+  /css-loader/6.11.0_webpack@5.92.1:
     resolution: {integrity: sha512-CTJ+AEQJjq5NzLga5pE39qdiSV56F8ywCIsqNIRF0r7BDgWsN25aazToqAFg7ZrtA/U016xudB3ffgweORxX7g==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -7651,18 +7595,18 @@ packages:
       webpack:
         optional: true
     dependencies:
-      icss-utils: 5.1.0_postcss@8.4.47
-      postcss: 8.4.47
-      postcss-modules-extract-imports: 3.1.0_postcss@8.4.47
-      postcss-modules-local-by-default: 4.0.5_postcss@8.4.47
-      postcss-modules-scope: 3.2.0_postcss@8.4.47
-      postcss-modules-values: 4.0.0_postcss@8.4.47
+      icss-utils: 5.1.0_postcss@8.4.39
+      postcss: 8.4.39
+      postcss-modules-extract-imports: 3.1.0_postcss@8.4.39
+      postcss-modules-local-by-default: 4.0.5_postcss@8.4.39
+      postcss-modules-scope: 3.2.0_postcss@8.4.39
+      postcss-modules-values: 4.0.0_postcss@8.4.39
       postcss-value-parser: 4.2.0
-      semver: 7.6.3
-      webpack: 5.95.0
+      semver: 7.6.2
+      webpack: 5.92.1
     dev: true
 
-  /css-minimizer-webpack-plugin/3.4.1_webpack@5.95.0:
+  /css-minimizer-webpack-plugin/3.4.1_webpack@5.92.1:
     resolution: {integrity: sha512-1u6D71zeIfgngN2XNRJefc/hY7Ybsxd74Jm4qngIXyUEk7fss3VUzuHxLAq/R8NAba4QU9OUSaMZlbpRc7bM4Q==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -7681,23 +7625,23 @@ packages:
       esbuild:
         optional: true
     dependencies:
-      cssnano: 5.1.15_postcss@8.4.47
+      cssnano: 5.1.15_postcss@8.4.39
       jest-worker: 27.5.1
-      postcss: 8.4.47
+      postcss: 8.4.39
       schema-utils: 4.2.0
       serialize-javascript: 6.0.2
       source-map: 0.6.1
-      webpack: 5.95.0
+      webpack: 5.92.1
     dev: true
 
-  /css-prefers-color-scheme/6.0.3_postcss@8.4.47:
+  /css-prefers-color-scheme/6.0.3_postcss@8.4.39:
     resolution: {integrity: sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA==}
     engines: {node: ^12 || ^14 || >=16}
     hasBin: true
     peerDependencies:
       postcss: ^8.4
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
     dev: true
 
   /css-select/4.3.0:
@@ -7746,62 +7690,62 @@ packages:
     hasBin: true
     dev: true
 
-  /cssnano-preset-default/5.2.14_postcss@8.4.47:
+  /cssnano-preset-default/5.2.14_postcss@8.4.39:
     resolution: {integrity: sha512-t0SFesj/ZV2OTylqQVOrFgEh5uanxbO6ZAdeCrNsUQ6fVuXwYTxJPNAGvGTxHbD68ldIJNec7PyYZDBrfDQ+6A==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      css-declaration-sorter: 6.4.1_postcss@8.4.47
-      cssnano-utils: 3.1.0_postcss@8.4.47
-      postcss: 8.4.47
-      postcss-calc: 8.2.4_postcss@8.4.47
-      postcss-colormin: 5.3.1_postcss@8.4.47
-      postcss-convert-values: 5.1.3_postcss@8.4.47
-      postcss-discard-comments: 5.1.2_postcss@8.4.47
-      postcss-discard-duplicates: 5.1.0_postcss@8.4.47
-      postcss-discard-empty: 5.1.1_postcss@8.4.47
-      postcss-discard-overridden: 5.1.0_postcss@8.4.47
-      postcss-merge-longhand: 5.1.7_postcss@8.4.47
-      postcss-merge-rules: 5.1.4_postcss@8.4.47
-      postcss-minify-font-values: 5.1.0_postcss@8.4.47
-      postcss-minify-gradients: 5.1.1_postcss@8.4.47
-      postcss-minify-params: 5.1.4_postcss@8.4.47
-      postcss-minify-selectors: 5.2.1_postcss@8.4.47
-      postcss-normalize-charset: 5.1.0_postcss@8.4.47
-      postcss-normalize-display-values: 5.1.0_postcss@8.4.47
-      postcss-normalize-positions: 5.1.1_postcss@8.4.47
-      postcss-normalize-repeat-style: 5.1.1_postcss@8.4.47
-      postcss-normalize-string: 5.1.0_postcss@8.4.47
-      postcss-normalize-timing-functions: 5.1.0_postcss@8.4.47
-      postcss-normalize-unicode: 5.1.1_postcss@8.4.47
-      postcss-normalize-url: 5.1.0_postcss@8.4.47
-      postcss-normalize-whitespace: 5.1.1_postcss@8.4.47
-      postcss-ordered-values: 5.1.3_postcss@8.4.47
-      postcss-reduce-initial: 5.1.2_postcss@8.4.47
-      postcss-reduce-transforms: 5.1.0_postcss@8.4.47
-      postcss-svgo: 5.1.0_postcss@8.4.47
-      postcss-unique-selectors: 5.1.1_postcss@8.4.47
+      css-declaration-sorter: 6.4.1_postcss@8.4.39
+      cssnano-utils: 3.1.0_postcss@8.4.39
+      postcss: 8.4.39
+      postcss-calc: 8.2.4_postcss@8.4.39
+      postcss-colormin: 5.3.1_postcss@8.4.39
+      postcss-convert-values: 5.1.3_postcss@8.4.39
+      postcss-discard-comments: 5.1.2_postcss@8.4.39
+      postcss-discard-duplicates: 5.1.0_postcss@8.4.39
+      postcss-discard-empty: 5.1.1_postcss@8.4.39
+      postcss-discard-overridden: 5.1.0_postcss@8.4.39
+      postcss-merge-longhand: 5.1.7_postcss@8.4.39
+      postcss-merge-rules: 5.1.4_postcss@8.4.39
+      postcss-minify-font-values: 5.1.0_postcss@8.4.39
+      postcss-minify-gradients: 5.1.1_postcss@8.4.39
+      postcss-minify-params: 5.1.4_postcss@8.4.39
+      postcss-minify-selectors: 5.2.1_postcss@8.4.39
+      postcss-normalize-charset: 5.1.0_postcss@8.4.39
+      postcss-normalize-display-values: 5.1.0_postcss@8.4.39
+      postcss-normalize-positions: 5.1.1_postcss@8.4.39
+      postcss-normalize-repeat-style: 5.1.1_postcss@8.4.39
+      postcss-normalize-string: 5.1.0_postcss@8.4.39
+      postcss-normalize-timing-functions: 5.1.0_postcss@8.4.39
+      postcss-normalize-unicode: 5.1.1_postcss@8.4.39
+      postcss-normalize-url: 5.1.0_postcss@8.4.39
+      postcss-normalize-whitespace: 5.1.1_postcss@8.4.39
+      postcss-ordered-values: 5.1.3_postcss@8.4.39
+      postcss-reduce-initial: 5.1.2_postcss@8.4.39
+      postcss-reduce-transforms: 5.1.0_postcss@8.4.39
+      postcss-svgo: 5.1.0_postcss@8.4.39
+      postcss-unique-selectors: 5.1.1_postcss@8.4.39
     dev: true
 
-  /cssnano-utils/3.1.0_postcss@8.4.47:
+  /cssnano-utils/3.1.0_postcss@8.4.39:
     resolution: {integrity: sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
     dev: true
 
-  /cssnano/5.1.15_postcss@8.4.47:
+  /cssnano/5.1.15_postcss@8.4.39:
     resolution: {integrity: sha512-j+BKgDcLDQA+eDifLx0EO4XSA56b7uut3BQFH+wbSaSTuGLuiyTa/wbRYthUXX8LC9mLg+WWKe8h+qJuwTAbHw==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      cssnano-preset-default: 5.2.14_postcss@8.4.47
+      cssnano-preset-default: 5.2.14_postcss@8.4.39
       lilconfig: 2.1.0
-      postcss: 8.4.47
+      postcss: 8.4.39
       yaml: 1.10.2
     dev: true
 
@@ -7887,7 +7831,7 @@ packages:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
     engines: {node: '>=0.11'}
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.24.7
     dev: true
 
   /debounce-fn/4.0.0:
@@ -7911,8 +7855,8 @@ packages:
       ms: 2.1.3
     dev: true
 
-  /debug/4.3.7:
-    resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
+  /debug/4.3.5:
+    resolution: {integrity: sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -7920,10 +7864,10 @@ packages:
       supports-color:
         optional: true
     dependencies:
-      ms: 2.1.3
+      ms: 2.1.2
 
-  /debug/4.3.7_supports-color@8.1.1:
-    resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
+  /debug/4.3.5_supports-color@8.1.1:
+    resolution: {integrity: sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -7931,7 +7875,7 @@ packages:
       supports-color:
         optional: true
     dependencies:
-      ms: 2.1.3
+      ms: 2.1.2
       supports-color: 8.1.1
     dev: true
 
@@ -7998,7 +7942,7 @@ packages:
       object-is: 1.1.6
       object-keys: 1.1.1
       object.assign: 4.1.5
-      regexp.prototype.flags: 1.5.3
+      regexp.prototype.flags: 1.5.2
       side-channel: 1.0.6
       which-boxed-primitive: 1.0.2
       which-collection: 1.0.2
@@ -8094,12 +8038,6 @@ packages:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
-  /detect-libc/1.0.3:
-    resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
-    engines: {node: '>=0.10'}
-    hasBin: true
-    dev: true
-
   /detect-newline/3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
@@ -8191,7 +8129,7 @@ packages:
   /dom-helpers/5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.24.7
       csstype: 3.1.3
 
   /dom-serializer/0.2.2:
@@ -8246,8 +8184,8 @@ packages:
       domelementtype: 2.3.0
     dev: true
 
-  /dompurify/2.5.7:
-    resolution: {integrity: sha512-2q4bEI+coQM8f5ez7kt2xclg1XsecaV9ASJk/54vwlfRRNQfDqJz2pzQ8t0Ix/ToBpXlVjrRIx7pFC/o8itG2Q==}
+  /dompurify/2.5.6:
+    resolution: {integrity: sha512-zUTaUBO8pY4+iJMPE1B9XlO2tXVYIcEA4SNGtvDELzTSCQO7RzH+j7S180BmhmJId78lqGU2z19vgVx2Sxs/PQ==}
 
   /domready/1.0.8:
     resolution: {integrity: sha512-uIzsOJUNk+AdGE9a6VDeessoMCzF8RrZvJCX/W8QtyfgdR6Uofn/MvRonih3OtCO79b2VDzDOymuiABrQ4z3XA==}
@@ -8272,7 +8210,7 @@ packages:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.8.0
+      tslib: 2.6.3
     dev: true
 
   /dot-prop/6.0.1:
@@ -8321,7 +8259,7 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
     dependencies:
-      jake: 10.9.2
+      jake: 10.9.1
     dev: true
 
   /electron-devtools-installer/2.2.4:
@@ -8339,8 +8277,8 @@ packages:
       conf: 10.2.0
       type-fest: 2.19.0
 
-  /electron-to-chromium/1.5.49:
-    resolution: {integrity: sha512-ZXfs1Of8fDb6z7WEYZjXpgIRF6MEu8JdeGA0A40aZq6OQbS+eJpnnV49epZRna2DU/YsEjSQuGtQPPtvt6J65A==}
+  /electron-to-chromium/1.4.823:
+    resolution: {integrity: sha512-4h+oPeAiGQOHFyUJOqpoEcPj/xxlicxBzOErVeYVMMmAiXUXsGpsFd0QXBMaUUbnD8hhSfLf9uw+MlsoIA7j5w==}
     dev: true
 
   /electron/24.8.8:
@@ -8350,7 +8288,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@electron/get': 2.0.3
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -8391,17 +8329,13 @@ packages:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
     engines: {node: '>= 0.8'}
 
-  /encodeurl/2.0.0:
-    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
-    engines: {node: '>= 0.8'}
-
   /end-of-stream/1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
     dependencies:
       once: 1.4.0
 
-  /enhanced-resolve/5.17.1:
-    resolution: {integrity: sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==}
+  /enhanced-resolve/5.17.0:
+    resolution: {integrity: sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA==}
     engines: {node: '>=10.13.0'}
     dependencies:
       graceful-fs: 4.2.11
@@ -8437,7 +8371,6 @@ packages:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
     dependencies:
       is-arrayish: 0.2.1
-    dev: true
 
   /error-stack-parser/2.1.4:
     resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
@@ -8483,7 +8416,7 @@ packages:
       object-inspect: 1.13.2
       object-keys: 1.1.1
       object.assign: 4.1.5
-      regexp.prototype.flags: 1.5.3
+      regexp.prototype.flags: 1.5.2
       safe-array-concat: 1.1.2
       safe-regex-test: 1.0.3
       string.prototype.trim: 1.2.9
@@ -8521,8 +8454,8 @@ packages:
       stop-iteration-iterator: 1.0.0
     dev: true
 
-  /es-iterator-helpers/1.1.0:
-    resolution: {integrity: sha512-/SurEfycdyssORP/E+bj4sEu1CWw4EmLDsHynHwSXQ7utgbrMRWW195pTrCjFgFCddf/UkYm3oqKPRq5i8bJbw==}
+  /es-iterator-helpers/1.0.19:
+    resolution: {integrity: sha512-zoMwbCcH5hwUkKJkT8kDIBZSz9I6mVG//+lDCinLCGov4+r7NIy0ld8o03M0cJxl2spVf6ESYVS6/gpIfq1FFw==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.7
@@ -8537,7 +8470,7 @@ packages:
       has-proto: 1.0.3
       has-symbols: 1.0.3
       internal-slot: 1.0.7
-      iterator.prototype: 1.1.3
+      iterator.prototype: 1.1.2
       safe-array-concat: 1.1.2
     dev: true
 
@@ -8743,8 +8676,8 @@ packages:
       esbuild-windows-arm64: 0.13.15
     dev: true
 
-  /escalade/3.2.0:
-    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+  /escalade/3.1.2:
+    resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
     engines: {node: '>=6'}
     dev: true
 
@@ -8754,7 +8687,6 @@ packages:
   /escape-string-regexp/1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
-    dev: true
 
   /escape-string-regexp/2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
@@ -8790,7 +8722,7 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /eslint-config-airbnb-base/14.2.1_lixxg4lvkdf443isck4h3kyyta:
+  /eslint-config-airbnb-base/14.2.1_ryxylqcqjrgqrcq5e2gwnwvmem:
     resolution: {integrity: sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==}
     engines: {node: '>= 6'}
     peerDependencies:
@@ -8799,12 +8731,12 @@ packages:
     dependencies:
       confusing-browser-globals: 1.0.11
       eslint: 7.32.0
-      eslint-plugin-import: 2.31.0_eslint@7.32.0
+      eslint-plugin-import: 2.29.1_eslint@7.32.0
       object.assign: 4.1.5
       object.entries: 1.1.8
     dev: true
 
-  /eslint-config-airbnb/18.2.1_j47woh5gdjkhehtho5cd7z7hme:
+  /eslint-config-airbnb/18.2.1_cb6pno7fzmlsn2yskxvbihgdme:
     resolution: {integrity: sha512-glZNDEZ36VdlZWoxn/bUR1r/sdFKPd1mHPbqUtkctgNG4yT2DLLtJ3D+yCV+jzZCc2V1nBVkmdknOJBZ5Hc0fg==}
     engines: {node: '>= 6'}
     peerDependencies:
@@ -8815,10 +8747,10 @@ packages:
       eslint-plugin-react-hooks: ^4 || ^3 || ^2.3.0 || ^1.7.0
     dependencies:
       eslint: 7.32.0
-      eslint-config-airbnb-base: 14.2.1_lixxg4lvkdf443isck4h3kyyta
-      eslint-plugin-import: 2.31.0_eslint@7.32.0
-      eslint-plugin-jsx-a11y: 6.10.2_eslint@7.32.0
-      eslint-plugin-react: 7.37.2_eslint@7.32.0
+      eslint-config-airbnb-base: 14.2.1_ryxylqcqjrgqrcq5e2gwnwvmem
+      eslint-plugin-import: 2.29.1_eslint@7.32.0
+      eslint-plugin-jsx-a11y: 6.9.0_eslint@7.32.0
+      eslint-plugin-react: 7.34.3_eslint@7.32.0
       eslint-plugin-react-hooks: 4.6.2_eslint@7.32.0
       object.assign: 4.1.5
       object.entries: 1.1.8
@@ -8834,7 +8766,7 @@ packages:
       get-stdin: 6.0.0
     dev: true
 
-  /eslint-config-react-app/6.0.0_vblgvs7dq6s2rjad5szwfif2ae:
+  /eslint-config-react-app/6.0.0_ssuykkwe44xqfk7ygtu5dsspum:
     resolution: {integrity: sha512-bpoAAC+YRfzq0dsTk+6v9aHm/uqnDwayNAXleMypGl6CpxI9oXXscVHo4fk3eJPIn+rsbtNetB4r/ZIidFIE8A==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -8860,33 +8792,33 @@ packages:
       confusing-browser-globals: 1.0.11
       eslint: 7.32.0
       eslint-plugin-flowtype: 5.10.0_eslint@7.32.0
-      eslint-plugin-import: 2.31.0_eslint@7.32.0
-      eslint-plugin-jsx-a11y: 6.10.2_eslint@7.32.0
-      eslint-plugin-react: 7.37.2_eslint@7.32.0
+      eslint-plugin-import: 2.29.1_eslint@7.32.0
+      eslint-plugin-jsx-a11y: 6.9.0_eslint@7.32.0
+      eslint-plugin-react: 7.34.3_eslint@7.32.0
       eslint-plugin-react-hooks: 4.6.2_eslint@7.32.0
     dev: true
 
-  /eslint-config-react-app/7.0.1_l6sf7e4olydjhtf3qe76zuqhfi:
+  /eslint-config-react-app/7.0.1_rxydg5byhhw2ikqe4ecaedklea:
     resolution: {integrity: sha512-K6rNzvkIeHaTd8m/QEh1Zko0KI7BACWkkneSs6s9cKZC/J27X3eZR6Upt1jkmZ/4FK+XUOPPxMEN7+lbUXfSlA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       eslint: ^8.0.0
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/eslint-parser': 7.25.9_ug2igzfsn2htp6pvbk547j4y6y
-      '@rushstack/eslint-patch': 1.10.4
-      '@typescript-eslint/eslint-plugin': 5.62.0_imxewgebu4zsddg3peaq2zpmd4
-      '@typescript-eslint/parser': 5.62.0_iefaljtug4ytsd5a3rfvfodvxa
+      '@babel/core': 7.24.7
+      '@babel/eslint-parser': 7.24.7_ivopgdbs46443pcald3k67gmwm
+      '@rushstack/eslint-patch': 1.10.3
+      '@typescript-eslint/eslint-plugin': 5.62.0_6642sdbk46myawr2npa4taenme
+      '@typescript-eslint/parser': 5.62.0_lhzdwpbtv2n477nxjcr5ny2fnm
       babel-preset-react-app: 10.0.1
       confusing-browser-globals: 1.0.11
-      eslint: 8.57.1
-      eslint-plugin-flowtype: 8.0.3_eslint@8.57.1
-      eslint-plugin-import: 2.31.0_eslint@8.57.1
-      eslint-plugin-jest: 25.7.0_vsn4rgfo3vkx5dadyu7tqmjoza
-      eslint-plugin-jsx-a11y: 6.10.2_eslint@8.57.1
-      eslint-plugin-react: 7.37.2_eslint@8.57.1
-      eslint-plugin-react-hooks: 4.6.2_eslint@8.57.1
-      eslint-plugin-testing-library: 5.11.1_iefaljtug4ytsd5a3rfvfodvxa
+      eslint: 8.57.0
+      eslint-plugin-flowtype: 8.0.3_eslint@8.57.0
+      eslint-plugin-import: 2.29.1_eslint@8.57.0
+      eslint-plugin-jest: 25.7.0_6g2l2tswdavbxveddlniuczqoi
+      eslint-plugin-jsx-a11y: 6.9.0_eslint@8.57.0
+      eslint-plugin-react: 7.34.3_eslint@8.57.0
+      eslint-plugin-react-hooks: 4.6.2_eslint@8.57.0
+      eslint-plugin-testing-library: 5.11.1_lhzdwpbtv2n477nxjcr5ny2fnm
     transitivePeerDependencies:
       - '@babel/plugin-syntax-flow'
       - '@babel/plugin-transform-react-jsx'
@@ -8899,12 +8831,12 @@ packages:
     resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
     dependencies:
       debug: 3.2.7
-      is-core-module: 2.15.1
+      is-core-module: 2.14.0
       resolve: 1.22.8
     dev: true
 
-  /eslint-module-utils/2.12.0_eslint@7.32.0:
-    resolution: {integrity: sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==}
+  /eslint-module-utils/2.8.1_eslint@7.32.0:
+    resolution: {integrity: sha512-rXDXR3h7cs7dy9RNpUlQf80nX31XWJEyGq1tRMo+6GsO5VmTe4UTwtmonAD4ZkAsrfMVDA2wlGJ3790Ys+D49Q==}
     engines: {node: '>=4'}
     peerDependencies:
       eslint: '*'
@@ -8916,8 +8848,8 @@ packages:
       eslint: 7.32.0
     dev: true
 
-  /eslint-module-utils/2.12.0_eslint@8.57.1:
-    resolution: {integrity: sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==}
+  /eslint-module-utils/2.8.1_eslint@8.57.0:
+    resolution: {integrity: sha512-rXDXR3h7cs7dy9RNpUlQf80nX31XWJEyGq1tRMo+6GsO5VmTe4UTwtmonAD4ZkAsrfMVDA2wlGJ3790Ys+D49Q==}
     engines: {node: '>=4'}
     peerDependencies:
       eslint: '*'
@@ -8926,7 +8858,7 @@ packages:
         optional: true
     dependencies:
       debug: 3.2.7
-      eslint: 8.57.1
+      eslint: 8.57.0
     dev: true
 
   /eslint-plugin-deprecation/1.2.1_eslint@7.32.0:
@@ -8954,7 +8886,7 @@ packages:
       string-natural-compare: 3.0.1
     dev: true
 
-  /eslint-plugin-flowtype/8.0.3_eslint@8.57.1:
+  /eslint-plugin-flowtype/8.0.3_eslint@8.57.0:
     resolution: {integrity: sha512-dX8l6qUL6O+fYPtpNRideCFSpmWOUVx5QcaGLVqe/vlDiBSe4vYljDWDETwnyFzpl7By/WVIu6rcrniCgH9BqQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -8962,18 +8894,17 @@ packages:
       '@babel/plugin-transform-react-jsx': ^7.14.9
       eslint: ^8.1.0
     dependencies:
-      eslint: 8.57.1
+      eslint: 8.57.0
       lodash: 4.17.21
       string-natural-compare: 3.0.1
     dev: true
 
-  /eslint-plugin-import/2.31.0_eslint@7.32.0:
-    resolution: {integrity: sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==}
+  /eslint-plugin-import/2.29.1_eslint@7.32.0:
+    resolution: {integrity: sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==}
     engines: {node: '>=4'}
     peerDependencies:
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
     dependencies:
-      '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
       array.prototype.flat: 1.3.2
@@ -8982,48 +8913,45 @@ packages:
       doctrine: 2.1.0
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0_eslint@7.32.0
+      eslint-module-utils: 2.8.1_eslint@7.32.0
       hasown: 2.0.2
-      is-core-module: 2.15.1
+      is-core-module: 2.14.0
       is-glob: 4.0.3
       minimatch: 3.1.2
       object.fromentries: 2.0.8
       object.groupby: 1.0.3
       object.values: 1.2.0
       semver: 6.3.1
-      string.prototype.trimend: 1.0.8
       tsconfig-paths: 3.15.0
     dev: true
 
-  /eslint-plugin-import/2.31.0_eslint@8.57.1:
-    resolution: {integrity: sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==}
+  /eslint-plugin-import/2.29.1_eslint@8.57.0:
+    resolution: {integrity: sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==}
     engines: {node: '>=4'}
     peerDependencies:
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
     dependencies:
-      '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
       array.prototype.flat: 1.3.2
       array.prototype.flatmap: 1.3.2
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 8.57.1
+      eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0_eslint@8.57.1
+      eslint-module-utils: 2.8.1_eslint@8.57.0
       hasown: 2.0.2
-      is-core-module: 2.15.1
+      is-core-module: 2.14.0
       is-glob: 4.0.3
       minimatch: 3.1.2
       object.fromentries: 2.0.8
       object.groupby: 1.0.3
       object.values: 1.2.0
       semver: 6.3.1
-      string.prototype.trimend: 1.0.8
       tsconfig-paths: 3.15.0
     dev: true
 
-  /eslint-plugin-jest/25.7.0_vsn4rgfo3vkx5dadyu7tqmjoza:
+  /eslint-plugin-jest/25.7.0_6g2l2tswdavbxveddlniuczqoi:
     resolution: {integrity: sha512-PWLUEXeeF7C9QGKqvdSbzLOiLTx+bno7/HC9eefePfEb257QFHg7ye3dh80AZVkaa/RQsBB1Q/ORQvg2X7F0NQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     peerDependencies:
@@ -9036,29 +8964,30 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0_imxewgebu4zsddg3peaq2zpmd4
-      '@typescript-eslint/experimental-utils': 5.62.0_iefaljtug4ytsd5a3rfvfodvxa
-      eslint: 8.57.1
+      '@typescript-eslint/eslint-plugin': 5.62.0_6642sdbk46myawr2npa4taenme
+      '@typescript-eslint/experimental-utils': 5.62.0_lhzdwpbtv2n477nxjcr5ny2fnm
+      eslint: 8.57.0
       jest: 27.5.1
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /eslint-plugin-jsx-a11y/6.10.2_eslint@7.32.0:
-    resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
+  /eslint-plugin-jsx-a11y/6.9.0_eslint@7.32.0:
+    resolution: {integrity: sha512-nOFOCaJG2pYqORjK19lqPqxMO/JpvdCZdPtNdxY3kvom3jTvkAbOvQvD8wuD0G8BYR0IGAGYDlzqWJOh/ybn2g==}
     engines: {node: '>=4.0'}
     peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
     dependencies:
-      aria-query: 5.3.2
+      aria-query: 5.1.3
       array-includes: 3.1.8
       array.prototype.flatmap: 1.3.2
       ast-types-flow: 0.0.8
-      axe-core: 4.10.2
-      axobject-query: 4.1.0
+      axe-core: 4.9.1
+      axobject-query: 3.1.1
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
+      es-iterator-helpers: 1.0.19
       eslint: 7.32.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
@@ -9066,31 +8995,32 @@ packages:
       minimatch: 3.1.2
       object.fromentries: 2.0.8
       safe-regex-test: 1.0.3
-      string.prototype.includes: 2.0.1
+      string.prototype.includes: 2.0.0
     dev: true
 
-  /eslint-plugin-jsx-a11y/6.10.2_eslint@8.57.1:
-    resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
+  /eslint-plugin-jsx-a11y/6.9.0_eslint@8.57.0:
+    resolution: {integrity: sha512-nOFOCaJG2pYqORjK19lqPqxMO/JpvdCZdPtNdxY3kvom3jTvkAbOvQvD8wuD0G8BYR0IGAGYDlzqWJOh/ybn2g==}
     engines: {node: '>=4.0'}
     peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
     dependencies:
-      aria-query: 5.3.2
+      aria-query: 5.1.3
       array-includes: 3.1.8
       array.prototype.flatmap: 1.3.2
       ast-types-flow: 0.0.8
-      axe-core: 4.10.2
-      axobject-query: 4.1.0
+      axe-core: 4.9.1
+      axobject-query: 3.1.1
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 8.57.1
+      es-iterator-helpers: 1.0.19
+      eslint: 8.57.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
       minimatch: 3.1.2
       object.fromentries: 2.0.8
       safe-regex-test: 1.0.3
-      string.prototype.includes: 2.0.1
+      string.prototype.includes: 2.0.0
     dev: true
 
   /eslint-plugin-prefer-arrow/1.2.3_eslint@7.32.0:
@@ -9127,67 +9057,67 @@ packages:
       eslint: 7.32.0
     dev: true
 
-  /eslint-plugin-react-hooks/4.6.2_eslint@8.57.1:
+  /eslint-plugin-react-hooks/4.6.2_eslint@8.57.0:
     resolution: {integrity: sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==}
     engines: {node: '>=10'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
     dependencies:
-      eslint: 8.57.1
+      eslint: 8.57.0
     dev: true
 
-  /eslint-plugin-react/7.37.2_eslint@7.32.0:
-    resolution: {integrity: sha512-EsTAnj9fLVr/GZleBLFbj/sSuXeWmp1eXIN60ceYnZveqEaUCyW4X+Vh4WTdUhCkW4xutXYqTXCUSyqD4rB75w==}
+  /eslint-plugin-react/7.34.3_eslint@7.32.0:
+    resolution: {integrity: sha512-aoW4MV891jkUulwDApQbPYTVZmeuSyFrudpbTAQuj5Fv8VL+o6df2xIGpw8B0hPjAaih1/Fb0om9grCdyFYemA==}
     engines: {node: '>=4'}
     peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlast: 1.2.5
       array.prototype.flatmap: 1.3.2
+      array.prototype.toreversed: 1.1.2
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
-      es-iterator-helpers: 1.1.0
+      es-iterator-helpers: 1.0.19
       eslint: 7.32.0
       estraverse: 5.3.0
-      hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       minimatch: 3.1.2
       object.entries: 1.1.8
       object.fromentries: 2.0.8
+      object.hasown: 1.1.4
       object.values: 1.2.0
       prop-types: 15.8.1
       resolve: 2.0.0-next.5
       semver: 6.3.1
       string.prototype.matchall: 4.0.11
-      string.prototype.repeat: 1.0.0
     dev: true
 
-  /eslint-plugin-react/7.37.2_eslint@8.57.1:
-    resolution: {integrity: sha512-EsTAnj9fLVr/GZleBLFbj/sSuXeWmp1eXIN60ceYnZveqEaUCyW4X+Vh4WTdUhCkW4xutXYqTXCUSyqD4rB75w==}
+  /eslint-plugin-react/7.34.3_eslint@8.57.0:
+    resolution: {integrity: sha512-aoW4MV891jkUulwDApQbPYTVZmeuSyFrudpbTAQuj5Fv8VL+o6df2xIGpw8B0hPjAaih1/Fb0om9grCdyFYemA==}
     engines: {node: '>=4'}
     peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlast: 1.2.5
       array.prototype.flatmap: 1.3.2
+      array.prototype.toreversed: 1.1.2
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
-      es-iterator-helpers: 1.1.0
-      eslint: 8.57.1
+      es-iterator-helpers: 1.0.19
+      eslint: 8.57.0
       estraverse: 5.3.0
-      hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       minimatch: 3.1.2
       object.entries: 1.1.8
       object.fromentries: 2.0.8
+      object.hasown: 1.1.4
       object.values: 1.2.0
       prop-types: 15.8.1
       resolve: 2.0.0-next.5
       semver: 6.3.1
       string.prototype.matchall: 4.0.11
-      string.prototype.repeat: 1.0.0
     dev: true
 
   /eslint-plugin-simple-import-sort/5.0.3_eslint@7.32.0:
@@ -9198,14 +9128,14 @@ packages:
       eslint: 7.32.0
     dev: true
 
-  /eslint-plugin-testing-library/5.11.1_iefaljtug4ytsd5a3rfvfodvxa:
+  /eslint-plugin-testing-library/5.11.1_lhzdwpbtv2n477nxjcr5ny2fnm:
     resolution: {integrity: sha512-5eX9e1Kc2PqVRed3taaLnAAqPZGEX75C+M/rXzUAI3wIg/ZxzUm1OVAwfe/O+vE+6YXOLetSe9g5GKD2ecXipw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0, npm: '>=6'}
     peerDependencies:
       eslint: ^7.5.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.62.0_iefaljtug4ytsd5a3rfvfodvxa
-      eslint: 8.57.1
+      '@typescript-eslint/utils': 5.62.0_lhzdwpbtv2n477nxjcr5ny2fnm
+      eslint: 8.57.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -9259,26 +9189,25 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /eslint-webpack-plugin/3.2.0_23g3mlqifdeyf7a5itkkqemkee:
+  /eslint-webpack-plugin/3.2.0_2razpbuuqgklq63beclqevrxh4:
     resolution: {integrity: sha512-avrKcGncpPbPSUHX6B3stNGzkKFto3eL+DKM4+VyMrVnhPc3vRczVlCq3uhuFOdRvDHTVXuzwk1ZKUrqDQHQ9w==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
       webpack: ^5.0.0
     dependencies:
-      '@types/eslint': 8.56.12
-      eslint: 8.57.1
+      '@types/eslint': 8.56.10
+      eslint: 8.57.0
       jest-worker: 28.1.3
-      micromatch: 4.0.8
+      micromatch: 4.0.7
       normalize-path: 3.0.0
       schema-utils: 4.2.0
-      webpack: 5.95.0
+      webpack: 5.92.1
     dev: true
 
   /eslint/7.32.0:
     resolution: {integrity: sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==}
     engines: {node: ^10.12.0 || >=12.0.0}
-    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     dependencies:
       '@babel/code-frame': 7.12.11
@@ -9287,7 +9216,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.7
+      debug: 4.3.5
       doctrine: 3.0.0
       enquirer: 2.4.1
       escape-string-regexp: 4.0.0
@@ -9315,7 +9244,7 @@ packages:
       optionator: 0.9.4
       progress: 2.0.3
       regexpp: 3.2.0
-      semver: 7.6.3
+      semver: 7.6.2
       strip-ansi: 6.0.1
       strip-json-comments: 3.1.1
       table: 6.8.2
@@ -9325,24 +9254,23 @@ packages:
       - supports-color
     dev: true
 
-  /eslint/8.57.1:
-    resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
+  /eslint/8.57.0:
+    resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.1_eslint@8.57.1
-      '@eslint-community/regexpp': 4.12.1
+      '@eslint-community/eslint-utils': 4.4.0_eslint@8.57.0
+      '@eslint-community/regexpp': 4.11.0
       '@eslint/eslintrc': 2.1.4
-      '@eslint/js': 8.57.1
-      '@humanwhocodes/config-array': 0.13.0
+      '@eslint/js': 8.57.0
+      '@humanwhocodes/config-array': 0.11.14
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       '@ungap/structured-clone': 1.2.0
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.7
+      debug: 4.3.5
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -9356,7 +9284,7 @@ packages:
       glob-parent: 6.0.2
       globals: 13.24.0
       graphemer: 1.4.0
-      ignore: 5.3.2
+      ignore: 5.3.1
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
@@ -9386,8 +9314,8 @@ packages:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 8.14.0
-      acorn-jsx: 5.3.2_acorn@8.14.0
+      acorn: 8.12.1
+      acorn-jsx: 5.3.2_acorn@8.12.1
       eslint-visitor-keys: 3.4.3
     dev: true
 
@@ -9540,21 +9468,21 @@ packages:
       jest-util: 29.7.0
     dev: true
 
-  /express-ws/5.0.2_express@4.21.1:
+  /express-ws/5.0.2_express@4.19.2:
     resolution: {integrity: sha512-0uvmuk61O9HXgLhGl3QhNSEtRsQevtmbL94/eILaliEADZBHZOQUAiHFrGPrgsjikohyrmSG5g+sCfASTt0lkQ==}
     engines: {node: '>=4.5.0'}
     peerDependencies:
       express: ^4.0.0 || ^5.0.0-alpha.1
     dependencies:
-      express: 4.21.1
+      express: 4.19.2
       ws: 7.5.10
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
     dev: false
 
-  /express/4.21.1:
-    resolution: {integrity: sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==}
+  /express/4.19.2:
+    resolution: {integrity: sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==}
     engines: {node: '>= 0.10.0'}
     dependencies:
       accepts: 1.3.8
@@ -9562,27 +9490,27 @@ packages:
       body-parser: 1.20.3
       content-disposition: 0.5.4
       content-type: 1.0.5
-      cookie: 0.7.1
+      cookie: 0.6.0
       cookie-signature: 1.0.6
       debug: 2.6.9
       depd: 2.0.0
-      encodeurl: 2.0.0
+      encodeurl: 1.0.2
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 1.3.1
+      finalhandler: 1.2.0
       fresh: 0.5.2
       http-errors: 2.0.0
-      merge-descriptors: 1.0.3
+      merge-descriptors: 1.0.1
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
       path-to-regexp: 0.1.10
       proxy-addr: 2.0.7
-      qs: 6.13.0
+      qs: 6.11.0
       range-parser: 1.2.1
       safe-buffer: 5.2.1
-      send: 0.19.0
-      serve-static: 1.16.2
+      send: 0.18.0
+      serve-static: 1.15.0
       setprototypeof: 1.2.0
       statuses: 2.0.1
       type-is: 1.6.18
@@ -9627,7 +9555,7 @@ packages:
     engines: {node: '>= 10.17.0'}
     hasBin: true
     dependencies:
-      debug: 4.3.7
+      debug: 4.3.5
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -9650,7 +9578,7 @@ packages:
       '@nodelib/fs.walk': 1.2.8
       glob-parent: 5.1.2
       merge2: 1.4.1
-      micromatch: 4.0.8
+      micromatch: 4.0.7
     dev: true
 
   /fast-json-stable-stringify/2.1.0:
@@ -9661,7 +9589,7 @@ packages:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: true
 
-  /fast-sass-loader/2.0.1_sass@1.80.5+webpack@5.95.0:
+  /fast-sass-loader/2.0.1_sass@1.77.7+webpack@5.92.1:
     resolution: {integrity: sha512-RGQNKA9d7OiF9dIa65QOabz4guGRZGg4CS2uXvLyWdmy5A6VLK8ZZEQKKlJ54ILmOpdFyaAq8u3Fj3oNkSmdug==}
     peerDependencies:
       sass: 1.x
@@ -9672,18 +9600,21 @@ packages:
       co: 4.6.0
       fs-extra: 3.0.1
       loader-utils: 1.4.2
-      sass: 1.80.5
-      webpack: 5.95.0
+      sass: 1.77.7
+      webpack: 5.92.1
     dev: true
 
-  /fast-sort/3.4.1:
-    resolution: {integrity: sha512-76uvGPsF6So53sZAqenP9UVT3p5l7cyTHkLWVCMinh41Y8NDrK1IYXJgaBMfc1gk7nJiSRZp676kddFG2Aa5+A==}
+  /fast-sort/3.4.0:
+    resolution: {integrity: sha512-c/cMBGA5mH3OYjaXedtLIM3hQjv+KuZuiD2QEH5GofNOZeQVDIYIN7Okc2AW1KPhk44g5PTZnXp8t2lOMl8qhQ==}
 
-  /fast-uri/3.0.3:
-    resolution: {integrity: sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==}
+  /fast-url-parser/1.1.3:
+    resolution: {integrity: sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==}
+    dependencies:
+      punycode: 1.4.1
+    dev: true
 
-  /fast-xml-parser/4.5.0:
-    resolution: {integrity: sha512-/PlTQCI96+fZMAOLMZK4CWG1ItCbfZ/0jx7UIJFChPNrx7tcEgerUgWbeieCM9MfHInUDyK8DWYZ+YrywDJuTg==}
+  /fast-xml-parser/4.4.1:
+    resolution: {integrity: sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==}
     hasBin: true
     dependencies:
       strnum: 1.0.5
@@ -9724,7 +9655,7 @@ packages:
       flat-cache: 3.2.0
     dev: true
 
-  /file-loader/6.2.0_webpack@5.95.0:
+  /file-loader/6.2.0_webpack@5.92.1:
     resolution: {integrity: sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -9732,7 +9663,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.95.0
+      webpack: 5.92.1
     dev: true
 
   /file-saver/2.0.5:
@@ -9757,12 +9688,12 @@ packages:
       to-regex-range: 5.0.1
     dev: true
 
-  /finalhandler/1.3.1:
-    resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
+  /finalhandler/1.2.0:
+    resolution: {integrity: sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==}
     engines: {node: '>= 0.8'}
     dependencies:
       debug: 2.6.9
-      encodeurl: 2.0.0
+      encodeurl: 1.0.2
       escape-html: 1.0.3
       on-finished: 2.4.1
       parseurl: 1.3.3
@@ -9781,6 +9712,9 @@ packages:
   /find-index/0.1.1:
     resolution: {integrity: sha512-uJ5vWrfBKMcE6y2Z8834dwEZj9mNGxYa3t3I53OwFeuZ8D9oc2E5zcsrkuhX6h4iYrjhiv0T3szQmxlAV9uxDg==}
     dev: true
+
+  /find-root/1.1.0:
+    resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
 
   /find-up/3.0.0:
     resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==}
@@ -9834,8 +9768,8 @@ packages:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
     dev: true
 
-  /follow-redirects/1.15.9:
-    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+  /follow-redirects/1.15.6:
+    resolution: {integrity: sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -9854,15 +9788,15 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /foreground-child/3.3.0:
-    resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
+  /foreground-child/3.2.1:
+    resolution: {integrity: sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==}
     engines: {node: '>=14'}
     dependencies:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
     dev: true
 
-  /fork-ts-checker-webpack-plugin/6.5.3_z6tosmbba6a4h5dofl3zomc5vu:
+  /fork-ts-checker-webpack-plugin/6.5.3_vmohbas7cixbs7dvjlkwhs5g3i:
     resolution: {integrity: sha512-SbH/l9ikmMWycd5puHJKTkZJKddF4iRLyW3DeZ08HTI7NGyLS38MXd/KGgeWumQO7YNQbW2u/NtPT2YowbPaGQ==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -9876,35 +9810,34 @@ packages:
       vue-template-compiler:
         optional: true
     dependencies:
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.24.7
       '@types/json-schema': 7.0.15
       chalk: 4.1.2
       chokidar: 3.6.0
       cosmiconfig: 6.0.0
       deepmerge: 4.3.1
-      eslint: 8.57.1
+      eslint: 8.57.0
       fs-extra: 9.1.0
       glob: 7.2.3
       memfs: 3.5.3
       minimatch: 3.1.2
       schema-utils: 2.7.0
-      semver: 7.6.3
+      semver: 7.6.2
       tapable: 1.1.3
       typescript: 5.0.4
-      webpack: 5.95.0
+      webpack: 5.92.1
     dev: true
 
-  /form-data/2.5.2:
-    resolution: {integrity: sha512-GgwY0PS7DbXqajuGf4OYlsrIu3zgxD6Vvql43IBhm6MahqA5SK/7mwhtNj2AdH2z35YR34ujJ7BN+3fFC3jP5Q==}
+  /form-data/2.5.1:
+    resolution: {integrity: sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==}
     engines: {node: '>= 0.12'}
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
-      safe-buffer: 5.2.1
 
-  /form-data/3.0.2:
-    resolution: {integrity: sha512-sJe+TQb2vIaIyO783qN6BlMYWMw3WBOHA1Ay2qxsnjuafEOQFJ2JakedOQirT6D5XPRxDvS7AHYyem9fTpb4LQ==}
+  /form-data/3.0.1:
+    resolution: {integrity: sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==}
     engines: {node: '>= 6'}
     dependencies:
       asynckit: 0.4.0
@@ -9912,8 +9845,8 @@ packages:
       mime-types: 2.1.35
     dev: true
 
-  /form-data/4.0.1:
-    resolution: {integrity: sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==}
+  /form-data/4.0.0:
+    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
     engines: {node: '>= 6'}
     dependencies:
       asynckit: 0.4.0
@@ -10067,13 +10000,13 @@ packages:
     resolution: {integrity: sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==}
     engines: {node: '>=6'}
     dependencies:
-      pump: 3.0.2
+      pump: 3.0.0
 
   /get-stream/5.2.0:
     resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
     engines: {node: '>=8'}
     dependencies:
-      pump: 3.0.2
+      pump: 3.0.0
 
   /get-stream/6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
@@ -10094,13 +10027,14 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /glob-gitignore/1.0.15:
-    resolution: {integrity: sha512-22pvDWt2hMPfL3UF6lWcZpP+VIwBekJyj6xyb1DpeSALJm+n/0gI9lWD30kvA/h3bgPqYeAX7xGONzmyHrSfqQ==}
+  /glob-gitignore/1.0.14:
+    resolution: {integrity: sha512-YuAEPqL58bOQDqDF2kMv009rIjSAtPs+WPzyGbwRWK+wD0UWQVRoP34Pz6yJ6ivco65C9tZnaIt0I3JCuQ8NZQ==}
     engines: {node: '>= 6'}
     dependencies:
       glob: 7.2.3
-      ignore: 5.3.2
-      lodash: 4.17.21
+      ignore: 5.3.1
+      lodash.difference: 4.5.0
+      lodash.union: 4.6.0
       make-array: 1.0.5
       util.inherits: 1.0.3
     dev: true
@@ -10127,11 +10061,11 @@ packages:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     hasBin: true
     dependencies:
-      foreground-child: 3.3.0
-      jackspeak: 3.4.3
+      foreground-child: 3.2.1
+      jackspeak: 3.4.2
       minimatch: 9.0.5
       minipass: 7.1.2
-      package-json-from-dist: 1.0.1
+      package-json-from-dist: 1.0.0
       path-scurry: 1.11.1
     dev: true
 
@@ -10175,7 +10109,7 @@ packages:
       es6-error: 4.1.1
       matcher: 3.0.0
       roarr: 2.15.4
-      semver: 7.6.3
+      semver: 7.6.2
       serialize-error: 7.0.1
     optional: true
 
@@ -10198,7 +10132,6 @@ packages:
   /globals/11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
-    dev: true
 
   /globals/13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
@@ -10221,7 +10154,7 @@ packages:
       array-union: 2.1.0
       dir-glob: 3.0.1
       fast-glob: 3.3.2
-      ignore: 5.3.2
+      ignore: 5.3.1
       merge2: 1.4.1
       slash: 3.0.0
     dev: true
@@ -10233,7 +10166,7 @@ packages:
       array-union: 3.0.1
       dir-glob: 3.0.1
       fast-glob: 3.3.2
-      ignore: 5.3.2
+      ignore: 5.3.1
       merge2: 1.4.1
       slash: 4.0.0
     dev: true
@@ -10244,7 +10177,7 @@ packages:
     dependencies:
       dir-glob: 3.0.1
       fast-glob: 3.3.2
-      ignore: 5.3.2
+      ignore: 5.3.1
       merge2: 1.4.1
       slash: 4.0.0
     dev: true
@@ -10323,7 +10256,6 @@ packages:
   /has-flag/3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
     engines: {node: '>=4'}
-    dev: true
 
   /has-flag/4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -10392,10 +10324,13 @@ packages:
     hasBin: true
     dev: true
 
+  /highlight-words-core/1.2.2:
+    resolution: {integrity: sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg==}
+
   /history/5.3.0:
     resolution: {integrity: sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==}
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.24.7
     dev: false
 
   /hoist-non-react-statics/3.3.2:
@@ -10461,7 +10396,7 @@ packages:
       he: 1.2.0
       param-case: 3.0.4
       relateurl: 0.2.7
-      terser: 5.36.0
+      terser: 5.31.1
     dev: true
 
   /html-tags/3.3.1:
@@ -10469,8 +10404,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /html-webpack-plugin/5.6.3_webpack@5.95.0:
-    resolution: {integrity: sha512-QSf1yjtSAsmf7rYBV7XX86uua4W/vkhIt0xNXKbsi2foEeW7vjJQz4bhnpL3xH+l1ryl1680uNv968Z+X6jSYg==}
+  /html-webpack-plugin/5.6.0_webpack@5.92.1:
+    resolution: {integrity: sha512-iwaY4wzbe48AfKLZ/Cc8k0L+FKG6oSNRaZ8x5A/T/IVDGyXcbHncM9TdDa93wn0FsSm82FhTKW7f3vS61thXAw==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
       '@rspack/core': 0.x || 1.x
@@ -10486,7 +10421,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.95.0
+      webpack: 5.92.1
     dev: true
 
   /htmlparser2/3.10.1:
@@ -10556,7 +10491,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.7
+      debug: 4.3.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10567,7 +10502,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.7
+      debug: 4.3.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10577,12 +10512,12 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7
+      debug: 4.3.5
     transitivePeerDependencies:
       - supports-color
 
-  /http-proxy-middleware/2.0.7_@types+express@4.17.21:
-    resolution: {integrity: sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==}
+  /http-proxy-middleware/2.0.6_@types+express@4.17.21:
+    resolution: {integrity: sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@types/express': ^4.17.13
@@ -10591,11 +10526,11 @@ packages:
         optional: true
     dependencies:
       '@types/express': 4.17.21
-      '@types/http-proxy': 1.17.15
+      '@types/http-proxy': 1.17.14
       http-proxy: 1.18.1
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
-      micromatch: 4.0.8
+      micromatch: 4.0.7
     transitivePeerDependencies:
       - debug
     dev: true
@@ -10605,7 +10540,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.9
+      follow-redirects: 1.15.6
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -10623,7 +10558,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.7
+      debug: 4.3.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10633,7 +10568,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7
+      debug: 4.3.5
     transitivePeerDependencies:
       - supports-color
 
@@ -10650,7 +10585,7 @@ packages:
   /i18next-browser-languagedetector/6.1.8:
     resolution: {integrity: sha512-Svm+MduCElO0Meqpj1kJAriTC6OhI41VhlT/A0UPjGoPZBhAHIaGE5EfsHlTpgdH09UVX7rcc72pSDDBeKSQQA==}
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.24.7
 
   /i18next-http-backend/1.4.5:
     resolution: {integrity: sha512-tLuHWuLWl6CmS07o+UB6EcQCaUjrZ1yhdseIN7sfq0u7phsMePJ8pqlGhIAdRDPF/q7ooyo5MID5DRFBCH+x5w==}
@@ -10666,7 +10601,7 @@ packages:
   /i18next/21.10.0:
     resolution: {integrity: sha512-YeuIBmFsGjUfO3qBmMOc0rQaun4mIpGKET5WDwvu8lU7gvwpcariZLNtL0Fzj+zazcHUrlXHiptcFhBMFaxzfg==}
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.24.7
 
   /iconv-lite/0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -10681,13 +10616,13 @@ packages:
       safer-buffer: 2.1.2
     dev: true
 
-  /icss-utils/5.1.0_postcss@8.4.47:
+  /icss-utils/5.1.0_postcss@8.4.39:
     resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
     dev: true
 
   /idb/7.1.1:
@@ -10706,8 +10641,8 @@ packages:
     engines: {node: '>= 4'}
     dev: true
 
-  /ignore/5.3.2:
-    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+  /ignore/5.3.1:
+    resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
     engines: {node: '>= 4'}
     dev: true
 
@@ -10724,8 +10659,8 @@ packages:
   /immer/9.0.6:
     resolution: {integrity: sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==}
 
-  /immutable/4.3.7:
-    resolution: {integrity: sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==}
+  /immutable/4.3.6:
+    resolution: {integrity: sha512-Ju0+lEMyzMVZarkTn/gqRpdqd5dOPaz1mCZ0SH3JV6iFw81PldE/PEB1hWVEA288HPt4WXW8O7AWxB10M+03QQ==}
     dev: true
 
   /import-fresh/3.3.0:
@@ -10734,15 +10669,14 @@ packages:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
-    dev: true
 
   /import-lazy/4.0.0:
     resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
     engines: {node: '>=8'}
     dev: true
 
-  /import-local/3.2.0:
-    resolution: {integrity: sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==}
+  /import-local/3.1.0:
+    resolution: {integrity: sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==}
     engines: {node: '>=8'}
     hasBin: true
     dependencies:
@@ -10788,8 +10722,8 @@ packages:
       side-channel: 1.0.6
     dev: true
 
-  /inversify/6.0.3:
-    resolution: {integrity: sha512-s/svzcRQ/scaGUUyaVtFSL1dvOaRgyvE7VvpGcJwXmFz7CCzfSfxC/Uyl7iSHDEmBabJ2gbDES72DaygtMmwvg==}
+  /inversify/6.0.2:
+    resolution: {integrity: sha512-i9m8j/7YIv4mDuYXUAcrpKPSaju/CIly9AHK5jvCBeoiM/2KEsuCQTTP+rzSWWpLYWRukdXFSl6ZTk2/uumbiA==}
 
   /ipaddr.js/1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -10836,7 +10770,6 @@ packages:
 
   /is-arrayish/0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
-    dev: true
 
   /is-async-function/2.0.0:
     resolution: {integrity: sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==}
@@ -10880,12 +10813,11 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /is-core-module/2.15.1:
-    resolution: {integrity: sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==}
+  /is-core-module/2.14.0:
+    resolution: {integrity: sha512-a5dFJih5ZLYlRtDc0dZWP7RiKr6xIKzmn/oAYCDvdLThadVgyJwlaoQPmRtMSpz+rk0OGAgIu+TcM9HUF0fk1A==}
     engines: {node: '>= 0.4'}
     dependencies:
       hasown: 2.0.2
-    dev: true
 
   /is-data-descriptor/1.0.1:
     resolution: {integrity: sha512-bc4NlCDiCr28U4aEsQ3Qs2491gVq4V8G7MQyws968ImqjKuYtTJXrl7Vq7jsN7Ly/C3xj5KWFrY7sHNeDkAzXw==}
@@ -11207,8 +11139,8 @@ packages:
     resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/parser': 7.26.2
+      '@babel/core': 7.24.7
+      '@babel/parser': 7.24.7
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -11220,11 +11152,11 @@ packages:
     resolution: {integrity: sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==}
     engines: {node: '>=10'}
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/parser': 7.26.2
+      '@babel/core': 7.24.7
+      '@babel/parser': 7.24.7
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.6.3
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11242,7 +11174,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.7
+      debug: 4.3.5
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -11257,9 +11189,8 @@ packages:
       istanbul-lib-report: 3.0.1
     dev: true
 
-  /iterator.prototype/1.1.3:
-    resolution: {integrity: sha512-FW5iMbeQ6rBGm/oKgzq2aW4KvAGpxPzYES8N4g4xNXUKpL1mclMvOe+76AcLDTvD+Ze+sOpVhgdAQEKF4L9iGQ==}
-    engines: {node: '>= 0.4'}
+  /iterator.prototype/1.1.2:
+    resolution: {integrity: sha512-DR33HMMr8EzwuRL8Y9D3u2BMj8+RqSE850jfGu59kS7tbmPLzGkZmVSfyCFSDxuZiEY6Rzt3T2NA/qU+NwVj1w==}
     dependencies:
       define-properties: 1.2.1
       get-intrinsic: 1.2.4
@@ -11268,20 +11199,21 @@ packages:
       set-function-name: 2.0.2
     dev: true
 
-  /jackspeak/3.4.3:
-    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+  /jackspeak/3.4.2:
+    resolution: {integrity: sha512-qH3nOSj8q/8+Eg8LUPOq3C+6HWkpUioIjDsq1+D4zY91oZvpPttw8GwtF1nReRYKXl+1AORyFqtm2f5Q1SB6/Q==}
+    engines: {node: 14 >=14.21 || 16 >=16.20 || >=18}
     dependencies:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
     dev: true
 
-  /jake/10.9.2:
-    resolution: {integrity: sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==}
+  /jake/10.9.1:
+    resolution: {integrity: sha512-61btcOHNnLnsOdtLgA5efqQWjnSi/vow5HbI7HMdKKWqvrKR1bLK3BPlJn9gcSaP2ewuamUSMB5XEy76KUIS2w==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      async: 3.2.6
+      async: 3.2.5
       chalk: 4.1.2
       filelist: 1.0.4
       minimatch: 3.1.2
@@ -11312,7 +11244,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -11340,7 +11272,7 @@ packages:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.3
@@ -11377,7 +11309,7 @@ packages:
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      import-local: 3.2.0
+      import-local: 3.1.0
       jest-config: 27.5.1
       jest-util: 27.5.1
       jest-validate: 27.5.1
@@ -11391,7 +11323,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /jest-cli/29.7.0_@types+node@18.19.62:
+  /jest-cli/29.7.0_@types+node@18.19.39:
     resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -11405,10 +11337,10 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0_@types+node@18.19.62
+      create-jest: 29.7.0_@types+node@18.19.39
       exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0_@types+node@18.19.62
+      import-local: 3.1.0
+      jest-config: 29.7.0_@types+node@18.19.39
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -11428,10 +11360,10 @@ packages:
       ts-node:
         optional: true
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.24.7
       '@jest/test-sequencer': 27.5.1
       '@jest/types': 27.5.1
-      babel-jest: 27.5.1_@babel+core@7.26.0
+      babel-jest: 27.5.1_@babel+core@7.24.7
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
@@ -11447,7 +11379,7 @@ packages:
       jest-runner: 27.5.1
       jest-util: 27.5.1
       jest-validate: 27.5.1
-      micromatch: 4.0.8
+      micromatch: 4.0.7
       parse-json: 5.2.0
       pretty-format: 27.5.1
       slash: 3.0.0
@@ -11459,7 +11391,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /jest-config/29.7.0_@types+node@18.19.62:
+  /jest-config/29.7.0_@types+node@18.19.39:
     resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -11471,11 +11403,11 @@ packages:
       ts-node:
         optional: true
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.24.7
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.62
-      babel-jest: 29.7.0_@babel+core@7.26.0
+      '@types/node': 18.19.39
+      babel-jest: 29.7.0_@babel+core@7.24.7
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
@@ -11489,7 +11421,7 @@ packages:
       jest-runner: 29.7.0
       jest-util: 29.7.0
       jest-validate: 29.7.0
-      micromatch: 4.0.8
+      micromatch: 4.0.7
       parse-json: 5.2.0
       pretty-format: 29.7.0
       slash: 3.0.0
@@ -11582,7 +11514,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       jest-mock: 27.5.1
       jest-util: 27.5.1
       jsdom: 16.7.0
@@ -11606,7 +11538,7 @@ packages:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/jsdom': 20.0.1
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       jest-mock: 29.7.0
       jest-util: 29.7.0
       jsdom: 20.0.3
@@ -11623,7 +11555,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       jest-mock: 27.5.1
       jest-util: 27.5.1
     dev: true
@@ -11635,7 +11567,7 @@ packages:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       jest-mock: 29.7.0
       jest-util: 29.7.0
     dev: true
@@ -11666,7 +11598,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@types/graceful-fs': 4.1.9
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -11674,7 +11606,7 @@ packages:
       jest-serializer: 27.5.1
       jest-util: 27.5.1
       jest-worker: 27.5.1
-      micromatch: 4.0.8
+      micromatch: 4.0.7
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.3
@@ -11686,14 +11618,14 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
       jest-regex-util: 29.6.3
       jest-util: 29.7.0
       jest-worker: 29.7.0
-      micromatch: 4.0.8
+      micromatch: 4.0.7
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.3
@@ -11707,7 +11639,7 @@ packages:
       '@jest/source-map': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       chalk: 4.1.2
       co: 4.6.0
       expect: 27.5.1
@@ -11774,12 +11706,12 @@ packages:
     resolution: {integrity: sha512-rMyFe1+jnyAAf+NHwTclDz0eAaLkVDdKVHHBFWsBWHnnh5YeJMNWWsv7AbFYXfK3oTqvL7VTWkhNLu1jX24D+g==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.24.7
       '@jest/types': 27.5.1
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
       graceful-fs: 4.2.11
-      micromatch: 4.0.8
+      micromatch: 4.0.7
       pretty-format: 27.5.1
       slash: 3.0.0
       stack-utils: 2.0.6
@@ -11789,12 +11721,12 @@ packages:
     resolution: {integrity: sha512-PFdn9Iewbt575zKPf1286Ht9EPoJmYT7P0kY+RibeYZ2XtOr53pDLEFoTWXbd1h4JiGiWpTBC84fc8xMXQMb7g==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.24.7
       '@jest/types': 28.1.3
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
       graceful-fs: 4.2.11
-      micromatch: 4.0.8
+      micromatch: 4.0.7
       pretty-format: 28.1.3
       slash: 3.0.0
       stack-utils: 2.0.6
@@ -11804,12 +11736,12 @@ packages:
     resolution: {integrity: sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.24.7
       '@jest/types': 29.6.3
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
       graceful-fs: 4.2.11
-      micromatch: 4.0.8
+      micromatch: 4.0.7
       pretty-format: 29.7.0
       slash: 3.0.0
       stack-utils: 2.0.6
@@ -11820,7 +11752,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
     dev: true
 
   /jest-mock/29.7.0:
@@ -11828,7 +11760,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       jest-util: 29.7.0
     dev: true
 
@@ -11932,7 +11864,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       chalk: 4.1.2
       emittery: 0.8.1
       graceful-fs: 4.2.11
@@ -11964,7 +11896,7 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -11996,7 +11928,7 @@ packages:
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
       chalk: 4.1.2
-      cjs-module-lexer: 1.4.1
+      cjs-module-lexer: 1.3.1
       collect-v8-coverage: 1.0.2
       execa: 5.1.1
       glob: 7.2.3
@@ -12025,9 +11957,9 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       chalk: 4.1.2
-      cjs-module-lexer: 1.4.1
+      cjs-module-lexer: 1.3.1
       collect-v8-coverage: 1.0.2
       glob: 7.2.3
       graceful-fs: 4.2.11
@@ -12048,7 +11980,7 @@ packages:
     resolution: {integrity: sha512-jZCyo6iIxO1aqUxpuBlwTDMkzOAJS4a3eYz3YzgxxVQFwLeSA7Jfq5cbqCY+JLvTDrWirgusI/0KwxKMgrdf7w==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       graceful-fs: 4.2.11
     dev: true
 
@@ -12056,16 +11988,16 @@ packages:
     resolution: {integrity: sha512-yYykXI5a0I31xX67mgeLw1DZ0bJB+gpq5IpSuCAoyDi0+BhgU/RIrL+RTzDmkNTchvDFWKP8lp+w/42Z3us5sA==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/generator': 7.26.2
-      '@babel/plugin-syntax-typescript': 7.25.9_@babel+core@7.26.0
-      '@babel/traverse': 7.25.9
-      '@babel/types': 7.26.0
+      '@babel/core': 7.24.7
+      '@babel/generator': 7.24.7
+      '@babel/plugin-syntax-typescript': 7.24.7_@babel+core@7.24.7
+      '@babel/traverse': 7.24.7
+      '@babel/types': 7.24.7
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
       '@types/babel__traverse': 7.20.6
       '@types/prettier': 2.7.3
-      babel-preset-current-node-syntax: 1.1.0_@babel+core@7.26.0
+      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.24.7
       chalk: 4.1.2
       expect: 27.5.1
       graceful-fs: 4.2.11
@@ -12077,7 +12009,7 @@ packages:
       jest-util: 27.5.1
       natural-compare: 1.4.0
       pretty-format: 27.5.1
-      semver: 7.6.3
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12086,15 +12018,15 @@ packages:
     resolution: {integrity: sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/generator': 7.26.2
-      '@babel/plugin-syntax-jsx': 7.25.9_@babel+core@7.26.0
-      '@babel/plugin-syntax-typescript': 7.25.9_@babel+core@7.26.0
-      '@babel/types': 7.26.0
+      '@babel/core': 7.24.7
+      '@babel/generator': 7.24.7
+      '@babel/plugin-syntax-jsx': 7.24.7_@babel+core@7.24.7
+      '@babel/plugin-syntax-typescript': 7.24.7_@babel+core@7.24.7
+      '@babel/types': 7.24.7
       '@jest/expect-utils': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      babel-preset-current-node-syntax: 1.1.0_@babel+core@7.26.0
+      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.24.7
       chalk: 4.1.2
       expect: 29.7.0
       graceful-fs: 4.2.11
@@ -12105,7 +12037,7 @@ packages:
       jest-util: 29.7.0
       natural-compare: 1.4.0
       pretty-format: 29.7.0
-      semver: 7.6.3
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12115,7 +12047,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -12127,7 +12059,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.3
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -12139,7 +12071,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -12192,7 +12124,7 @@ packages:
     dependencies:
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest-util: 27.5.1
@@ -12205,7 +12137,7 @@ packages:
     dependencies:
       '@jest/test-result': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.10.2
@@ -12219,7 +12151,7 @@ packages:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -12231,7 +12163,7 @@ packages:
     resolution: {integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       merge-stream: 2.0.0
       supports-color: 7.2.0
     dev: true
@@ -12240,7 +12172,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -12249,7 +12181,7 @@ packages:
     resolution: {integrity: sha512-CqRA220YV/6jCo8VWvAt1KKx6eek1VIHMPeLEbpcfSfkEeWyBNppynM/o6q+Wmw+sOhos2ml34wZbSX3G13//g==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -12258,7 +12190,7 @@ packages:
     resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 18.19.62
+      '@types/node': 18.19.39
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -12275,7 +12207,7 @@ packages:
         optional: true
     dependencies:
       '@jest/core': 27.5.1
-      import-local: 3.2.0
+      import-local: 3.1.0
       jest-cli: 27.5.1
     transitivePeerDependencies:
       - bufferutil
@@ -12285,7 +12217,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /jest/29.7.0_@types+node@18.19.62:
+  /jest/29.7.0_@types+node@18.19.39:
     resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -12297,8 +12229,8 @@ packages:
     dependencies:
       '@jest/core': 29.7.0
       '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0_@types+node@18.19.62
+      import-local: 3.1.0
+      jest-cli: 29.7.0_@types+node@18.19.39
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -12315,8 +12247,8 @@ packages:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
     dev: true
 
-  /jotai/2.10.1_ryhct6r6jz2fex4xfo2quarxhi:
-    resolution: {integrity: sha512-4FycO+BOTl2auLyF2Chvi6KTDqdsdDDtpaL/WHQMs8f3KS1E3loiUShQzAzFA/sMU5cJ0hz/RT1xum9YbG/zaA==}
+  /jotai/2.9.0_3vdbhqr2ncalcx7opnshezpx3q:
+    resolution: {integrity: sha512-MioTpMvR78IGfJ+W8EwQj3kwTkb+u0reGnTyg3oJZMWK9rK9v8NBSC9Rhrg9jrrFYA6bGZtzJa96zsuAYF6W3w==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
       '@types/react': '>=17.0.0'
@@ -12327,7 +12259,7 @@ packages:
       react:
         optional: true
     dependencies:
-      '@types/react': 18.3.12
+      '@types/react': 18.3.3
       react: 18.3.1
 
   /js-base64/3.7.7:
@@ -12361,7 +12293,7 @@ packages:
         optional: true
     dependencies:
       abab: 2.0.6
-      acorn: 8.14.0
+      acorn: 8.12.1
       acorn-globals: 6.0.0
       cssom: 0.4.4
       cssstyle: 2.3.0
@@ -12369,12 +12301,12 @@ packages:
       decimal.js: 10.4.3
       domexception: 2.0.1
       escodegen: 2.1.0
-      form-data: 3.0.2
+      form-data: 3.0.1
       html-encoding-sniffer: 2.0.1
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.1
       is-potential-custom-element-name: 1.0.1
-      nwsapi: 2.2.13
+      nwsapi: 2.2.10
       parse5: 6.0.1
       saxes: 5.0.1
       symbol-tree: 3.2.4
@@ -12403,7 +12335,7 @@ packages:
         optional: true
     dependencies:
       abab: 2.0.6
-      acorn: 8.14.0
+      acorn: 8.12.1
       acorn-globals: 7.0.1
       cssom: 0.5.0
       cssstyle: 2.3.0
@@ -12411,13 +12343,13 @@ packages:
       decimal.js: 10.4.3
       domexception: 4.0.0
       escodegen: 2.1.0
-      form-data: 4.0.1
+      form-data: 4.0.0
       html-encoding-sniffer: 3.0.0
       http-proxy-agent: 5.0.0
       https-proxy-agent: 5.0.1
       is-potential-custom-element-name: 1.0.1
-      nwsapi: 2.2.13
-      parse5: 7.2.1
+      nwsapi: 2.2.10
+      parse5: 7.1.2
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 4.1.4
@@ -12434,11 +12366,15 @@ packages:
       - utf-8-validate
     dev: true
 
-  /jsesc/3.0.2:
-    resolution: {integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==}
-    engines: {node: '>=6'}
+  /jsesc/0.5.0:
+    resolution: {integrity: sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==}
     hasBin: true
     dev: true
+
+  /jsesc/2.5.2:
+    resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   /json-buffer/3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -12449,7 +12385,6 @@ packages:
 
   /json-parse-even-better-errors/2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
-    dev: true
 
   /json-schema-traverse/0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -12589,10 +12524,10 @@ packages:
       language-subtag-registry: 0.3.23
     dev: true
 
-  /launch-editor/2.9.1:
-    resolution: {integrity: sha512-Gcnl4Bd+hRO9P9icCP/RVVT2o8SFlPXofuCxvA2SaZuH45whSvf5p8x5oih5ftLiVhEI4sp5xDY+R+b3zJBh5w==}
+  /launch-editor/2.8.0:
+    resolution: {integrity: sha512-vJranOAJrI/llyWGRQqiDM+adrw+k83fvmmx3+nV47g3+36xM15jE+zyZ6Ffel02+xSvuM0b2GDRosXZkbb6wA==}
     dependencies:
-      picocolors: 1.1.1
+      picocolors: 1.0.1
       shell-quote: 1.8.1
     dev: true
 
@@ -12627,15 +12562,8 @@ packages:
     engines: {node: '>=14'}
     dev: true
 
-  /linebreak/1.1.0:
-    resolution: {integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==}
-    dependencies:
-      base64-js: 0.0.8
-      unicode-trie: 2.0.0
-
   /lines-and-columns/1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
-    dev: true
 
   /linkify-it/2.2.0:
     resolution: {integrity: sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==}
@@ -12650,13 +12578,13 @@ packages:
       cli-truncate: 2.1.0
       commander: 6.2.1
       cosmiconfig: 7.1.0
-      debug: 4.3.7
+      debug: 4.3.5
       dedent: 0.7.0
       enquirer: 2.4.1
       execa: 4.1.0
       listr2: 3.14.0_enquirer@2.4.1
       log-symbols: 4.1.0
-      micromatch: 4.0.8
+      micromatch: 4.0.7
       normalize-path: 3.0.0
       please-upgrade-node: 3.2.0
       string-argv: 0.3.1
@@ -12748,9 +12676,16 @@ packages:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
     dev: true
 
+  /lodash.difference/4.5.0:
+    resolution: {integrity: sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==}
+    dev: true
+
+  /lodash.get/4.4.2:
+    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    dev: true
+
   /lodash.isequal/4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
-    dev: false
 
   /lodash.memoize/4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
@@ -12766,6 +12701,10 @@ packages:
 
   /lodash.truncate/4.4.2:
     resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
+    dev: true
+
+  /lodash.union/4.6.0:
+    resolution: {integrity: sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==}
     dev: true
 
   /lodash.uniq/4.5.0:
@@ -12806,7 +12745,7 @@ packages:
   /lower-case/2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
-      tslib: 2.8.0
+      tslib: 2.6.3
     dev: true
 
   /lowercase-keys/2.0.0:
@@ -12861,7 +12800,7 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.6.3
+      semver: 7.6.2
     dev: true
 
   /make-error/1.3.6:
@@ -12942,7 +12881,7 @@ packages:
   /mdast-util-to-markdown/0.6.5:
     resolution: {integrity: sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==}
     dependencies:
-      '@types/unist': 2.0.11
+      '@types/unist': 2.0.10
       longest-streak: 2.0.4
       mdast-util-to-string: 2.0.0
       parse-entities: 2.0.0
@@ -12977,8 +12916,14 @@ packages:
       fs-monkey: 1.0.6
     dev: true
 
+  /memoize-one/4.0.3:
+    resolution: {integrity: sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw==}
+
   /memoize-one/5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
+
+  /memoize-one/6.0.0:
+    resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
 
   /memorystream/0.3.1:
     resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
@@ -13003,8 +12948,8 @@ packages:
       yargs-parser: 20.2.9
     dev: true
 
-  /merge-descriptors/1.0.3:
-    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+  /merge-descriptors/1.0.1:
+    resolution: {integrity: sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==}
 
   /merge-options/1.0.1:
     resolution: {integrity: sha512-iuPV41VWKWBIOpBsjoxjDZw8/GbSfZ2mk7N1453bwMrfzdrIk7EzBd+8UVR6rkw67th7xnk9Dytl3J+lHPdxvg==}
@@ -13035,7 +12980,7 @@ packages:
   /micromark/2.11.4:
     resolution: {integrity: sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==}
     dependencies:
-      debug: 4.3.7
+      debug: 4.3.5
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -13060,8 +13005,8 @@ packages:
       to-regex: 3.0.2
     dev: true
 
-  /micromatch/4.0.8:
-    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+  /micromatch/4.0.7:
+    resolution: {integrity: sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==}
     engines: {node: '>=8.6'}
     dependencies:
       braces: 3.0.3
@@ -13076,11 +13021,6 @@ packages:
   /mime-db/1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
-
-  /mime-db/1.53.0:
-    resolution: {integrity: sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==}
-    engines: {node: '>= 0.6'}
-    dev: true
 
   /mime-types/2.1.18:
     resolution: {integrity: sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==}
@@ -13121,25 +13061,19 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /mini-css-extract-plugin/2.9.1_webpack@5.95.0:
-    resolution: {integrity: sha512-+Vyi+GCCOHnrJ2VPS+6aPoXN2k2jgUzDRhTFLjjTBn23qyXJXkjUWQgTL+mXpF5/A8ixLdCc6kWsoeOjKGejKQ==}
+  /mini-css-extract-plugin/2.9.0_webpack@5.92.1:
+    resolution: {integrity: sha512-Zs1YsZVfemekSZG+44vBsYTLQORkPMwnlv+aehcxK/NLKC+EGhDB39/YePYYqx/sTk6NnYpuqikhSn7+JIevTA==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
       schema-utils: 4.2.0
       tapable: 2.2.1
-      webpack: 5.95.0
+      webpack: 5.92.1
     dev: true
 
   /minimalistic-assert/1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
-    dev: true
-
-  /minimatch/3.0.8:
-    resolution: {integrity: sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==}
-    dependencies:
-      brace-expansion: 1.1.11
     dev: true
 
   /minimatch/3.1.2:
@@ -13203,30 +13137,30 @@ packages:
     hasBin: true
     dev: true
 
-  /mocha-junit-reporter/2.2.1_mocha@10.8.2:
+  /mocha-junit-reporter/2.2.1_mocha@10.6.0:
     resolution: {integrity: sha512-iDn2tlKHn8Vh8o4nCzcUVW4q7iXp7cC4EB78N0cDHIobLymyHNwe0XG8HEHHjc3hJlXm0Vy6zcrxaIhnI2fWmw==}
     peerDependencies:
       mocha: '>=2.2.5'
     dependencies:
-      debug: 4.3.7
+      debug: 4.3.5
       md5: 2.3.0
       mkdirp: 3.0.1
-      mocha: 10.8.2
+      mocha: 10.6.0
       strip-ansi: 6.0.1
       xml: 1.0.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /mocha/10.8.2:
-    resolution: {integrity: sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==}
+  /mocha/10.6.0:
+    resolution: {integrity: sha512-hxjt4+EEB0SA0ZDygSS015t65lJw/I2yRCS3Ae+SJ5FrbzrXgfYwJr96f0OvIXdj7h4lv/vLCrH3rkiuizFSvw==}
     engines: {node: '>= 14.0.0'}
     hasBin: true
     dependencies:
       ansi-colors: 4.1.3
       browser-stdout: 1.3.1
       chokidar: 3.6.0
-      debug: 4.3.7_supports-color@8.1.1
+      debug: 4.3.5_supports-color@8.1.1
       diff: 5.2.0
       escape-string-regexp: 4.0.0
       find-up: 5.0.0
@@ -13247,6 +13181,9 @@ packages:
 
   /ms/2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
+  /ms/2.1.2:
+    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
 
   /ms/2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -13321,11 +13258,7 @@ packages:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.8.0
-    dev: true
-
-  /node-addon-api/7.1.1:
-    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+      tslib: 2.6.3
     dev: true
 
   /node-fetch/2.6.7:
@@ -13348,8 +13281,8 @@ packages:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
     dev: true
 
-  /node-releases/2.0.18:
-    resolution: {integrity: sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==}
+  /node-releases/2.0.14:
+    resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
     dev: true
 
   /noms/0.0.0:
@@ -13373,8 +13306,8 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       hosted-git-info: 4.1.0
-      is-core-module: 2.15.1
-      semver: 7.6.3
+      is-core-module: 2.14.0
+      semver: 7.6.2
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -13435,8 +13368,8 @@ packages:
     resolution: {integrity: sha512-Y1wZESM7VUThYY+4W+X4ySH2maqcA+p7UR+w8VWNWVAd6lwuXXWz/w/Cz43J/dI2I+PS6wD5N+bJUF+gjWvIqg==}
     dev: true
 
-  /nwsapi/2.2.13:
-    resolution: {integrity: sha512-cTGB9ptp9dY9A5VbMSe7fQBcl/tt22Vcqdq8+eN93rblOuE0aCFu4aZ2vMwct/2t+lFnosm8RkQW1I0Omb1UtQ==}
+  /nwsapi/2.2.10:
+    resolution: {integrity: sha512-QK0sRs7MKv0tKe1+5uZIQk/C8XGza4DAnztJG8iD+TpJIORARrCxczA738awHrZoHeTjSSoHqao2teO0dC/gFQ==}
     dev: true
 
   /object-assign/3.0.0:
@@ -13527,6 +13460,15 @@ packages:
       es-abstract: 1.23.3
     dev: true
 
+  /object.hasown/1.1.4:
+    resolution: {integrity: sha512-FZ9LZt9/RHzGySlBARE3VF+gE26TxR38SdmqOqliuTnl9wrKulaQs+4dee1V+Io8VfxqzAfHu6YuRgUy8OHoTg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      define-properties: 1.2.1
+      es-abstract: 1.23.3
+      es-object-atoms: 1.0.0
+    dev: true
+
   /object.pick/1.3.0:
     resolution: {integrity: sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==}
     engines: {node: '>=0.10.0'}
@@ -13547,8 +13489,8 @@ packages:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
     dev: true
 
-  /oidc-client-ts/2.4.1:
-    resolution: {integrity: sha512-IxlGMsbkZPsHJGCliWT3LxjUcYzmiN21656n/Zt2jDncZlBFc//cd8WqFF0Lt681UT3AImM57E6d4N53ziTCYA==}
+  /oidc-client-ts/2.4.0:
+    resolution: {integrity: sha512-WijhkTrlXK2VvgGoakWJiBdfIsVGz6CFzgjNNqZU1hPKV2kyeEaJgLs7RwuiSp2WhLfWBQuLvr2SxVlZnk3N1w==}
     engines: {node: '>=12.13.0'}
     dependencies:
       crypto-js: 4.2.0
@@ -13689,18 +13631,15 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
-  /package-json-from-dist/1.0.1:
-    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+  /package-json-from-dist/1.0.0:
+    resolution: {integrity: sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==}
     dev: true
-
-  /pako/0.2.9:
-    resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
 
   /param-case/3.0.4:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.8.0
+      tslib: 2.6.3
     dev: true
 
   /parent-module/1.0.1:
@@ -13708,7 +13647,6 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       callsites: 3.1.0
-    dev: true
 
   /parse-entities/2.0.0:
     resolution: {integrity: sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==}
@@ -13733,18 +13671,17 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.24.7
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
-    dev: true
 
   /parse5/6.0.1:
     resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
     dev: true
 
-  /parse5/7.2.1:
-    resolution: {integrity: sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==}
+  /parse5/7.1.2:
+    resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
     dependencies:
       entities: 4.5.0
     dev: true
@@ -13757,7 +13694,7 @@ packages:
     resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.8.0
+      tslib: 2.6.3
     dev: true
 
   /pascalcase/0.1.1:
@@ -13794,7 +13731,6 @@ packages:
 
   /path-parse/1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
-    dev: true
 
   /path-scurry/1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
@@ -13807,8 +13743,8 @@ packages:
   /path-to-regexp/0.1.10:
     resolution: {integrity: sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==}
 
-  /path-to-regexp/8.2.0:
-    resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
+  /path-to-regexp/8.1.0:
+    resolution: {integrity: sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ==}
     engines: {node: '>=16'}
     dev: true
 
@@ -13822,7 +13758,6 @@ packages:
   /path-type/4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
-    dev: true
 
   /pend/1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
@@ -13835,9 +13770,8 @@ packages:
     resolution: {integrity: sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==}
     dev: true
 
-  /picocolors/1.1.1:
-    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
-    dev: true
+  /picocolors/1.0.1:
+    resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
 
   /picomatch/2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
@@ -13894,302 +13828,302 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /postcss-attribute-case-insensitive/5.0.2_postcss@8.4.47:
+  /postcss-attribute-case-insensitive/5.0.2_postcss@8.4.39:
     resolution: {integrity: sha512-XIidXV8fDr0kKt28vqki84fRK8VW8eTuIa4PChv2MqKuT6C9UjmSKzen6KaWhWEoYvwxFCa7n/tC1SZ3tyq4SQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.47
-      postcss-selector-parser: 6.1.2
+      postcss: 8.4.39
+      postcss-selector-parser: 6.1.0
     dev: true
 
-  /postcss-browser-comments/4.0.0_22bcdb3nr4qkkg7bvewmb25sri:
+  /postcss-browser-comments/4.0.0_73z3fjs2jrhgsuowbj3qmsq6yu:
     resolution: {integrity: sha512-X9X9/WN3KIvY9+hNERUqX9gncsgBA25XaeR+jshHz2j8+sYyHktHw1JdKuMjeLpGktXidqDhA7b/qm1mrBDmgg==}
     engines: {node: '>=8'}
     peerDependencies:
       browserslist: '>=4'
       postcss: '>=8'
     dependencies:
-      browserslist: 4.24.2
-      postcss: 8.4.47
+      browserslist: 4.23.2
+      postcss: 8.4.39
     dev: true
 
-  /postcss-calc/8.2.4_postcss@8.4.47:
+  /postcss-calc/8.2.4_postcss@8.4.39:
     resolution: {integrity: sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==}
     peerDependencies:
       postcss: ^8.2.2
     dependencies:
-      postcss: 8.4.47
-      postcss-selector-parser: 6.1.2
+      postcss: 8.4.39
+      postcss-selector-parser: 6.1.0
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-clamp/4.1.0_postcss@8.4.47:
+  /postcss-clamp/4.1.0_postcss@8.4.39:
     resolution: {integrity: sha512-ry4b1Llo/9zz+PKC+030KUnPITTJAHeOwjfAyyB60eT0AorGLdzp52s31OsPRHRf8NchkgFoG2y6fCfn1IV1Ow==}
     engines: {node: '>=7.6.0'}
     peerDependencies:
       postcss: ^8.4.6
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-color-functional-notation/4.2.4_postcss@8.4.47:
+  /postcss-color-functional-notation/4.2.4_postcss@8.4.39:
     resolution: {integrity: sha512-2yrTAUZUab9s6CpxkxC4rVgFEVaR6/2Pipvi6qcgvnYiVqZcbDHEoBDhrXzyb7Efh2CCfHQNtcqWcIruDTIUeg==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-color-hex-alpha/8.0.4_postcss@8.4.47:
+  /postcss-color-hex-alpha/8.0.4_postcss@8.4.39:
     resolution: {integrity: sha512-nLo2DCRC9eE4w2JmuKgVA3fGL3d01kGq752pVALF68qpGLmx2Qrk91QTKkdUqqp45T1K1XV8IhQpcu1hoAQflQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.4
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-color-rebeccapurple/7.1.1_postcss@8.4.47:
+  /postcss-color-rebeccapurple/7.1.1_postcss@8.4.39:
     resolution: {integrity: sha512-pGxkuVEInwLHgkNxUc4sdg4g3py7zUeCQ9sMfwyHAT+Ezk8a4OaaVZ8lIY5+oNqA/BXXgLyXv0+5wHP68R79hg==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-colormin/5.3.1_postcss@8.4.47:
+  /postcss-colormin/5.3.1_postcss@8.4.39:
     resolution: {integrity: sha512-UsWQG0AqTFQmpBegeLLc1+c3jIqBNB0zlDGRWR+dQ3pRKJL1oeMzyqmH3o2PIfn9MBdNrVPWhDbT769LxCTLJQ==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.24.2
+      browserslist: 4.23.2
       caniuse-api: 3.0.0
       colord: 2.9.3
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-convert-values/5.1.3_postcss@8.4.47:
+  /postcss-convert-values/5.1.3_postcss@8.4.39:
     resolution: {integrity: sha512-82pC1xkJZtcJEfiLw6UXnXVXScgtBrjlO5CBmuDQc+dlb88ZYheFsjTn40+zBVi3DkfF7iezO0nJUPLcJK3pvA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.24.2
-      postcss: 8.4.47
+      browserslist: 4.23.2
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-custom-media/8.0.2_postcss@8.4.47:
+  /postcss-custom-media/8.0.2_postcss@8.4.39:
     resolution: {integrity: sha512-7yi25vDAoHAkbhAzX9dHx2yc6ntS4jQvejrNcC+csQJAXjj15e7VcWfMgLqBNAbOvqi5uIa9huOVwdHbf+sKqg==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.3
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-custom-properties/12.1.11_postcss@8.4.47:
+  /postcss-custom-properties/12.1.11_postcss@8.4.39:
     resolution: {integrity: sha512-0IDJYhgU8xDv1KY6+VgUwuQkVtmYzRwu+dMjnmdMafXYv86SWqfxkc7qdDvWS38vsjaEtv8e0vGOUQrAiMBLpQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-custom-selectors/6.0.3_postcss@8.4.47:
+  /postcss-custom-selectors/6.0.3_postcss@8.4.39:
     resolution: {integrity: sha512-fgVkmyiWDwmD3JbpCmB45SvvlCD6z9CG6Ie6Iere22W5aHea6oWa7EM2bpnv2Fj3I94L3VbtvX9KqwSi5aFzSg==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.3
     dependencies:
-      postcss: 8.4.47
-      postcss-selector-parser: 6.1.2
+      postcss: 8.4.39
+      postcss-selector-parser: 6.1.0
     dev: true
 
-  /postcss-dir-pseudo-class/6.0.5_postcss@8.4.47:
+  /postcss-dir-pseudo-class/6.0.5_postcss@8.4.39:
     resolution: {integrity: sha512-eqn4m70P031PF7ZQIvSgy9RSJ5uI2171O/OO/zcRNYpJbvaeKFUlar1aJ7rmgiQtbm0FSPsRewjpdS0Oew7MPA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.47
-      postcss-selector-parser: 6.1.2
+      postcss: 8.4.39
+      postcss-selector-parser: 6.1.0
     dev: true
 
-  /postcss-discard-comments/5.1.2_postcss@8.4.47:
+  /postcss-discard-comments/5.1.2_postcss@8.4.39:
     resolution: {integrity: sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
     dev: true
 
-  /postcss-discard-duplicates/5.1.0_postcss@8.4.47:
+  /postcss-discard-duplicates/5.1.0_postcss@8.4.39:
     resolution: {integrity: sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
     dev: true
 
-  /postcss-discard-empty/5.1.1_postcss@8.4.47:
+  /postcss-discard-empty/5.1.1_postcss@8.4.39:
     resolution: {integrity: sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
     dev: true
 
-  /postcss-discard-overridden/5.1.0_postcss@8.4.47:
+  /postcss-discard-overridden/5.1.0_postcss@8.4.39:
     resolution: {integrity: sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
     dev: true
 
-  /postcss-double-position-gradients/3.1.2_postcss@8.4.47:
+  /postcss-double-position-gradients/3.1.2_postcss@8.4.39:
     resolution: {integrity: sha512-GX+FuE/uBR6eskOK+4vkXgT6pDkexLokPaz/AbJna9s5Kzp/yl488pKPjhy0obB475ovfT1Wv8ho7U/cHNaRgQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 1.3.0_postcss@8.4.47
-      postcss: 8.4.47
+      '@csstools/postcss-progressive-custom-properties': 1.3.0_postcss@8.4.39
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-env-function/4.0.6_postcss@8.4.47:
+  /postcss-env-function/4.0.6_postcss@8.4.39:
     resolution: {integrity: sha512-kpA6FsLra+NqcFnL81TnsU+Z7orGtDTxcOhl6pwXeEq1yFPpRMkCDpHhrz8CFQDr/Wfm0jLiNQ1OsGGPjlqPwA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.4
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-flexbugs-fixes/5.0.2_postcss@8.4.47:
+  /postcss-flexbugs-fixes/5.0.2_postcss@8.4.39:
     resolution: {integrity: sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ==}
     peerDependencies:
       postcss: ^8.1.4
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
     dev: true
 
-  /postcss-focus-visible/6.0.4_postcss@8.4.47:
+  /postcss-focus-visible/6.0.4_postcss@8.4.39:
     resolution: {integrity: sha512-QcKuUU/dgNsstIK6HELFRT5Y3lbrMLEOwG+A4s5cA+fx3A3y/JTq3X9LaOj3OC3ALH0XqyrgQIgey/MIZ8Wczw==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.4
     dependencies:
-      postcss: 8.4.47
-      postcss-selector-parser: 6.1.2
+      postcss: 8.4.39
+      postcss-selector-parser: 6.1.0
     dev: true
 
-  /postcss-focus-within/5.0.4_postcss@8.4.47:
+  /postcss-focus-within/5.0.4_postcss@8.4.39:
     resolution: {integrity: sha512-vvjDN++C0mu8jz4af5d52CB184ogg/sSxAFS+oUJQq2SuCe7T5U2iIsVJtsCp2d6R4j0jr5+q3rPkBVZkXD9fQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.4
     dependencies:
-      postcss: 8.4.47
-      postcss-selector-parser: 6.1.2
+      postcss: 8.4.39
+      postcss-selector-parser: 6.1.0
     dev: true
 
-  /postcss-font-variant/5.0.0_postcss@8.4.47:
+  /postcss-font-variant/5.0.0_postcss@8.4.39:
     resolution: {integrity: sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
     dev: true
 
-  /postcss-gap-properties/3.0.5_postcss@8.4.47:
+  /postcss-gap-properties/3.0.5_postcss@8.4.39:
     resolution: {integrity: sha512-IuE6gKSdoUNcvkGIqdtjtcMtZIFyXZhmFd5RUlg97iVEvp1BZKV5ngsAjCjrVy+14uhGBQl9tzmi1Qwq4kqVOg==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
     dev: true
 
-  /postcss-html/0.36.0_7ddkth4qkj3urzklvpilix4jii:
+  /postcss-html/0.36.0_lrpgrolfvll3p4c7yzuvfga3qm:
     resolution: {integrity: sha512-HeiOxGcuwID0AFsNAL0ox3mW6MHH5cstWN1Z3Y+n6H+g12ih7LHdYxWwEA/QmrebctLjo79xz9ouK3MroHwOJw==}
     peerDependencies:
       postcss: '>=5.0.0'
       postcss-syntax: '>=0.36.0'
     dependencies:
       htmlparser2: 3.10.1
-      postcss: 8.4.47
-      postcss-syntax: 0.36.2_postcss@8.4.47
+      postcss: 8.4.39
+      postcss-syntax: 0.36.2_postcss@8.4.39
     dev: true
 
-  /postcss-image-set-function/4.0.7_postcss@8.4.47:
+  /postcss-image-set-function/4.0.7_postcss@8.4.39:
     resolution: {integrity: sha512-9T2r9rsvYzm5ndsBE8WgtrMlIT7VbtTfE7b3BQnudUqnBcBo7L758oc+o+pdj/dUV0l5wjwSdjeOH2DZtfv8qw==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-import/15.1.0_postcss@8.4.47:
+  /postcss-import/15.1.0_postcss@8.4.39:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       postcss: ^8.0.0
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.8
     dev: true
 
-  /postcss-initial/4.0.1_postcss@8.4.47:
+  /postcss-initial/4.0.1_postcss@8.4.39:
     resolution: {integrity: sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==}
     peerDependencies:
       postcss: ^8.0.0
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
     dev: true
 
-  /postcss-js/4.0.1_postcss@8.4.47:
+  /postcss-js/4.0.1_postcss@8.4.39:
     resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
       postcss: ^8.4.21
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.4.47
+      postcss: 8.4.39
     dev: true
 
-  /postcss-lab-function/4.2.1_postcss@8.4.47:
+  /postcss-lab-function/4.2.1_postcss@8.4.39:
     resolution: {integrity: sha512-xuXll4isR03CrQsmxyz92LJB2xX9n+pZJ5jE9JgcnmsCammLyKdlzrBin+25dy6wIjfhJpKBAN80gsTlCgRk2w==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 1.3.0_postcss@8.4.47
-      postcss: 8.4.47
+      '@csstools/postcss-progressive-custom-properties': 1.3.0_postcss@8.4.39
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
@@ -14197,10 +14131,10 @@ packages:
     resolution: {integrity: sha512-7TvleQWNM2QLcHqvudt3VYjULVB49uiW6XzEUFmvwHzvsOEF5MwBrIXZDJQvJNFGjJQTzSzZnDoCJ8h/ljyGXA==}
     engines: {node: '>=6.14.4'}
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
     dev: true
 
-  /postcss-load-config/4.0.2_postcss@8.4.47:
+  /postcss-load-config/4.0.2_postcss@8.4.39:
     resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
     engines: {node: '>= 14'}
     peerDependencies:
@@ -14213,11 +14147,11 @@ packages:
         optional: true
     dependencies:
       lilconfig: 3.1.2
-      postcss: 8.4.47
-      yaml: 2.6.0
+      postcss: 8.4.39
+      yaml: 2.4.5
     dev: true
 
-  /postcss-loader/6.2.1_ttspydkdwnlpk544tqarzu6cim:
+  /postcss-loader/6.2.1_h7ybz3vosd2sabh3expkxy422u:
     resolution: {integrity: sha512-WbbYpmAaKcux/P66bZ40bpWsBucjx/TTgVVzRZ9yUO8yQfVBlameJ0ZGVaPfH64hNSBh63a+ICP5nqOpBA0w+Q==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -14226,255 +14160,255 @@ packages:
     dependencies:
       cosmiconfig: 7.1.0
       klona: 2.0.6
-      postcss: 8.4.47
-      semver: 7.6.3
-      webpack: 5.95.0
+      postcss: 8.4.39
+      semver: 7.6.2
+      webpack: 5.92.1
     dev: true
 
-  /postcss-logical/5.0.4_postcss@8.4.47:
+  /postcss-logical/5.0.4_postcss@8.4.39:
     resolution: {integrity: sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.4
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
     dev: true
 
-  /postcss-media-minmax/5.0.0_postcss@8.4.47:
+  /postcss-media-minmax/5.0.0_postcss@8.4.39:
     resolution: {integrity: sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
     dev: true
 
   /postcss-media-query-parser/0.2.3:
     resolution: {integrity: sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==}
     dev: true
 
-  /postcss-merge-longhand/5.1.7_postcss@8.4.47:
+  /postcss-merge-longhand/5.1.7_postcss@8.4.39:
     resolution: {integrity: sha512-YCI9gZB+PLNskrK0BB3/2OzPnGhPkBEwmwhfYk1ilBHYVAZB7/tkTHFBAnCrvBBOmeYyMYw3DMjT55SyxMBzjQ==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
-      stylehacks: 5.1.1_postcss@8.4.47
+      stylehacks: 5.1.1_postcss@8.4.39
     dev: true
 
-  /postcss-merge-rules/5.1.4_postcss@8.4.47:
+  /postcss-merge-rules/5.1.4_postcss@8.4.39:
     resolution: {integrity: sha512-0R2IuYpgU93y9lhVbO/OylTtKMVcHb67zjWIfCiKR9rWL3GUk1677LAqD/BcHizukdZEjT8Ru3oHRoAYoJy44g==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.24.2
+      browserslist: 4.23.2
       caniuse-api: 3.0.0
-      cssnano-utils: 3.1.0_postcss@8.4.47
-      postcss: 8.4.47
-      postcss-selector-parser: 6.1.2
+      cssnano-utils: 3.1.0_postcss@8.4.39
+      postcss: 8.4.39
+      postcss-selector-parser: 6.1.0
     dev: true
 
-  /postcss-minify-font-values/5.1.0_postcss@8.4.47:
+  /postcss-minify-font-values/5.1.0_postcss@8.4.39:
     resolution: {integrity: sha512-el3mYTgx13ZAPPirSVsHqFzl+BBBDrXvbySvPGFnQcTI4iNslrPaFq4muTkLZmKlGk4gyFAYUBMH30+HurREyA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-minify-gradients/5.1.1_postcss@8.4.47:
+  /postcss-minify-gradients/5.1.1_postcss@8.4.39:
     resolution: {integrity: sha512-VGvXMTpCEo4qHTNSa9A0a3D+dxGFZCYwR6Jokk+/3oB6flu2/PnPXAh2x7x52EkY5xlIHLm+Le8tJxe/7TNhzw==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
       colord: 2.9.3
-      cssnano-utils: 3.1.0_postcss@8.4.47
-      postcss: 8.4.47
+      cssnano-utils: 3.1.0_postcss@8.4.39
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-minify-params/5.1.4_postcss@8.4.47:
+  /postcss-minify-params/5.1.4_postcss@8.4.39:
     resolution: {integrity: sha512-+mePA3MgdmVmv6g+30rn57USjOGSAyuxUmkfiWpzalZ8aiBkdPYjXWtHuwJGm1v5Ojy0Z0LaSYhHaLJQB0P8Jw==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.24.2
-      cssnano-utils: 3.1.0_postcss@8.4.47
-      postcss: 8.4.47
+      browserslist: 4.23.2
+      cssnano-utils: 3.1.0_postcss@8.4.39
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-minify-selectors/5.2.1_postcss@8.4.47:
+  /postcss-minify-selectors/5.2.1_postcss@8.4.39:
     resolution: {integrity: sha512-nPJu7OjZJTsVUmPdm2TcaiohIwxP+v8ha9NehQ2ye9szv4orirRU3SDdtUmKH+10nzn0bAyOXZ0UEr7OpvLehg==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.47
-      postcss-selector-parser: 6.1.2
+      postcss: 8.4.39
+      postcss-selector-parser: 6.1.0
     dev: true
 
-  /postcss-modules-extract-imports/3.1.0_postcss@8.4.47:
+  /postcss-modules-extract-imports/3.1.0_postcss@8.4.39:
     resolution: {integrity: sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
     dev: true
 
-  /postcss-modules-local-by-default/4.0.5_postcss@8.4.47:
+  /postcss-modules-local-by-default/4.0.5_postcss@8.4.39:
     resolution: {integrity: sha512-6MieY7sIfTK0hYfafw1OMEG+2bg8Q1ocHCpoWLqOKj3JXlKu4G7btkmM/B7lFubYkYWmRSPLZi5chid63ZaZYw==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      icss-utils: 5.1.0_postcss@8.4.47
-      postcss: 8.4.47
-      postcss-selector-parser: 6.1.2
+      icss-utils: 5.1.0_postcss@8.4.39
+      postcss: 8.4.39
+      postcss-selector-parser: 6.1.0
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-modules-scope/3.2.0_postcss@8.4.47:
+  /postcss-modules-scope/3.2.0_postcss@8.4.39:
     resolution: {integrity: sha512-oq+g1ssrsZOsx9M96c5w8laRmvEu9C3adDSjI8oTcbfkrTE8hx/zfyobUoWIxaKPO8bt6S62kxpw5GqypEw1QQ==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      postcss: 8.4.47
-      postcss-selector-parser: 6.1.2
+      postcss: 8.4.39
+      postcss-selector-parser: 6.1.0
     dev: true
 
-  /postcss-modules-values/4.0.0_postcss@8.4.47:
+  /postcss-modules-values/4.0.0_postcss@8.4.39:
     resolution: {integrity: sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      icss-utils: 5.1.0_postcss@8.4.47
-      postcss: 8.4.47
+      icss-utils: 5.1.0_postcss@8.4.39
+      postcss: 8.4.39
     dev: true
 
-  /postcss-nested/6.2.0_postcss@8.4.47:
-    resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
+  /postcss-nested/6.0.1_postcss@8.4.39:
+    resolution: {integrity: sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.2.14
     dependencies:
-      postcss: 8.4.47
-      postcss-selector-parser: 6.1.2
+      postcss: 8.4.39
+      postcss-selector-parser: 6.1.0
     dev: true
 
-  /postcss-nesting/10.2.0_postcss@8.4.47:
+  /postcss-nesting/10.2.0_postcss@8.4.39:
     resolution: {integrity: sha512-EwMkYchxiDiKUhlJGzWsD9b2zvq/r2SSubcRrgP+jujMXFzqvANLt16lJANC+5uZ6hjI7lpRmI6O8JIl+8l1KA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/selector-specificity': 2.2.0_j747yjqyvnzekvomyruvypt3ti
-      postcss: 8.4.47
-      postcss-selector-parser: 6.1.2
+      '@csstools/selector-specificity': 2.2.0_jbx4mus4njtel3ypyfykqgp6rq
+      postcss: 8.4.39
+      postcss-selector-parser: 6.1.0
     dev: true
 
-  /postcss-normalize-charset/5.1.0_postcss@8.4.47:
+  /postcss-normalize-charset/5.1.0_postcss@8.4.39:
     resolution: {integrity: sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
     dev: true
 
-  /postcss-normalize-display-values/5.1.0_postcss@8.4.47:
+  /postcss-normalize-display-values/5.1.0_postcss@8.4.39:
     resolution: {integrity: sha512-WP4KIM4o2dazQXWmFaqMmcvsKmhdINFblgSeRgn8BJ6vxaMyaJkwAzpPpuvSIoG/rmX3M+IrRZEz2H0glrQNEA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-normalize-positions/5.1.1_postcss@8.4.47:
+  /postcss-normalize-positions/5.1.1_postcss@8.4.39:
     resolution: {integrity: sha512-6UpCb0G4eofTCQLFVuI3EVNZzBNPiIKcA1AKVka+31fTVySphr3VUgAIULBhxZkKgwLImhzMR2Bw1ORK+37INg==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-normalize-repeat-style/5.1.1_postcss@8.4.47:
+  /postcss-normalize-repeat-style/5.1.1_postcss@8.4.39:
     resolution: {integrity: sha512-mFpLspGWkQtBcWIRFLmewo8aC3ImN2i/J3v8YCFUwDnPu3Xz4rLohDO26lGjwNsQxB3YF0KKRwspGzE2JEuS0g==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-normalize-string/5.1.0_postcss@8.4.47:
+  /postcss-normalize-string/5.1.0_postcss@8.4.39:
     resolution: {integrity: sha512-oYiIJOf4T9T1N4i+abeIc7Vgm/xPCGih4bZz5Nm0/ARVJ7K6xrDlLwvwqOydvyL3RHNf8qZk6vo3aatiw/go3w==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-normalize-timing-functions/5.1.0_postcss@8.4.47:
+  /postcss-normalize-timing-functions/5.1.0_postcss@8.4.39:
     resolution: {integrity: sha512-DOEkzJ4SAXv5xkHl0Wa9cZLF3WCBhF3o1SKVxKQAa+0pYKlueTpCgvkFAHfk+Y64ezX9+nITGrDZeVGgITJXjg==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-normalize-unicode/5.1.1_postcss@8.4.47:
+  /postcss-normalize-unicode/5.1.1_postcss@8.4.39:
     resolution: {integrity: sha512-qnCL5jzkNUmKVhZoENp1mJiGNPcsJCs1aaRmURmeJGES23Z/ajaln+EPTD+rBeNkSryI+2WTdW+lwcVdOikrpA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.24.2
-      postcss: 8.4.47
+      browserslist: 4.23.2
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-normalize-url/5.1.0_postcss@8.4.47:
+  /postcss-normalize-url/5.1.0_postcss@8.4.39:
     resolution: {integrity: sha512-5upGeDO+PVthOxSmds43ZeMeZfKH+/DKgGRD7TElkkyS46JXAUhMzIKiCa7BabPeIy3AQcTkXwVVN7DbqsiCew==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
       normalize-url: 6.1.0
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-normalize-whitespace/5.1.1_postcss@8.4.47:
+  /postcss-normalize-whitespace/5.1.1_postcss@8.4.39:
     resolution: {integrity: sha512-83ZJ4t3NUDETIHTa3uEg6asWjSBYL5EdkVB0sDncx9ERzOKBVJIUeDO9RyA9Zwtig8El1d79HBp0JEi8wvGQnA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-normalize/10.0.1_22bcdb3nr4qkkg7bvewmb25sri:
+  /postcss-normalize/10.0.1_73z3fjs2jrhgsuowbj3qmsq6yu:
     resolution: {integrity: sha512-+5w18/rDev5mqERcG3W5GZNMJa1eoYYNGo8gB7tEwaos0ajk3ZXAI4mHGcNT47NE+ZnZD1pEpUOFLvltIwmeJA==}
     engines: {node: '>= 12'}
     peerDependencies:
@@ -14482,202 +14416,202 @@ packages:
       postcss: '>= 8'
     dependencies:
       '@csstools/normalize.css': 12.1.1
-      browserslist: 4.24.2
-      postcss: 8.4.47
-      postcss-browser-comments: 4.0.0_22bcdb3nr4qkkg7bvewmb25sri
+      browserslist: 4.23.2
+      postcss: 8.4.39
+      postcss-browser-comments: 4.0.0_73z3fjs2jrhgsuowbj3qmsq6yu
       sanitize.css: 13.0.0
     dev: true
 
-  /postcss-opacity-percentage/1.1.3_postcss@8.4.47:
+  /postcss-opacity-percentage/1.1.3_postcss@8.4.39:
     resolution: {integrity: sha512-An6Ba4pHBiDtyVpSLymUUERMo2cU7s+Obz6BTrS+gxkbnSBNKSuD0AVUc+CpBMrpVPKKfoVz0WQCX+Tnst0i4A==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
     dev: true
 
-  /postcss-ordered-values/5.1.3_postcss@8.4.47:
+  /postcss-ordered-values/5.1.3_postcss@8.4.39:
     resolution: {integrity: sha512-9UO79VUhPwEkzbb3RNpqqghc6lcYej1aveQteWY+4POIwlqkYE21HKWaLDF6lWNuqCobEAyTovVhtI32Rbv2RQ==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      cssnano-utils: 3.1.0_postcss@8.4.47
-      postcss: 8.4.47
+      cssnano-utils: 3.1.0_postcss@8.4.39
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-overflow-shorthand/3.0.4_postcss@8.4.47:
+  /postcss-overflow-shorthand/3.0.4_postcss@8.4.39:
     resolution: {integrity: sha512-otYl/ylHK8Y9bcBnPLo3foYFLL6a6Ak+3EQBPOTR7luMYCOsiVTUk1iLvNf6tVPNGXcoL9Hoz37kpfriRIFb4A==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-page-break/3.0.4_postcss@8.4.47:
+  /postcss-page-break/3.0.4_postcss@8.4.39:
     resolution: {integrity: sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==}
     peerDependencies:
       postcss: ^8
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
     dev: true
 
-  /postcss-place/7.0.5_postcss@8.4.47:
+  /postcss-place/7.0.5_postcss@8.4.39:
     resolution: {integrity: sha512-wR8igaZROA6Z4pv0d+bvVrvGY4GVHihBCBQieXFY3kuSuMyOmEnnfFzHl/tQuqHZkfkIVBEbDvYcFfHmpSet9g==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-prefix-selector/1.16.1_postcss@8.4.47:
+  /postcss-prefix-selector/1.16.1_postcss@8.4.39:
     resolution: {integrity: sha512-Umxu+FvKMwlY6TyDzGFoSUnzW+NOfMBLyC1tAkIjgX+Z/qGspJeRjVC903D7mx7TuBpJlwti2ibXtWuA7fKMeQ==}
     peerDependencies:
       postcss: '>4 <9'
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
     dev: true
 
-  /postcss-preset-env/7.8.3_postcss@8.4.47:
+  /postcss-preset-env/7.8.3_postcss@8.4.39:
     resolution: {integrity: sha512-T1LgRm5uEVFSEF83vHZJV2z19lHg4yJuZ6gXZZkqVsqv63nlr6zabMH3l4Pc01FQCyfWVrh2GaUeCVy9Po+Aag==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/postcss-cascade-layers': 1.1.1_postcss@8.4.47
-      '@csstools/postcss-color-function': 1.1.1_postcss@8.4.47
-      '@csstools/postcss-font-format-keywords': 1.0.1_postcss@8.4.47
-      '@csstools/postcss-hwb-function': 1.0.2_postcss@8.4.47
-      '@csstools/postcss-ic-unit': 1.0.1_postcss@8.4.47
-      '@csstools/postcss-is-pseudo-class': 2.0.7_postcss@8.4.47
-      '@csstools/postcss-nested-calc': 1.0.0_postcss@8.4.47
-      '@csstools/postcss-normalize-display-values': 1.0.1_postcss@8.4.47
-      '@csstools/postcss-oklab-function': 1.1.1_postcss@8.4.47
-      '@csstools/postcss-progressive-custom-properties': 1.3.0_postcss@8.4.47
-      '@csstools/postcss-stepped-value-functions': 1.0.1_postcss@8.4.47
-      '@csstools/postcss-text-decoration-shorthand': 1.0.0_postcss@8.4.47
-      '@csstools/postcss-trigonometric-functions': 1.0.2_postcss@8.4.47
-      '@csstools/postcss-unset-value': 1.0.2_postcss@8.4.47
-      autoprefixer: 10.4.20_postcss@8.4.47
-      browserslist: 4.24.2
-      css-blank-pseudo: 3.0.3_postcss@8.4.47
-      css-has-pseudo: 3.0.4_postcss@8.4.47
-      css-prefers-color-scheme: 6.0.3_postcss@8.4.47
+      '@csstools/postcss-cascade-layers': 1.1.1_postcss@8.4.39
+      '@csstools/postcss-color-function': 1.1.1_postcss@8.4.39
+      '@csstools/postcss-font-format-keywords': 1.0.1_postcss@8.4.39
+      '@csstools/postcss-hwb-function': 1.0.2_postcss@8.4.39
+      '@csstools/postcss-ic-unit': 1.0.1_postcss@8.4.39
+      '@csstools/postcss-is-pseudo-class': 2.0.7_postcss@8.4.39
+      '@csstools/postcss-nested-calc': 1.0.0_postcss@8.4.39
+      '@csstools/postcss-normalize-display-values': 1.0.1_postcss@8.4.39
+      '@csstools/postcss-oklab-function': 1.1.1_postcss@8.4.39
+      '@csstools/postcss-progressive-custom-properties': 1.3.0_postcss@8.4.39
+      '@csstools/postcss-stepped-value-functions': 1.0.1_postcss@8.4.39
+      '@csstools/postcss-text-decoration-shorthand': 1.0.0_postcss@8.4.39
+      '@csstools/postcss-trigonometric-functions': 1.0.2_postcss@8.4.39
+      '@csstools/postcss-unset-value': 1.0.2_postcss@8.4.39
+      autoprefixer: 10.4.19_postcss@8.4.39
+      browserslist: 4.23.2
+      css-blank-pseudo: 3.0.3_postcss@8.4.39
+      css-has-pseudo: 3.0.4_postcss@8.4.39
+      css-prefers-color-scheme: 6.0.3_postcss@8.4.39
       cssdb: 7.11.2
-      postcss: 8.4.47
-      postcss-attribute-case-insensitive: 5.0.2_postcss@8.4.47
-      postcss-clamp: 4.1.0_postcss@8.4.47
-      postcss-color-functional-notation: 4.2.4_postcss@8.4.47
-      postcss-color-hex-alpha: 8.0.4_postcss@8.4.47
-      postcss-color-rebeccapurple: 7.1.1_postcss@8.4.47
-      postcss-custom-media: 8.0.2_postcss@8.4.47
-      postcss-custom-properties: 12.1.11_postcss@8.4.47
-      postcss-custom-selectors: 6.0.3_postcss@8.4.47
-      postcss-dir-pseudo-class: 6.0.5_postcss@8.4.47
-      postcss-double-position-gradients: 3.1.2_postcss@8.4.47
-      postcss-env-function: 4.0.6_postcss@8.4.47
-      postcss-focus-visible: 6.0.4_postcss@8.4.47
-      postcss-focus-within: 5.0.4_postcss@8.4.47
-      postcss-font-variant: 5.0.0_postcss@8.4.47
-      postcss-gap-properties: 3.0.5_postcss@8.4.47
-      postcss-image-set-function: 4.0.7_postcss@8.4.47
-      postcss-initial: 4.0.1_postcss@8.4.47
-      postcss-lab-function: 4.2.1_postcss@8.4.47
-      postcss-logical: 5.0.4_postcss@8.4.47
-      postcss-media-minmax: 5.0.0_postcss@8.4.47
-      postcss-nesting: 10.2.0_postcss@8.4.47
-      postcss-opacity-percentage: 1.1.3_postcss@8.4.47
-      postcss-overflow-shorthand: 3.0.4_postcss@8.4.47
-      postcss-page-break: 3.0.4_postcss@8.4.47
-      postcss-place: 7.0.5_postcss@8.4.47
-      postcss-pseudo-class-any-link: 7.1.6_postcss@8.4.47
-      postcss-replace-overflow-wrap: 4.0.0_postcss@8.4.47
-      postcss-selector-not: 6.0.1_postcss@8.4.47
+      postcss: 8.4.39
+      postcss-attribute-case-insensitive: 5.0.2_postcss@8.4.39
+      postcss-clamp: 4.1.0_postcss@8.4.39
+      postcss-color-functional-notation: 4.2.4_postcss@8.4.39
+      postcss-color-hex-alpha: 8.0.4_postcss@8.4.39
+      postcss-color-rebeccapurple: 7.1.1_postcss@8.4.39
+      postcss-custom-media: 8.0.2_postcss@8.4.39
+      postcss-custom-properties: 12.1.11_postcss@8.4.39
+      postcss-custom-selectors: 6.0.3_postcss@8.4.39
+      postcss-dir-pseudo-class: 6.0.5_postcss@8.4.39
+      postcss-double-position-gradients: 3.1.2_postcss@8.4.39
+      postcss-env-function: 4.0.6_postcss@8.4.39
+      postcss-focus-visible: 6.0.4_postcss@8.4.39
+      postcss-focus-within: 5.0.4_postcss@8.4.39
+      postcss-font-variant: 5.0.0_postcss@8.4.39
+      postcss-gap-properties: 3.0.5_postcss@8.4.39
+      postcss-image-set-function: 4.0.7_postcss@8.4.39
+      postcss-initial: 4.0.1_postcss@8.4.39
+      postcss-lab-function: 4.2.1_postcss@8.4.39
+      postcss-logical: 5.0.4_postcss@8.4.39
+      postcss-media-minmax: 5.0.0_postcss@8.4.39
+      postcss-nesting: 10.2.0_postcss@8.4.39
+      postcss-opacity-percentage: 1.1.3_postcss@8.4.39
+      postcss-overflow-shorthand: 3.0.4_postcss@8.4.39
+      postcss-page-break: 3.0.4_postcss@8.4.39
+      postcss-place: 7.0.5_postcss@8.4.39
+      postcss-pseudo-class-any-link: 7.1.6_postcss@8.4.39
+      postcss-replace-overflow-wrap: 4.0.0_postcss@8.4.39
+      postcss-selector-not: 6.0.1_postcss@8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-pseudo-class-any-link/7.1.6_postcss@8.4.47:
+  /postcss-pseudo-class-any-link/7.1.6_postcss@8.4.39:
     resolution: {integrity: sha512-9sCtZkO6f/5ML9WcTLcIyV1yz9D1rf0tWc+ulKcvV30s0iZKS/ONyETvoWsr6vnrmW+X+KmuK3gV/w5EWnT37w==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.47
-      postcss-selector-parser: 6.1.2
+      postcss: 8.4.39
+      postcss-selector-parser: 6.1.0
     dev: true
 
-  /postcss-reduce-initial/5.1.2_postcss@8.4.47:
+  /postcss-reduce-initial/5.1.2_postcss@8.4.39:
     resolution: {integrity: sha512-dE/y2XRaqAi6OvjzD22pjTUQ8eOfc6m/natGHgKFBK9DxFmIm69YmaRVQrGgFlEfc1HePIurY0TmDeROK05rIg==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.24.2
+      browserslist: 4.23.2
       caniuse-api: 3.0.0
-      postcss: 8.4.47
+      postcss: 8.4.39
     dev: true
 
-  /postcss-reduce-transforms/5.1.0_postcss@8.4.47:
+  /postcss-reduce-transforms/5.1.0_postcss@8.4.39:
     resolution: {integrity: sha512-2fbdbmgir5AvpW9RLtdONx1QoYG2/EtqpNQbFASDlixBbAYuTcJ0dECwlqNqH7VbaUnEnh8SrxOe2sRIn24XyQ==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-replace-overflow-wrap/4.0.0_postcss@8.4.47:
+  /postcss-replace-overflow-wrap/4.0.0_postcss@8.4.39:
     resolution: {integrity: sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==}
     peerDependencies:
       postcss: ^8.0.3
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
     dev: true
 
-  /postcss-resolve-nested-selector/0.1.6:
-    resolution: {integrity: sha512-0sglIs9Wmkzbr8lQwEyIzlDOOC9bGmfVKcJTaxv3vMmd3uo4o4DerC3En0bnmgceeql9BfC8hRkp7cg0fjdVqw==}
+  /postcss-resolve-nested-selector/0.1.1:
+    resolution: {integrity: sha512-HvExULSwLqHLgUy1rl3ANIqCsvMS0WHss2UOsXhXnQaZ9VCc2oBvIpXrl00IUFT5ZDITME0o6oiXeiHr2SAIfw==}
     dev: true
 
   /postcss-safe-parser/4.0.2:
     resolution: {integrity: sha512-Uw6ekxSWNLCPesSv/cmqf2bY/77z11O7jZGPax3ycZMFU/oi2DMH9i89AdHc1tRwFg/arFoEwX0IS3LCUxJh1g==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
     dev: true
 
   /postcss-sass/0.4.4:
     resolution: {integrity: sha512-BYxnVYx4mQooOhr+zer0qWbSPYnarAy8ZT7hAQtbxtgVf8gy+LSLT/hHGe35h14/pZDTw1DsxdbrwxBN++H+fg==}
     dependencies:
       gonzales-pe: 4.3.0
-      postcss: 8.4.47
+      postcss: 8.4.39
     dev: true
 
   /postcss-scss/2.1.1:
     resolution: {integrity: sha512-jQmGnj0hSGLd9RscFw9LyuSVAa5Bl1/KBPqG1NQw9w8ND55nY4ZEsdlVuYJvLPpV+y0nwTV5v/4rHPzZRihQbA==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
     dev: true
 
-  /postcss-selector-not/6.0.1_postcss@8.4.47:
+  /postcss-selector-not/6.0.1_postcss@8.4.39:
     resolution: {integrity: sha512-1i9affjAe9xu/y9uqWH+tD4r6/hDaXJruk8xn2x1vzxC2U3J3LKO3zJW4CyxlNhA56pADJ/djpEwpH1RClI2rQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.47
-      postcss-selector-parser: 6.1.2
+      postcss: 8.4.39
+      postcss-selector-parser: 6.1.0
     dev: true
 
-  /postcss-selector-parser/6.1.2:
-    resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
+  /postcss-selector-parser/6.1.0:
+    resolution: {integrity: sha512-UMz42UD0UY0EApS0ZL9o1XnLhSTtvvvLe5Dc2H2O56fvRZi+KulDyf5ctDhhtYJBGKStV2FL1fy6253cmLgqVQ==}
     engines: {node: '>=4'}
     dependencies:
       cssesc: 3.0.0
@@ -14689,49 +14623,49 @@ packages:
     engines: {node: '>=8.7.0'}
     dependencies:
       lodash: 4.17.21
-      postcss: 8.4.47
+      postcss: 8.4.39
     dev: true
 
-  /postcss-svgo/5.1.0_postcss@8.4.47:
+  /postcss-svgo/5.1.0_postcss@8.4.39:
     resolution: {integrity: sha512-D75KsH1zm5ZrHyxPakAxJWtkyXew5qwS70v56exwvw542d9CRtTo78K0WeFxZB4G7JXKKMbEZtZayTGdIky/eA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-value-parser: 4.2.0
       svgo: 2.8.0
     dev: true
 
-  /postcss-syntax/0.36.2_postcss@8.4.47:
+  /postcss-syntax/0.36.2_postcss@8.4.39:
     resolution: {integrity: sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==}
     peerDependencies:
       postcss: '>=5.0.0'
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
     dev: true
 
-  /postcss-unique-selectors/5.1.1_postcss@8.4.47:
+  /postcss-unique-selectors/5.1.1_postcss@8.4.39:
     resolution: {integrity: sha512-5JiODlELrz8L2HwxfPnhOWZYWDxVHWL83ufOv84NrcgipI7TaeRsatAhK4Tr2/ZiYldpK/wBvw5BD3qfaK96GA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.47
-      postcss-selector-parser: 6.1.2
+      postcss: 8.4.39
+      postcss-selector-parser: 6.1.0
     dev: true
 
   /postcss-value-parser/4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
     dev: true
 
-  /postcss/8.4.47:
-    resolution: {integrity: sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==}
+  /postcss/8.4.39:
+    resolution: {integrity: sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.7
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
+      picocolors: 1.0.1
+      source-map-js: 1.2.0
     dev: true
 
   /posthtml-parser/0.2.1:
@@ -14895,20 +14829,29 @@ packages:
     resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
     dev: true
 
-  /pump/3.0.2:
-    resolution: {integrity: sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==}
+  /pump/3.0.0:
+    resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
     dependencies:
       end-of-stream: 1.4.4
       once: 1.4.0
 
+  /punycode/1.4.1:
+    resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
+    dev: true
+
   /punycode/2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
-    dev: true
 
   /pure-rand/6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
     dev: true
+
+  /qs/6.11.0:
+    resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
+    engines: {node: '>=0.6'}
+    dependencies:
+      side-channel: 1.0.6
 
   /qs/6.13.0:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
@@ -14989,7 +14932,7 @@ packages:
     resolution: {integrity: sha512-sZ41cxiU5llIB003yxxQBYrARBqe0repqPTTYBTmMqTz9szeBbE37BehCE891NZsmdZqqP+xWKdT3eo3vOzN8w==}
     engines: {node: '>=14'}
     dependencies:
-      core-js: 3.39.0
+      core-js: 3.37.1
       object-assign: 4.1.1
       promise: 8.3.0
       raf: 3.4.1
@@ -15009,20 +14952,20 @@ packages:
       section-iterator: 2.0.0
       shallow-equal: 1.2.1
 
-  /react-dev-utils/12.0.1_z6tosmbba6a4h5dofl3zomc5vu:
+  /react-dev-utils/12.0.1_vmohbas7cixbs7dvjlkwhs5g3i:
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
     dependencies:
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.24.7
       address: 1.2.2
-      browserslist: 4.24.2
+      browserslist: 4.23.2
       chalk: 4.1.2
       cross-spawn: 7.0.3
       detect-port-alt: 1.1.6
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3_z6tosmbba6a4h5dofl3zomc5vu
+      fork-ts-checker-webpack-plugin: 6.5.3_vmohbas7cixbs7dvjlkwhs5g3i
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -15053,25 +14996,35 @@ packages:
       react: 18.3.1
       scheduler: 0.23.2
 
+  /react-error-boundary/4.0.13_react@18.3.1:
+    resolution: {integrity: sha512-b6PwbdSv8XeOSYvjt8LpgpKrZ0yGdtZokYwkwV2wlcZbxgopHX/hgPl5VgpnoVOWd868n1hktM8Qm4b+02MiLQ==}
+    peerDependencies:
+      react: '>=16.13.1'
+    dependencies:
+      '@babel/runtime': 7.24.7
+      react: 18.3.1
+
   /react-error-boundary/4.0.3_react@18.3.1:
     resolution: {integrity: sha512-IzNKP/ViHWp2QRDgsDMirEcf0XLsLueN6Wgzm1TVwgbAH+paX8Z42VyKvZcFFRHgd+rPK2P4TLrOrHC/dommew==}
     peerDependencies:
       react: '>=16.13.1'
     dependencies:
-      '@babel/runtime': 7.26.0
-      react: 18.3.1
-
-  /react-error-boundary/4.1.2_react@18.3.1:
-    resolution: {integrity: sha512-GQDxZ5Jd+Aq/qUxbCm1UtzmL/s++V7zKgE8yMktJiCQXCCFZnMZh9ng+6/Ne6PjNSXH0L9CjeOEREfRnq6Duag==}
-    peerDependencies:
-      react: '>=16.13.1'
-    dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.24.7
       react: 18.3.1
 
   /react-error-overlay/6.0.11:
     resolution: {integrity: sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==}
     dev: true
+
+  /react-highlight-words/0.20.0_react@18.3.1:
+    resolution: {integrity: sha512-asCxy+jCehDVhusNmCBoxDf2mm1AJ//D+EzDx1m5K7EqsMBIHdZ5G4LdwbSEXqZq1Ros0G0UySWmAtntSph7XA==}
+    peerDependencies:
+      react: ^0.14.0 || ^15.0.0 || ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
+    dependencies:
+      highlight-words-core: 1.2.2
+      memoize-one: 4.0.3
+      prop-types: 15.8.1
+      react: 18.3.1
 
   /react-intersection-observer/8.34.0_react@18.3.1:
     resolution: {integrity: sha512-TYKh52Zc0Uptp5/b4N91XydfSGKubEhgZRtcg1rhTKABXijc4Sdr1uTp5lJ8TN27jwUsdXxjHXtHa0kPj704sw==}
@@ -15103,8 +15056,8 @@ packages:
       react-native:
         optional: true
     dependencies:
-      '@babel/runtime': 7.26.0
-      '@types/react-redux': 7.1.34
+      '@babel/runtime': 7.24.7
+      '@types/react-redux': 7.1.33
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -15117,28 +15070,62 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /react-router-dom/6.27.0_nnrd3gsncyragczmpvfhocinkq:
-    resolution: {integrity: sha512-+bvtFWMC0DgAFrfKXKG9Fc+BcXWRUO1aJIihbB79xaeq0v5UzfvnM5houGUm1Y461WVRcgAQ+Clh5rdb1eCx4g==}
+  /react-router-dom/6.24.1_nnrd3gsncyragczmpvfhocinkq:
+    resolution: {integrity: sha512-U19KtXqooqw967Vw0Qcn5cOvrX5Ejo9ORmOtJMzYWtCT4/WOfFLIZGGsVLxcd9UkBO0mSTZtXqhZBsWlHr7+Sg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
     dependencies:
-      '@remix-run/router': 1.20.0
+      '@remix-run/router': 1.17.1
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
-      react-router: 6.27.0_react@18.3.1
+      react-router: 6.24.1_react@18.3.1
     dev: false
 
-  /react-router/6.27.0_react@18.3.1:
-    resolution: {integrity: sha512-YA+HGZXz4jaAkVoYBE98VQl+nVzI+cVI2Oj/06F5ZM+0u3TgedN9Y9kmMRo2mnkSK2nCpNQn0DVob4HCsY/WLw==}
+  /react-router/6.24.1_react@18.3.1:
+    resolution: {integrity: sha512-PTXFXGK2pyXpHzVo3rR9H7ip4lSPZZc0bHG5CARmj65fTT6qG7sTngmb6lcYu1gf3y/8KxORoy9yn59pGpCnpg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
     dependencies:
-      '@remix-run/router': 1.20.0
+      '@remix-run/router': 1.17.1
       react: 18.3.1
     dev: false
+
+  /react-select-async-paginate/0.7.2_kipqsbdvtmv5eumhayztwa7ftm:
+    resolution: {integrity: sha512-NlF717+Kh/OgSC7YyEYuB0ebsqF2YhyEdcETH1lX6X4INgNKpKH269MI1H5soIThZdCPZl5xz2QSldcPKlPlew==}
+    peerDependencies:
+      react: ^16.14.0 || ^17.0.0 || ^18.0.0
+      react-select: ^5.0.0
+    dependencies:
+      '@seznam/compose-react-refs': 1.0.6
+      '@vtaits/use-lazy-ref': 0.1.3_react@18.3.1
+      react: 18.3.1
+      react-select: 5.7.0_psuonouaqi5wuc37nxyknoubym
+      sleep-promise: 9.1.0
+      use-is-mounted-ref: 1.5.0_react@18.3.1
+
+  /react-select/5.7.0_psuonouaqi5wuc37nxyknoubym:
+    resolution: {integrity: sha512-lJGiMxCa3cqnUr2Jjtg9YHsaytiZqeNOKeibv6WF5zbK/fPegZ1hg3y/9P1RZVLhqBTs0PfqQLKuAACednYGhQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.24.7
+      '@emotion/cache': 11.11.0
+      '@emotion/react': 11.11.4_3vdbhqr2ncalcx7opnshezpx3q
+      '@floating-ui/dom': 1.6.7
+      '@types/react-transition-group': 4.4.10
+      memoize-one: 6.0.0
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1_react@18.3.1
+      react-transition-group: 4.4.5_nnrd3gsncyragczmpvfhocinkq
+      use-isomorphic-layout-effect: 1.1.2_3vdbhqr2ncalcx7opnshezpx3q
+    transitivePeerDependencies:
+      - '@types/react'
+      - supports-color
 
   /react-table/7.8.0_react@18.3.1:
     resolution: {integrity: sha512-hNaz4ygkZO4bESeFfnfOft73iBUj8K5oKi1EcSHPAibEydfsX2MyU6Z8KCr3mv3C9Kqqh71U+DhZkFvibbnPbA==}
@@ -15158,7 +15145,7 @@ packages:
       react: '>=16.6.0'
       react-dom: '>=16.6.0'
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.24.7
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -15172,7 +15159,7 @@ packages:
       react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
       react-dom: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.24.7
       memoize-one: 5.2.1
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
@@ -15263,11 +15250,6 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /readdirp/4.0.2:
-    resolution: {integrity: sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==}
-    engines: {node: '>= 14.16.0'}
-    dev: true
-
   /recursive-readdir/2.2.3:
     resolution: {integrity: sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==}
     engines: {node: '>=6.0.0'}
@@ -15286,7 +15268,7 @@ packages:
   /redux/4.2.1:
     resolution: {integrity: sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==}
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.24.7
 
   /reflect-metadata/0.1.14:
     resolution: {integrity: sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==}
@@ -15301,11 +15283,11 @@ packages:
       es-errors: 1.3.0
       get-intrinsic: 1.2.4
       globalthis: 1.0.4
-      which-builtin-type: 1.1.4
+      which-builtin-type: 1.1.3
     dev: true
 
-  /regenerate-unicode-properties/10.2.0:
-    resolution: {integrity: sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA==}
+  /regenerate-unicode-properties/10.1.1:
+    resolution: {integrity: sha512-X007RyZLsCJVVrjgEFVpLUTZwyOZk3oiL75ZcuYjlIWd6rNJtOjkBwQc5AsRrpbKVkxN6sklw/k/9m2jJYOf8Q==}
     engines: {node: '>=4'}
     dependencies:
       regenerate: 1.4.2
@@ -15325,7 +15307,7 @@ packages:
   /regenerator-transform/0.15.2:
     resolution: {integrity: sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==}
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.24.7
     dev: true
 
   /regex-not/1.0.2:
@@ -15340,8 +15322,8 @@ packages:
     resolution: {integrity: sha512-TVILVSz2jY5D47F4mA4MppkBrafEaiUWJO/TcZHEIuI13AqoZMkK1WMA4Om1YkYbTx+9Ki1/tSUXbceyr9saRg==}
     dev: true
 
-  /regexp.prototype.flags/1.5.3:
-    resolution: {integrity: sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==}
+  /regexp.prototype.flags/1.5.2:
+    resolution: {integrity: sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.7
@@ -15355,16 +15337,16 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /regexpu-core/6.1.1:
-    resolution: {integrity: sha512-k67Nb9jvwJcJmVpw0jPttR1/zVfnKf8Km0IPatrU/zJ5XeG3+Slx0xLXs9HByJSzXzrlz5EDvN6yLNMDc2qdnw==}
+  /regexpu-core/5.3.2:
+    resolution: {integrity: sha512-RAM5FlZz+Lhmo7db9L298p2vHP5ZywrVXmVXpmAD9GuL5MPH6t9ROw1iA/wfHkQ76Qe7AaPF0nGuim96/IrQMQ==}
     engines: {node: '>=4'}
     dependencies:
+      '@babel/regjsgen': 0.8.0
       regenerate: 1.4.2
-      regenerate-unicode-properties: 10.2.0
-      regjsgen: 0.8.0
-      regjsparser: 0.11.2
+      regenerate-unicode-properties: 10.1.1
+      regjsparser: 0.9.1
       unicode-match-property-ecmascript: 2.0.0
-      unicode-match-property-value-ecmascript: 2.2.0
+      unicode-match-property-value-ecmascript: 2.1.0
     dev: true
 
   /registry-auth-token/3.3.2:
@@ -15381,15 +15363,11 @@ packages:
       rc: 1.2.8
     dev: true
 
-  /regjsgen/0.8.0:
-    resolution: {integrity: sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==}
-    dev: true
-
-  /regjsparser/0.11.2:
-    resolution: {integrity: sha512-3OGZZ4HoLJkkAZx/48mTXJNlmqTGOzc0o9OWQPuWpkOlXXPbyN6OafCcoXUnBqE2D3f/T5L+pWc1kdEmnfnRsA==}
+  /regjsparser/0.9.1:
+    resolution: {integrity: sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==}
     hasBin: true
     dependencies:
-      jsesc: 3.0.2
+      jsesc: 0.5.0
     dev: true
 
   /relateurl/0.2.7:
@@ -15469,7 +15447,6 @@ packages:
   /resolve-from/4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
-    dev: true
 
   /resolve-from/5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -15491,7 +15468,7 @@ packages:
       adjust-sourcemap-loader: 4.0.0
       convert-source-map: 1.9.0
       loader-utils: 2.0.4
-      postcss: 8.4.47
+      postcss: 8.4.39
       source-map: 0.6.1
     dev: true
 
@@ -15513,7 +15490,7 @@ packages:
   /resolve/1.19.0:
     resolution: {integrity: sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==}
     dependencies:
-      is-core-module: 2.15.1
+      is-core-module: 2.14.0
       path-parse: 1.0.7
     dev: true
 
@@ -15521,16 +15498,15 @@ packages:
     resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
     hasBin: true
     dependencies:
-      is-core-module: 2.15.1
+      is-core-module: 2.14.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
-    dev: true
 
   /resolve/2.0.0-next.5:
     resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
     hasBin: true
     dependencies:
-      is-core-module: 2.15.1
+      is-core-module: 2.14.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
@@ -15610,17 +15586,17 @@ packages:
       rollup-plugin-inject: 3.0.2
     dev: true
 
-  /rollup-plugin-terser/7.0.2_rollup@2.79.2:
+  /rollup-plugin-terser/7.0.2_rollup@2.79.1:
     resolution: {integrity: sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==}
     deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-terser
     peerDependencies:
       rollup: ^2.0.0
     dependencies:
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.24.7
       jest-worker: 26.6.2
-      rollup: 2.79.2
+      rollup: 2.79.1
       serialize-javascript: 4.0.0
-      terser: 5.36.0
+      terser: 5.31.1
     dev: true
 
   /rollup-pluginutils/2.8.2:
@@ -15629,8 +15605,8 @@ packages:
       estree-walker: 0.6.1
     dev: true
 
-  /rollup/2.79.2:
-    resolution: {integrity: sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==}
+  /rollup/2.79.1:
+    resolution: {integrity: sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==}
     engines: {node: '>=10.0.0'}
     hasBin: true
     optionalDependencies:
@@ -15660,7 +15636,7 @@ packages:
   /rxjs/7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
     dependencies:
-      tslib: 2.8.0
+      tslib: 2.6.3
 
   /safe-array-concat/1.1.2:
     resolution: {integrity: sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==}
@@ -15701,7 +15677,7 @@ packages:
     resolution: {integrity: sha512-ZRwKbh/eQ6w9vmTjkuG0Ioi3HBwPFce0O+v//ve+aOq1oeCy7jMV2qzzAlpsNuqpqCBjjriM1lbtZbF/Q8jVyA==}
     dev: true
 
-  /sass-loader/12.6.0_sass@1.80.5+webpack@5.95.0:
+  /sass-loader/12.6.0_sass@1.77.7+webpack@5.92.1:
     resolution: {integrity: sha512-oLTaH0YCtX4cfnJZxKSLAyglED0naiYfNG1iXfU5w1LNZ+ukoA5DtyDIN5zmKVZwYNJP4KRc5Y3hkWga+7tYfA==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -15722,19 +15698,18 @@ packages:
     dependencies:
       klona: 2.0.6
       neo-async: 2.6.2
-      sass: 1.80.5
-      webpack: 5.95.0
+      sass: 1.77.7
+      webpack: 5.92.1
     dev: true
 
-  /sass/1.80.5:
-    resolution: {integrity: sha512-TQd2aoQl/+zsxRMEDSxVdpPIqeq9UFc6pr7PzkugiTx3VYCFPUaa3P4RrBQsqok4PO200Vkz0vXQBNlg7W907g==}
+  /sass/1.77.7:
+    resolution: {integrity: sha512-9ywH75cO+rLjbrZ6en3Gp8qAMwPGBapFtlsMJoDTkcMU/bSe5a6cjKVUn5Jr4Gzg5GbP3HE8cm+02pLCgcoMow==}
     engines: {node: '>=14.0.0'}
     hasBin: true
     dependencies:
-      '@parcel/watcher': 2.4.1
-      chokidar: 4.0.1
-      immutable: 4.3.7
-      source-map-js: 1.2.1
+      chokidar: 3.6.0
+      immutable: 4.3.6
+      source-map-js: 1.2.0
     dev: true
 
   /saxes/5.0.1:
@@ -15788,9 +15763,9 @@ packages:
     engines: {node: '>= 12.13.0'}
     dependencies:
       '@types/json-schema': 7.0.15
-      ajv: 8.17.1
+      ajv: 8.16.0
       ajv-formats: 2.1.1
-      ajv-keywords: 5.1.0_ajv@8.17.1
+      ajv-keywords: 5.1.0_ajv@8.16.0
     dev: true
 
   /section-iterator/2.0.0:
@@ -15827,13 +15802,13 @@ packages:
       lru-cache: 6.0.0
     dev: true
 
-  /semver/7.6.3:
-    resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
+  /semver/7.6.2:
+    resolution: {integrity: sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==}
     engines: {node: '>=10'}
     hasBin: true
 
-  /send/0.19.0:
-    resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
+  /send/0.18.0:
+    resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
     engines: {node: '>= 0.8.0'}
     dependencies:
       debug: 2.6.9
@@ -15869,15 +15844,16 @@ packages:
       randombytes: 2.1.0
     dev: true
 
-  /serve-handler/6.1.6:
-    resolution: {integrity: sha512-x5RL9Y2p5+Sh3D38Fh9i/iQ5ZK+e4xuXRd/pGbM4D13tgo/MGwbttUk8emytcr1YYzBYs+apnUngBDFYfpjPuQ==}
+  /serve-handler/6.1.5:
+    resolution: {integrity: sha512-ijPFle6Hwe8zfmBxJdE+5fta53fdIY0lHISJvuikXB3VYFafRjMRpOffSPvCYsbKyBA7pvy9oYr/BT1O3EArlg==}
     dependencies:
       bytes: 3.0.0
       content-disposition: 0.5.2
+      fast-url-parser: 1.1.3
       mime-types: 2.1.18
       minimatch: 3.1.2
       path-is-inside: 1.0.2
-      path-to-regexp: 8.2.0
+      path-to-regexp: 8.1.0
       range-parser: 1.2.0
     dev: true
 
@@ -15894,17 +15870,17 @@ packages:
       parseurl: 1.3.3
     dev: true
 
-  /serve-static/1.16.2:
-    resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
+  /serve-static/1.15.0:
+    resolution: {integrity: sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==}
     engines: {node: '>= 0.8.0'}
     dependencies:
-      encodeurl: 2.0.0
+      encodeurl: 1.0.2
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 0.19.0
+      send: 0.18.0
 
-  /serve/14.2.4:
-    resolution: {integrity: sha512-qy1S34PJ/fcY8gjVGszDB3EXiPSk5FKhUa7tQe0UPRddxRidc2V6cNHPNewbE1D7MAkgLuWEt3Vw56vYy73tzQ==}
+  /serve/14.2.3:
+    resolution: {integrity: sha512-VqUFMC7K3LDGeGnJM9h56D3XGKb6KGgOw0cVNtA26yYXHCcpxf3xwCTUaQoWlVS7i8Jdh3GjQkOB23qsXyjoyQ==}
     engines: {node: '>= 14'}
     hasBin: true
     dependencies:
@@ -15917,7 +15893,7 @@ packages:
       clipboardy: 3.0.0
       compression: 1.7.4
       is-port-reachable: 4.0.0
-      serve-handler: 6.1.6
+      serve-handler: 6.1.5
       update-check: 1.5.4
     dev: true
 
@@ -16032,6 +16008,9 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
+  /sleep-promise/9.1.0:
+    resolution: {integrity: sha512-UHYzVpz9Xn8b+jikYSD6bqvf754xL2uBUzDFwiU6NcdZeifPr6UfgU43xpkPu67VMS88+TI2PSI7Eohgqf2fKA==}
+
   /slice-ansi/3.0.0:
     resolution: {integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==}
     engines: {node: '>=8'}
@@ -16076,12 +16055,12 @@ packages:
     resolution: {integrity: sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==}
     dev: true
 
-  /source-map-js/1.2.1:
-    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+  /source-map-js/1.2.0:
+    resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /source-map-loader/3.0.2_webpack@5.95.0:
+  /source-map-loader/3.0.2_webpack@5.92.1:
     resolution: {integrity: sha512-BokxPoLjyl3iOrgkWaakaxqnelAJSS+0V+De0kKIq6lyWrXuiPgYTGp6z3iHmqljKAaLXwZa+ctD8GccRJeVvg==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -16089,19 +16068,19 @@ packages:
     dependencies:
       abab: 2.0.6
       iconv-lite: 0.6.3
-      source-map-js: 1.2.1
-      webpack: 5.95.0
+      source-map-js: 1.2.0
+      webpack: 5.92.1
     dev: true
 
-  /source-map-loader/4.0.2_webpack@5.95.0:
+  /source-map-loader/4.0.2_webpack@5.92.1:
     resolution: {integrity: sha512-oYwAqCuL0OZhBoSgmdrLa7mv9MjommVMiQIWgcztf+eS4+8BfcUee6nenFnDhKOhzAVnk5gpZdfnz1iiBv+5sg==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       webpack: ^5.72.1
     dependencies:
       iconv-lite: 0.6.3
-      source-map-js: 1.2.1
-      webpack: 5.95.0
+      source-map-js: 1.2.0
+      webpack: 5.92.1
     dev: true
 
   /source-map-resolve/0.5.3:
@@ -16137,7 +16116,6 @@ packages:
   /source-map/0.5.7:
     resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /source-map/0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
@@ -16161,15 +16139,15 @@ packages:
     deprecated: Please use @jridgewell/sourcemap-codec instead
     dev: true
 
-  /spawn-command/0.0.2:
-    resolution: {integrity: sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==}
+  /spawn-command/0.0.2-1:
+    resolution: {integrity: sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==}
     dev: true
 
   /spdx-correct/3.2.0:
     resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
     dependencies:
       spdx-expression-parse: 3.0.1
-      spdx-license-ids: 3.0.20
+      spdx-license-ids: 3.0.18
     dev: true
 
   /spdx-exceptions/2.5.0:
@@ -16180,17 +16158,17 @@ packages:
     resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
     dependencies:
       spdx-exceptions: 2.5.0
-      spdx-license-ids: 3.0.20
+      spdx-license-ids: 3.0.18
     dev: true
 
-  /spdx-license-ids/3.0.20:
-    resolution: {integrity: sha512-jg25NiDV/1fLtSgEgyvVyDunvaNHbuwF9lfNV17gSmPFAlYzdfNBlLtLzXTevwkPj7DhGbmN9VnmJIgLnhvaBw==}
+  /spdx-license-ids/3.0.18:
+    resolution: {integrity: sha512-xxRs31BqRYHwiMzudOrpSiHtZ8i/GeionCBDSilhYRj+9gIcI8wCZTlXZKu9vZIVqViP3dcp9qE5G6AlIaD+TQ==}
     dev: true
 
   /spdy-transport/3.0.0:
     resolution: {integrity: sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==}
     dependencies:
-      debug: 4.3.7
+      debug: 4.3.5
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -16204,7 +16182,7 @@ packages:
     resolution: {integrity: sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      debug: 4.3.7
+      debug: 4.3.5
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -16340,11 +16318,9 @@ packages:
       strip-ansi: 7.1.0
     dev: true
 
-  /string.prototype.includes/2.0.1:
-    resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
-    engines: {node: '>= 0.4'}
+  /string.prototype.includes/2.0.0:
+    resolution: {integrity: sha512-E34CkBgyeqNDcrbU76cDjL5JLcVrtSdYq0MEh/B10r17pRP4ciHLwTgnuLV8Ay6cgEMLkcBkFCKyFZ43YldYzg==}
     dependencies:
-      call-bind: 1.0.7
       define-properties: 1.2.1
       es-abstract: 1.23.3
     dev: true
@@ -16362,7 +16338,7 @@ packages:
       gopd: 1.0.1
       has-symbols: 1.0.3
       internal-slot: 1.0.7
-      regexp.prototype.flags: 1.5.3
+      regexp.prototype.flags: 1.5.2
       set-function-name: 2.0.2
       side-channel: 1.0.6
     dev: true
@@ -16375,13 +16351,6 @@ packages:
       define-properties: 1.2.1
       es-abstract: 1.23.3
       es-object-atoms: 1.0.0
-    dev: true
-
-  /string.prototype.repeat/1.0.0:
-    resolution: {integrity: sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==}
-    dependencies:
-      define-properties: 1.2.1
-      es-abstract: 1.23.3
     dev: true
 
   /string.prototype.trim/1.2.9:
@@ -16461,7 +16430,7 @@ packages:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
     engines: {node: '>=12'}
     dependencies:
-      ansi-regex: 6.1.0
+      ansi-regex: 6.0.1
     dev: true
 
   /strip-bom/3.0.0:
@@ -16508,28 +16477,28 @@ packages:
   /strnum/1.0.5:
     resolution: {integrity: sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==}
 
-  /style-loader/3.3.4_webpack@5.95.0:
+  /style-loader/3.3.4_webpack@5.92.1:
     resolution: {integrity: sha512-0WqXzrsMTyb8yjZJHDqwmnwRJvhALK9LfRtRc6B4UTWe8AijYLZYZ9thuJTZc2VfQWINADW/j+LiJnfy2RoC1w==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.95.0
+      webpack: 5.92.1
     dev: true
 
   /style-search/0.1.0:
     resolution: {integrity: sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==}
     dev: true
 
-  /stylehacks/5.1.1_postcss@8.4.47:
+  /stylehacks/5.1.1_postcss@8.4.39:
     resolution: {integrity: sha512-sBpcd5Hx7G6seo7b1LkpttvTz7ikD0LlH5RmdcBNb6fFR0Fl7LQwHDFr300q4cwUqi+IYrFGmsIHieMBfnN/Bw==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.24.2
-      postcss: 8.4.47
-      postcss-selector-parser: 6.1.2
+      browserslist: 4.23.2
+      postcss: 8.4.39
+      postcss-selector-parser: 6.1.0
     dev: true
 
   /stylelint-config-prettier/8.0.2_stylelint@13.13.1:
@@ -16558,7 +16527,7 @@ packages:
       stylelint: ^10.0.1 || ^11.0.0 || ^12.0.0 || ^13.0.0
     dependencies:
       lodash: 4.17.21
-      postcss: 8.4.47
+      postcss: 8.4.39
       postcss-sorting: 5.0.1
       stylelint: 13.13.1
     dev: true
@@ -16583,8 +16552,8 @@ packages:
     dependencies:
       lodash: 4.17.21
       postcss-media-query-parser: 0.2.3
-      postcss-resolve-nested-selector: 0.1.6
-      postcss-selector-parser: 6.1.2
+      postcss-resolve-nested-selector: 0.1.1
+      postcss-selector-parser: 6.1.0
       postcss-value-parser: 4.2.0
       stylelint: 13.13.1
     dev: true
@@ -16594,13 +16563,13 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
     dependencies:
-      '@stylelint/postcss-css-in-js': 0.37.3_7ddkth4qkj3urzklvpilix4jii
-      '@stylelint/postcss-markdown': 0.36.2_7ddkth4qkj3urzklvpilix4jii
+      '@stylelint/postcss-css-in-js': 0.37.3_lrpgrolfvll3p4c7yzuvfga3qm
+      '@stylelint/postcss-markdown': 0.36.2_lrpgrolfvll3p4c7yzuvfga3qm
       autoprefixer: 9.8.8
       balanced-match: 2.0.0
       chalk: 4.1.2
       cosmiconfig: 7.1.0
-      debug: 4.3.7
+      debug: 4.3.5
       execall: 2.0.0
       fast-glob: 3.3.2
       fastest-levenshtein: 1.0.16
@@ -16610,7 +16579,7 @@ packages:
       globby: 11.1.0
       globjoin: 0.1.4
       html-tags: 3.3.1
-      ignore: 5.3.2
+      ignore: 5.3.1
       import-lazy: 4.0.0
       imurmurhash: 0.1.4
       known-css-properties: 0.21.0
@@ -16618,18 +16587,18 @@ packages:
       log-symbols: 4.1.0
       mathml-tag-names: 2.1.3
       meow: 9.0.0
-      micromatch: 4.0.8
+      micromatch: 4.0.7
       normalize-selector: 0.2.0
-      postcss: 8.4.47
-      postcss-html: 0.36.0_7ddkth4qkj3urzklvpilix4jii
+      postcss: 8.4.39
+      postcss-html: 0.36.0_lrpgrolfvll3p4c7yzuvfga3qm
       postcss-less: 3.1.4
       postcss-media-query-parser: 0.2.3
-      postcss-resolve-nested-selector: 0.1.6
+      postcss-resolve-nested-selector: 0.1.1
       postcss-safe-parser: 4.0.2
       postcss-sass: 0.4.4
       postcss-scss: 2.1.1
-      postcss-selector-parser: 6.1.2
-      postcss-syntax: 0.36.2_postcss@8.4.47
+      postcss-selector-parser: 6.1.0
+      postcss-syntax: 0.36.2_postcss@8.4.39
       postcss-value-parser: 4.2.0
       resolve-from: 5.0.0
       slash: 3.0.0
@@ -16645,6 +16614,9 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /stylis/4.2.0:
+    resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
 
   /subarg/1.0.0:
     resolution: {integrity: sha512-RIrIdRY0X1xojthNcVtgT9sjpOGagEUKpZdgBUi054OEPFo282yg+zE+t1Rj3+RqKq2xStL7uUHhY+AjbC4BXg==}
@@ -16669,14 +16641,14 @@ packages:
   /sugarss/2.0.0:
     resolution: {integrity: sha512-WfxjozUk0UVA4jm+U1d736AUpzSrNsQcIbyOkoE364GrtWmIrFdk5lksEupgWMD4VaT/0kVx1dobpiDumSgmJQ==}
     dependencies:
-      postcss: 8.4.47
+      postcss: 8.4.39
     dev: true
 
   /sumchecker/3.0.1:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
     engines: {node: '>= 8.0'}
     dependencies:
-      debug: 4.3.7
+      debug: 4.3.5
     transitivePeerDependencies:
       - supports-color
 
@@ -16690,7 +16662,6 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       has-flag: 3.0.0
-    dev: true
 
   /supports-color/6.1.0:
     resolution: {integrity: sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==}
@@ -16724,7 +16695,6 @@ packages:
   /supports-preserve-symlinks-flag/1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /svg-baker-runtime/1.4.7:
     resolution: {integrity: sha512-Zorfwwj5+lWjk/oxwSMsRdS2sPQQdTmmsvaSpzU+i9ZWi3zugHLt6VckWfnswphQP0LmOel3nggpF5nETbt6xw==}
@@ -16744,12 +16714,12 @@ packages:
       loader-utils: 1.4.2
       merge-options: 1.0.1
       micromatch: 3.1.0
-      postcss: 8.4.47
-      postcss-prefix-selector: 1.16.1_postcss@8.4.47
+      postcss: 8.4.39
+      postcss-prefix-selector: 1.16.1_postcss@8.4.39
       posthtml-rename-id: 1.0.12
       posthtml-svg-mode: 1.0.3
       query-string: 4.3.4
-      traverse: 0.6.10
+      traverse: 0.6.9
     dev: true
 
   /svg-parser/2.0.4:
@@ -16784,7 +16754,7 @@ packages:
       css-select: 4.3.0
       css-tree: 1.1.3
       csso: 4.2.0
-      picocolors: 1.1.1
+      picocolors: 1.0.1
       stable: 0.1.8
     dev: true
 
@@ -16799,15 +16769,15 @@ packages:
     resolution: {integrity: sha512-w2sfv80nrAh2VCbqR5AK27wswXhqcck2AhfnNW76beQXskGZ1V12GwS//yYVa3d3fcvAip2OUnbDAjW2k3v9fA==}
     engines: {node: '>=10.0.0'}
     dependencies:
-      ajv: 8.17.1
+      ajv: 8.16.0
       lodash.truncate: 4.4.2
       slice-ansi: 4.0.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
     dev: true
 
-  /tailwindcss/3.4.14:
-    resolution: {integrity: sha512-IcSvOcTRcUtQQ7ILQL5quRDg7Xs93PdJEk1ZLbhhvJc7uj/OAhYOnruEiwnGgBvUtaUAJ8/mhSw1o8L2jCiENA==}
+  /tailwindcss/3.4.4:
+    resolution: {integrity: sha512-ZoyXOdJjISB7/BcLTR6SEsLgKtDStYyYZVLsUtWChO4Ps20CBad7lfJKVDiejocV4ME1hLmyY0WJE3hSDcmQ2A==}
     engines: {node: '>=14.0.0'}
     hasBin: true
     dependencies:
@@ -16821,16 +16791,16 @@ packages:
       is-glob: 4.0.3
       jiti: 1.21.6
       lilconfig: 2.1.0
-      micromatch: 4.0.8
+      micromatch: 4.0.7
       normalize-path: 3.0.0
       object-hash: 3.0.0
-      picocolors: 1.1.1
-      postcss: 8.4.47
-      postcss-import: 15.1.0_postcss@8.4.47
-      postcss-js: 4.0.1_postcss@8.4.47
-      postcss-load-config: 4.0.2_postcss@8.4.47
-      postcss-nested: 6.2.0_postcss@8.4.47
-      postcss-selector-parser: 6.1.2
+      picocolors: 1.0.1
+      postcss: 8.4.39
+      postcss-import: 15.1.0_postcss@8.4.39
+      postcss-js: 4.0.1_postcss@8.4.39
+      postcss-load-config: 4.0.2_postcss@8.4.39
+      postcss-nested: 6.0.1_postcss@8.4.39
+      postcss-selector-parser: 6.1.0
       resolve: 1.22.8
       sucrase: 3.35.0
     transitivePeerDependencies:
@@ -16870,7 +16840,7 @@ packages:
       supports-hyperlinks: 2.3.0
     dev: true
 
-  /terser-webpack-plugin/5.3.10_webpack@5.95.0:
+  /terser-webpack-plugin/5.3.10_webpack@5.92.1:
     resolution: {integrity: sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -16890,17 +16860,17 @@ packages:
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
-      terser: 5.36.0
-      webpack: 5.95.0
+      terser: 5.31.1
+      webpack: 5.92.1
     dev: true
 
-  /terser/5.36.0:
-    resolution: {integrity: sha512-IYV9eNMuFAV4THUspIRXkLakHnV6XO7FEdtKjf/mDyrnqUg9LnlOn6/RwRvM9SZjR4GUq8Nk8zj67FzVARr74w==}
+  /terser/5.31.1:
+    resolution: {integrity: sha512-37upzU1+viGvuFtBo9NPufCb9dwM0+l9hMxYyWfBA+fbwrPqNJAhbZ6W47bBFnZHKHTUBnMvi87434qq+qnxOg==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
       '@jridgewell/source-map': 0.3.6
-      acorn: 8.14.0
+      acorn: 8.12.1
       commander: 2.20.3
       source-map-support: 0.5.21
     dev: true
@@ -16950,9 +16920,6 @@ packages:
     resolution: {integrity: sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==}
     dev: true
 
-  /tiny-inflate/1.0.3:
-    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
-
   /tippy.js/6.3.7:
     resolution: {integrity: sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==}
     dependencies:
@@ -16961,6 +16928,10 @@ packages:
   /tmpl/1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
     dev: true
+
+  /to-fast-properties/2.0.0:
+    resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
+    engines: {node: '>=4'}
 
   /to-object-path/0.3.0:
     resolution: {integrity: sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==}
@@ -17027,8 +16998,8 @@ packages:
       punycode: 2.3.1
     dev: true
 
-  /traverse/0.6.10:
-    resolution: {integrity: sha512-hN4uFRxbK+PX56DxYiGHsTn2dME3TVr9vbNqlQGcGcPhJAn+tdP126iA+TArMpI4YSgnTkMWyoLl5bf81Hi5TA==}
+  /traverse/0.6.9:
+    resolution: {integrity: sha512-7bBrcF+/LQzSgFmT0X5YclVqQxtv7TDJ1f8Wj7ibBu/U6BMLeOpUxuZjV7rMc44UtKxlnMFigdhFAIszSX1DMg==}
     engines: {node: '>= 0.4'}
     dependencies:
       gopd: 1.0.1
@@ -17058,7 +17029,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-jest/27.1.5_6i3m6jxo354ochmqovrdrplut4:
+  /ts-jest/27.1.5_ffc5qouy45v3zjlzng7flfczky:
     resolution: {integrity: sha512-Xv6jBQPoBEvBq/5i2TeSG9tt/nqkbpcurrEG1b+2yfBrcJelOZF9Ml6dmyMh7bcW9JyFbRYpR5rxROSlBLTZHA==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     hasBin: true
@@ -17079,8 +17050,8 @@ packages:
       esbuild:
         optional: true
     dependencies:
-      '@babel/core': 7.26.0
-      babel-jest: 27.5.1_@babel+core@7.26.0
+      '@babel/core': 7.24.7
+      babel-jest: 27.5.1_@babel+core@7.24.7
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       jest: 27.5.1
@@ -17088,13 +17059,13 @@ packages:
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.6.3
+      semver: 7.6.2
       typescript: 5.0.4
       yargs-parser: 20.2.9
     dev: true
 
-  /ts-jest/29.2.5_qbbgenyc4wnry6yt7igwhfhjbm:
-    resolution: {integrity: sha512-KD8zB2aAZrcKIdGk4OwpJggeLcH1FgrICqDSROWqlnJXGCXK4Mn6FcdK2B6670Xr73lHMG1kHw8R87A0ecZ+vA==}
+  /ts-jest/29.2.0_qbbgenyc4wnry6yt7igwhfhjbm:
+    resolution: {integrity: sha512-eFmkE9MG0+oT6nqSOcUwL+2UUmK2IvhhUV8hFDsCHnc++v2WCCbQQZh5vvjsa8sgOY/g9T0325hmkEmi6rninA==}
     engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -17118,20 +17089,19 @@ packages:
         optional: true
     dependencies:
       bs-logger: 0.2.6
-      ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0_@types+node@18.19.62
+      jest: 29.7.0_@types+node@18.19.39
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.6.3
+      semver: 7.6.2
       typescript: 5.0.4
       yargs-parser: 21.1.1
     dev: true
 
-  /ts-key-enum/2.0.13:
-    resolution: {integrity: sha512-zixs6j8+NhzazLUQ1SiFrlo1EFWG/DbqLuUGcWWZ5zhwjRT7kbi1hBlofxdqel+h28zrby2It5TrOyKp04kvqw==}
+  /ts-key-enum/2.0.12:
+    resolution: {integrity: sha512-Ety4IvKMaeG34AyXMp5r11XiVZNDRL+XWxXbVVJjLvq2vxKRttEANBE7Za1bxCAZRdH2/sZT6jFyyTWxXz28hw==}
 
   /tsconfig-paths/3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
@@ -17146,8 +17116,8 @@ packages:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
 
-  /tslib/2.8.0:
-    resolution: {integrity: sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==}
+  /tslib/2.6.3:
+    resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
 
   /tsutils/3.21.0:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
@@ -17329,12 +17299,6 @@ packages:
     hasBin: true
     dev: true
 
-  /typescript/5.4.2:
-    resolution: {integrity: sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-    dev: true
-
   /uc.micro/1.0.6:
     resolution: {integrity: sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==}
 
@@ -17360,8 +17324,8 @@ packages:
   /undici-types/5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
-  /unicode-canonical-property-names-ecmascript/2.0.1:
-    resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
+  /unicode-canonical-property-names-ecmascript/2.0.0:
+    resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
     engines: {node: '>=4'}
     dev: true
 
@@ -17369,12 +17333,12 @@ packages:
     resolution: {integrity: sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==}
     engines: {node: '>=4'}
     dependencies:
-      unicode-canonical-property-names-ecmascript: 2.0.1
+      unicode-canonical-property-names-ecmascript: 2.0.0
       unicode-property-aliases-ecmascript: 2.1.0
     dev: true
 
-  /unicode-match-property-value-ecmascript/2.2.0:
-    resolution: {integrity: sha512-4IehN3V/+kkr5YeSSDDQG8QLqO26XpL2XP3GQtqwlT/QYSECAwFztxVHjlbh0+gjJ3XmNLS0zDsbgs9jWKExLg==}
+  /unicode-match-property-value-ecmascript/2.1.0:
+    resolution: {integrity: sha512-qxkjQt6qjg/mYscYMC0XKRn3Rh0wFPlfxB0xkt9CfyTvpX1Ra0+rAmdX2QyAobptSEvuy4RtpPRui6XkV+8wjA==}
     engines: {node: '>=4'}
     dev: true
 
@@ -17382,12 +17346,6 @@ packages:
     resolution: {integrity: sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==}
     engines: {node: '>=4'}
     dev: true
-
-  /unicode-trie/2.0.0:
-    resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
-    dependencies:
-      pako: 0.2.9
-      tiny-inflate: 1.0.3
 
   /unidecode/0.1.8:
     resolution: {integrity: sha512-SdoZNxCWpN2tXTCrGkPF/0rL2HEq+i2gwRG1ReBvx8/0yTzC3enHfugOf8A9JBShVwwrRIkLX0YcDUGbzjbVCA==}
@@ -17435,7 +17393,7 @@ packages:
   /unist-util-stringify-position/2.0.3:
     resolution: {integrity: sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==}
     dependencies:
-      '@types/unist': 2.0.11
+      '@types/unist': 2.0.10
     dev: true
 
   /universalify/0.1.2:
@@ -17474,15 +17432,15 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /update-browserslist-db/1.1.1_browserslist@4.24.2:
-    resolution: {integrity: sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==}
+  /update-browserslist-db/1.1.0_browserslist@4.23.2:
+    resolution: {integrity: sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
     dependencies:
-      browserslist: 4.24.2
-      escalade: 3.2.0
-      picocolors: 1.1.1
+      browserslist: 4.23.2
+      escalade: 3.1.2
+      picocolors: 1.0.1
     dev: true
 
   /update-check/1.5.4:
@@ -17496,7 +17454,6 @@ packages:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.3.1
-    dev: true
 
   /urix/0.1.0:
     resolution: {integrity: sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==}
@@ -17515,6 +17472,32 @@ packages:
     dependencies:
       unidecode: 0.1.8
     dev: true
+
+  /use-is-mounted-ref/1.5.0_react@18.3.1:
+    resolution: {integrity: sha512-p5FksHf/ospZUr5KU9ese6u3jp9fzvZ3wuSb50i0y6fdONaHWgmOqQtxR/PUcwi6hnhQDbNxWSg3eTK3N6m+dg==}
+    peerDependencies:
+      react: '>=16.0.0'
+    dependencies:
+      react: 18.3.1
+
+  /use-isomorphic-layout-effect/1.1.2_3vdbhqr2ncalcx7opnshezpx3q:
+    resolution: {integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 18.3.3
+      react: 18.3.1
+
+  /use-sync-external-store/1.2.0_react@18.3.1:
+    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.3.1
 
   /use-sync-external-store/1.2.2_react@18.3.1:
     resolution: {integrity: sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==}
@@ -17586,6 +17569,11 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
+  /validator/13.12.0:
+    resolution: {integrity: sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==}
+    engines: {node: '>= 0.10'}
+    dev: true
+
   /vary/1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
@@ -17593,14 +17581,14 @@ packages:
   /vfile-message/2.0.4:
     resolution: {integrity: sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==}
     dependencies:
-      '@types/unist': 2.0.11
+      '@types/unist': 2.0.10
       unist-util-stringify-position: 2.0.3
     dev: true
 
   /vfile/4.2.1:
     resolution: {integrity: sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==}
     dependencies:
-      '@types/unist': 2.0.11
+      '@types/unist': 2.0.10
       is-buffer: 2.0.5
       unist-util-stringify-position: 2.0.3
       vfile-message: 2.0.4
@@ -17641,8 +17629,8 @@ packages:
       makeerror: 1.0.12
     dev: true
 
-  /watchpack/2.4.2:
-    resolution: {integrity: sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==}
+  /watchpack/2.4.1:
+    resolution: {integrity: sha512-8wrBCMtVhqcXP2Sup1ctSkga6uc2Bx0IIvKyT7yTFier5AXHooSI+QyQQAtTb7+E0IUCCKyTFmXqdqgum2XWGg==}
     engines: {node: '>=10.13.0'}
     dependencies:
       glob-to-regexp: 0.4.1
@@ -17677,7 +17665,7 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /webpack-dev-middleware/5.3.4_webpack@5.95.0:
+  /webpack-dev-middleware/5.3.4_webpack@5.92.1:
     resolution: {integrity: sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -17688,10 +17676,10 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.95.0
+      webpack: 5.92.1
     dev: true
 
-  /webpack-dev-server/4.15.2_webpack@5.95.0:
+  /webpack-dev-server/4.15.2_webpack@5.92.1:
     resolution: {integrity: sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==}
     engines: {node: '>= 12.13.0'}
     hasBin: true
@@ -17710,7 +17698,7 @@ packages:
       '@types/serve-index': 1.9.4
       '@types/serve-static': 1.15.7
       '@types/sockjs': 0.3.36
-      '@types/ws': 8.5.12
+      '@types/ws': 8.5.10
       ansi-html-community: 0.0.8
       bonjour-service: 1.2.1
       chokidar: 3.6.0
@@ -17718,12 +17706,12 @@ packages:
       compression: 1.7.4
       connect-history-api-fallback: 2.0.0
       default-gateway: 6.0.3
-      express: 4.21.1
+      express: 4.19.2
       graceful-fs: 4.2.11
       html-entities: 2.5.2
-      http-proxy-middleware: 2.0.7_@types+express@4.17.21
+      http-proxy-middleware: 2.0.6_@types+express@4.17.21
       ipaddr.js: 2.2.0
-      launch-editor: 2.9.1
+      launch-editor: 2.8.0
       open: 8.4.2
       p-retry: 4.6.2
       rimraf: 3.0.2
@@ -17732,8 +17720,8 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.95.0
-      webpack-dev-middleware: 5.3.4_webpack@5.95.0
+      webpack: 5.92.1
+      webpack-dev-middleware: 5.3.4_webpack@5.92.1
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
@@ -17742,14 +17730,14 @@ packages:
       - utf-8-validate
     dev: true
 
-  /webpack-manifest-plugin/4.1.1_webpack@5.95.0:
+  /webpack-manifest-plugin/4.1.1_webpack@5.92.1:
     resolution: {integrity: sha512-YXUAwxtfKIJIKkhg03MKuiFAD72PlrqCiwdwO4VEXdRO5V0ORCNwaOwAZawPZalCbmH9kBDmXnNeQOw+BIEiow==}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       webpack: ^4.44.2 || ^5.47.0
     dependencies:
       tapable: 2.2.1
-      webpack: 5.95.0
+      webpack: 5.92.1
       webpack-sources: 2.3.1
     dev: true
 
@@ -17773,8 +17761,8 @@ packages:
     engines: {node: '>=10.13.0'}
     dev: true
 
-  /webpack/5.95.0:
-    resolution: {integrity: sha512-2t3XstrKULz41MNMBF+cJ97TyHdyQ8HCt//pqErqDvNjU9YQBnZxIHa11VXsi7F3mb5/aO2tuDxdeTPdU7xu9Q==}
+  /webpack/5.92.1:
+    resolution: {integrity: sha512-JECQ7IwJb+7fgUFBlrJzbyu3GEuNBcdqr1LD7IbSzwkSmIevTm8PF+wej3Oxuz/JFBUZ6O1o43zsPkwm1C4TmA==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
@@ -17783,15 +17771,16 @@ packages:
       webpack-cli:
         optional: true
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.5
       '@webassemblyjs/ast': 1.12.1
       '@webassemblyjs/wasm-edit': 1.12.1
       '@webassemblyjs/wasm-parser': 1.12.1
-      acorn: 8.14.0
-      acorn-import-attributes: 1.9.5_acorn@8.14.0
-      browserslist: 4.24.2
+      acorn: 8.12.1
+      acorn-import-attributes: 1.9.5_acorn@8.12.1
+      browserslist: 4.23.2
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.17.1
+      enhanced-resolve: 5.17.0
       es-module-lexer: 1.5.4
       eslint-scope: 5.1.1
       events: 3.3.0
@@ -17803,8 +17792,8 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10_webpack@5.95.0
-      watchpack: 2.4.2
+      terser-webpack-plugin: 5.3.10_webpack@5.92.1
+      watchpack: 2.4.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:
       - '@swc/core'
@@ -17893,8 +17882,8 @@ packages:
       is-symbol: 1.0.4
     dev: true
 
-  /which-builtin-type/1.1.4:
-    resolution: {integrity: sha512-bppkmBSsHFmIMSl8BO9TbsyzsvGjVoppt8xUiGzwiu/bhDCGxnpOKCxgqj6GuyHE0mINMDecBFPlOm2hzY084w==}
+  /which-builtin-type/1.1.3:
+    resolution: {integrity: sha512-YmjsSMDBYsM1CaFiayOVT06+KJeXf0o5M/CAd4o1lTadFAtacTUM49zoYxr/oroopFDfhvN6iEcBxUyc3gvKmw==}
     engines: {node: '>= 0.4'}
     dependencies:
       function.prototype.name: 1.1.6
@@ -17985,23 +17974,23 @@ packages:
     resolution: {integrity: sha512-Tjf+gBwOTuGyZwMz2Nk/B13Fuyeo0Q84W++bebbVsfr9iLkDSo6j6PST8tET9HYA58mlRXwlMGpyWO8ETJiXdQ==}
     engines: {node: '>=10.0.0'}
     dependencies:
-      '@apideck/better-ajv-errors': 0.3.6_ajv@8.17.1
-      '@babel/core': 7.26.0
-      '@babel/preset-env': 7.26.0_@babel+core@7.26.0
-      '@babel/runtime': 7.26.0
-      '@rollup/plugin-babel': 5.3.1_jv6xoz77vs757ecddpkzporema
-      '@rollup/plugin-node-resolve': 11.2.1_rollup@2.79.2
-      '@rollup/plugin-replace': 2.4.2_rollup@2.79.2
+      '@apideck/better-ajv-errors': 0.3.6_ajv@8.16.0
+      '@babel/core': 7.24.7
+      '@babel/preset-env': 7.24.7_@babel+core@7.24.7
+      '@babel/runtime': 7.24.7
+      '@rollup/plugin-babel': 5.3.1_je4nbmfg47mhbnn75kmajdcj7i
+      '@rollup/plugin-node-resolve': 11.2.1_rollup@2.79.1
+      '@rollup/plugin-replace': 2.4.2_rollup@2.79.1
       '@surma/rollup-plugin-off-main-thread': 2.2.3
-      ajv: 8.17.1
+      ajv: 8.16.0
       common-tags: 1.8.2
       fast-json-stable-stringify: 2.1.0
       fs-extra: 9.1.0
       glob: 7.2.3
       lodash: 4.17.21
       pretty-bytes: 5.6.0
-      rollup: 2.79.2
-      rollup-plugin-terser: 7.0.2_rollup@2.79.2
+      rollup: 2.79.1
+      rollup-plugin-terser: 7.0.2_rollup@2.79.1
       source-map: 0.8.0-beta.0
       stringify-object: 3.3.0
       strip-comments: 2.0.1
@@ -18109,7 +18098,7 @@ packages:
     resolution: {integrity: sha512-R2IkwDokbtHUE4Kus8pKO5+VkPHD2oqTgl+XJwh4zbF1HyjAbgNmK/FneZHVU7p03XUt9ICfuGDYISWG9qV/CQ==}
     dev: true
 
-  /workbox-webpack-plugin/6.6.0_webpack@5.95.0:
+  /workbox-webpack-plugin/6.6.0_webpack@5.92.1:
     resolution: {integrity: sha512-xNZIZHalboZU66Wa7x1YkjIqEy1gTR+zPM+kjrYJzqN7iurYZBctBLISyScjhkJKYuRrZUP0iqViZTh8rS0+3A==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
@@ -18118,7 +18107,7 @@ packages:
       fast-json-stable-stringify: 2.1.0
       pretty-bytes: 5.6.0
       upath: 1.2.0
-      webpack: 5.95.0
+      webpack: 5.92.1
       webpack-sources: 1.4.3
       workbox-build: 6.6.0
     transitivePeerDependencies:
@@ -18265,10 +18254,9 @@ packages:
   /yaml/1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
-    dev: true
 
-  /yaml/2.6.0:
-    resolution: {integrity: sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==}
+  /yaml/2.4.5:
+    resolution: {integrity: sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==}
     engines: {node: '>= 14'}
     hasBin: true
     dev: true
@@ -18320,7 +18308,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       cliui: 7.0.4
-      escalade: 3.2.0
+      escalade: 3.1.2
       get-caller-file: 2.0.5
       require-directory: 2.1.1
       string-width: 4.2.3
@@ -18333,7 +18321,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       cliui: 8.0.1
-      escalade: 3.2.0
+      escalade: 3.1.2
       get-caller-file: 2.0.5
       require-directory: 2.1.1
       string-width: 4.2.3
@@ -18352,8 +18340,20 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /zustand/4.5.5_esssjoahjgjy6wmb4kavvr2kri:
-    resolution: {integrity: sha512-+0PALYNJNgK6hldkgDq2vLrw5f6g/jCInz52n9RTpropGgeAf/ioFUCdtsjCqu4gNhW9D01rUQBROoRjdzyn2Q==}
+  /z-schema/5.0.5:
+    resolution: {integrity: sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==}
+    engines: {node: '>=8.0.0'}
+    hasBin: true
+    dependencies:
+      lodash.get: 4.4.2
+      lodash.isequal: 4.5.0
+      validator: 13.12.0
+    optionalDependencies:
+      commander: 9.5.0
+    dev: true
+
+  /zustand/4.5.4_djzcoonmr6xkxvxv5wbacldipi:
+    resolution: {integrity: sha512-/BPMyLKJPtFEvVL0E9E9BTUM63MNyhPGlvxk1XjrfWTUlV+BR8jufjsovHzrtR6YNcBEcL7cMHovL1n9xHawEg==}
     engines: {node: '>=12.7.0'}
     peerDependencies:
       '@types/react': '>=16.8'
@@ -18367,10 +18367,10 @@ packages:
       react:
         optional: true
     dependencies:
-      '@types/react': 18.3.12
+      '@types/react': 18.3.3
       immer: 9.0.6
       react: 18.3.1
-      use-sync-external-store: 1.2.2_react@18.3.1
+      use-sync-external-store: 1.2.0_react@18.3.1
 
   /zwitch/1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -3,9 +3,9 @@ lockfileVersion: 5.4
 overrides:
   body-parser@<1.20.3: ^1.20.3
   braces: ^3.0.3
-  postcss: ^8.4.31
   path-to-regexp@>=0.2.0: ^8.0.0
   path-to-regexp@<0.1.10: ^0.1.10
+  postcss: ^8.4.31
 
 importers:
 
@@ -83,73 +83,73 @@ importers:
       webpack: ^5.1.2
     dependencies:
       '@bentley/icons-generic-webfont': 1.0.34
-      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/appui-layout-react': 4.8.3_jscgs7su4cyo55wt5klvj3iepa
-      '@itwin/appui-react': 4.15.1_yrqai5hl5gvsf4dek6el5aloii
-      '@itwin/components-react': 4.15.1_jscgs7su4cyo55wt5klvj3iepa
-      '@itwin/core-backend': 4.7.4_zzr6hivuljmnvzdhcyobjpaqme
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
-      '@itwin/core-electron': 4.7.4_hworozxoblmw2cyo32mpk5ebjm
-      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
-      '@itwin/core-geometry': 4.7.4
-      '@itwin/core-i18n': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/core-markup': 4.7.4_aa3bt7vk4zzsxcvhcdi4ojlcwe
-      '@itwin/core-orbitgt': 4.7.4
-      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/core-react': 4.15.1_bpptdsfauwdziiwg4uklizbr74
-      '@itwin/core-telemetry': 4.7.4_@itwin+core-geometry@4.7.4
+      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/appui-layout-react': 4.8.3_zs6rif5h5jixp3mcoeld6e43pu
+      '@itwin/appui-react': 4.17.2_ggnmyqo32cg3w26befg4w43y64
+      '@itwin/components-react': 4.17.2_zs6rif5h5jixp3mcoeld6e43pu
+      '@itwin/core-backend': 4.9.5_r6lwpu3senlcflmx65u2gwowne
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/core-electron': 4.9.5_xnnzauzbsosxbhso2acbfdnloq
+      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
+      '@itwin/core-geometry': 4.9.5
+      '@itwin/core-i18n': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/core-markup': 4.9.5_rsqcs3hzbyxjzpttbshdocpt74
+      '@itwin/core-orbitgt': 4.9.5
+      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/core-react': 4.17.2_b5szh4swag42x6ykxwn6buimra
+      '@itwin/core-telemetry': 4.9.5_@itwin+core-geometry@4.9.5
       '@itwin/desktop-viewer-react': link:../../modules/desktop-viewer-react
-      '@itwin/ecschema-metadata': 4.7.4_jokiwfzdpldlrb2ppvojwoxovq
-      '@itwin/ecschema-rpcinterface-common': 4.7.4_bcf6l4a62o6ayq645yaljtfq2i
-      '@itwin/ecschema-rpcinterface-impl': 4.7.4_5hmlesdtddppohhn2hwm7h44ha
-      '@itwin/electron-authorization': 0.15.0_4vf3fjdy4loqcqolj5aeocucyi
-      '@itwin/express-server': 4.7.4_7f6lob4dy5xhizoy2hu6gtyoy4
+      '@itwin/ecschema-metadata': 4.9.5_ht7pcu4cvk5h6sxcpkl7x76mje
+      '@itwin/ecschema-rpcinterface-common': 4.9.5_ubcdmbjl4iri5lyyvzc2dtfxiq
+      '@itwin/ecschema-rpcinterface-impl': 4.9.5_wkhnl5tbdp3ufasrx26orysshe
+      '@itwin/electron-authorization': 0.15.0_a56cjor36hmzwips5mhrqrpbva
+      '@itwin/express-server': 4.9.5_ghqkdihqtcgmxbakiynn72u3oi
       '@itwin/imodel-browser-react': 1.3.1_nnrd3gsncyragczmpvfhocinkq
-      '@itwin/imodel-components-react': 4.15.1_avm2jbcgpodgccdhk4zetypeem
-      '@itwin/imodels-access-backend': 5.2.1_4z423c7twni3c7p4vwjttw7w4q
-      '@itwin/imodels-access-frontend': 5.2.1_r7pomf6q3izykcd6xffknqbpim
+      '@itwin/imodel-components-react': 4.17.2_inn3jcow7lwqfeofdqhb3etkfi
+      '@itwin/imodels-access-backend': 5.2.3_3pcl427xpsrwbipdq34svx7mdu
+      '@itwin/imodels-access-frontend': 5.2.3_x7r3qyjan52efy6jnvzj72woaa
       '@itwin/itwinui-css': 1.12.10
-      '@itwin/itwinui-icons-react': 2.8.0_nnrd3gsncyragczmpvfhocinkq
+      '@itwin/itwinui-icons-react': 2.9.0_nnrd3gsncyragczmpvfhocinkq
       '@itwin/itwinui-illustrations-react': 2.1.0_nnrd3gsncyragczmpvfhocinkq
       '@itwin/itwinui-layouts-css': 0.2.0
       '@itwin/itwinui-layouts-react': 0.2.0_nnrd3gsncyragczmpvfhocinkq
       '@itwin/itwinui-react': 2.12.26_nnrd3gsncyragczmpvfhocinkq
       '@itwin/itwinui-variables': 2.1.2
-      '@itwin/measure-tools-react': 0.13.0_hhvtoxm2vupiyzv3tuuiwwirjq
-      '@itwin/presentation-backend': 4.7.4_nztxufmverfbgaq2tic42bdzqu
-      '@itwin/presentation-common': 4.7.4_jrcxtioaccikuahb3i3h6f5rhe
-      '@itwin/presentation-components': 5.4.1_coeiqitrdc3kbyoxwt3ak4fycm
-      '@itwin/presentation-frontend': 4.7.4_lbci6e5ivpkspr33wpe53pcp5i
-      '@itwin/property-grid-react': 1.10.0_qjr4doayn7cutuokumbiwhomja
-      '@itwin/tree-widget-react': 1.2.2_mwt5u2ylvl5wdlvny262vrwmma
-      '@itwin/unified-selection': 0.4.5
-      '@itwin/webgl-compatibility': 4.7.4
+      '@itwin/measure-tools-react': 0.13.0_i7qwmeovtjabsqcqehc6iw7vpa
+      '@itwin/presentation-backend': 4.9.5_6poatpavnnrtfvnacw25xntdke
+      '@itwin/presentation-common': 4.9.5_752sgixgtdkx2uobp37xqv5rci
+      '@itwin/presentation-components': 5.6.0_pgm6v4yzke2vvcj2rwx47ufaoy
+      '@itwin/presentation-frontend': 4.9.5_cfzxbnb6dite7ncbt3vw277mvu
+      '@itwin/property-grid-react': 1.13.0_ogdchnjgcc3nlmep57rhegv4nu
+      '@itwin/tree-widget-react': 1.2.2_wdle7gtptdoktkpvzniwyk6jjq
+      '@itwin/unified-selection': 0.4.6
+      '@itwin/webgl-compatibility': 4.9.5
       dotenv-flow: 3.3.0
       electron: 24.8.8
       minimist: 1.2.8
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
       react-redux: 7.2.9_nnrd3gsncyragczmpvfhocinkq
-      react-router: 6.24.1_react@18.3.1
-      react-router-dom: 6.24.1_nnrd3gsncyragczmpvfhocinkq
+      react-router: 6.27.0_react@18.3.1
+      react-router-dom: 6.27.0_nnrd3gsncyragczmpvfhocinkq
       redux: 4.2.1
     devDependencies:
       '@bentley/react-scripts': 5.0.7_pe74uhjrq4tiyv4442ml54dfiu
-      '@itwin/build-tools': 4.7.4_@types+node@18.19.39
+      '@itwin/build-tools': 4.9.5_@types+node@18.19.62
       '@types/electron-devtools-installer': 2.2.5
       '@types/minimist': 1.2.5
-      '@types/node': 18.19.39
-      '@types/react': 18.3.3
-      '@types/react-dom': 18.3.0
+      '@types/node': 18.19.62
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
       cpx2: 4.2.0
       cross-env: 5.2.1
       electron-devtools-installer: 2.2.4
       npm-run-all: 4.1.5
       rimraf: 3.0.2
-      sass: 1.77.7
+      sass: 1.80.5
       typescript: 5.0.4
-      webpack: 5.92.1
+      webpack: 5.95.0
 
   ../../packages/apps/web-viewer-test:
     specifiers:
@@ -201,51 +201,51 @@ importers:
       typescript: ~5.0.4
     dependencies:
       '@bentley/icons-generic': 1.0.34
-      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/appui-layout-react': 4.8.3_jscgs7su4cyo55wt5klvj3iepa
-      '@itwin/appui-react': 4.15.1_yrqai5hl5gvsf4dek6el5aloii
-      '@itwin/browser-authorization': 1.1.2_7i4fuy3zzvrtjsnyekcav72ie4
-      '@itwin/components-react': 4.15.1_jscgs7su4cyo55wt5klvj3iepa
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
-      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
-      '@itwin/core-geometry': 4.7.4
-      '@itwin/core-i18n': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/core-markup': 4.7.4_aa3bt7vk4zzsxcvhcdi4ojlcwe
-      '@itwin/core-orbitgt': 4.7.4
-      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/core-react': 4.15.1_bpptdsfauwdziiwg4uklizbr74
-      '@itwin/core-telemetry': 4.7.4_@itwin+core-geometry@4.7.4
-      '@itwin/ecschema-metadata': 4.7.4_jokiwfzdpldlrb2ppvojwoxovq
-      '@itwin/ecschema-rpcinterface-common': 4.7.4_bcf6l4a62o6ayq645yaljtfq2i
-      '@itwin/frontend-devtools': 4.7.4_7jxo73lwmrfxldbvkntwilqkhe
-      '@itwin/imodel-components-react': 4.15.1_avm2jbcgpodgccdhk4zetypeem
-      '@itwin/imodels-access-frontend': 5.2.1_r7pomf6q3izykcd6xffknqbpim
+      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/appui-layout-react': 4.8.3_zs6rif5h5jixp3mcoeld6e43pu
+      '@itwin/appui-react': 4.17.2_ggnmyqo32cg3w26befg4w43y64
+      '@itwin/browser-authorization': 1.1.3_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/components-react': 4.17.2_zs6rif5h5jixp3mcoeld6e43pu
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
+      '@itwin/core-geometry': 4.9.5
+      '@itwin/core-i18n': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/core-markup': 4.9.5_rsqcs3hzbyxjzpttbshdocpt74
+      '@itwin/core-orbitgt': 4.9.5
+      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/core-react': 4.17.2_b5szh4swag42x6ykxwn6buimra
+      '@itwin/core-telemetry': 4.9.5_@itwin+core-geometry@4.9.5
+      '@itwin/ecschema-metadata': 4.9.5_ht7pcu4cvk5h6sxcpkl7x76mje
+      '@itwin/ecschema-rpcinterface-common': 4.9.5_ubcdmbjl4iri5lyyvzc2dtfxiq
+      '@itwin/frontend-devtools': 4.9.5_orynrjj7mkimir6kjmara2i7dq
+      '@itwin/imodel-components-react': 4.17.2_inn3jcow7lwqfeofdqhb3etkfi
+      '@itwin/imodels-access-frontend': 5.2.3_x7r3qyjan52efy6jnvzj72woaa
       '@itwin/itwinui-react': 2.12.26_nnrd3gsncyragczmpvfhocinkq
-      '@itwin/measure-tools-react': 0.13.0_hhvtoxm2vupiyzv3tuuiwwirjq
-      '@itwin/presentation-common': 4.7.4_jrcxtioaccikuahb3i3h6f5rhe
-      '@itwin/presentation-components': 5.4.1_coeiqitrdc3kbyoxwt3ak4fycm
-      '@itwin/presentation-frontend': 4.7.4_lbci6e5ivpkspr33wpe53pcp5i
-      '@itwin/property-grid-react': 1.10.0_qjr4doayn7cutuokumbiwhomja
-      '@itwin/reality-data-client': 1.2.1_@itwin+core-bentley@4.7.4
+      '@itwin/measure-tools-react': 0.13.0_i7qwmeovtjabsqcqehc6iw7vpa
+      '@itwin/presentation-common': 4.9.5_752sgixgtdkx2uobp37xqv5rci
+      '@itwin/presentation-components': 5.6.0_pgm6v4yzke2vvcj2rwx47ufaoy
+      '@itwin/presentation-frontend': 4.9.5_cfzxbnb6dite7ncbt3vw277mvu
+      '@itwin/property-grid-react': 1.13.0_ogdchnjgcc3nlmep57rhegv4nu
+      '@itwin/reality-data-client': 1.2.1_@itwin+core-bentley@4.9.5
       '@itwin/test-local-extension': link:../../modules/test-local-extension
-      '@itwin/tree-widget-react': 1.2.2_mwt5u2ylvl5wdlvny262vrwmma
-      '@itwin/unified-selection': 0.4.5
+      '@itwin/tree-widget-react': 1.2.2_wdle7gtptdoktkpvzniwyk6jjq
+      '@itwin/unified-selection': 0.4.6
       '@itwin/web-viewer-react': link:../../modules/web-viewer-react
-      '@itwin/webgl-compatibility': 4.7.4
-      '@remix-run/router': 1.17.1
+      '@itwin/webgl-compatibility': 4.9.5
+      '@remix-run/router': 1.20.0
       history: 5.3.0
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
       react-redux: 7.2.9_nnrd3gsncyragczmpvfhocinkq
-      react-router: 6.24.1_react@18.3.1
-      react-router-dom: 6.24.1_nnrd3gsncyragczmpvfhocinkq
+      react-router: 6.27.0_react@18.3.1
+      react-router-dom: 6.27.0_nnrd3gsncyragczmpvfhocinkq
       redux: 4.2.1
     devDependencies:
       '@bentley/react-scripts': 5.0.7_pe74uhjrq4tiyv4442ml54dfiu
-      '@types/node': 18.19.39
-      '@types/react': 18.3.3
-      '@types/react-dom': 18.3.0
+      '@types/node': 18.19.62
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
       typescript: 5.0.4
 
   ../../packages/modules/desktop-viewer-react:
@@ -296,51 +296,51 @@ importers:
       ts-jest: ^29.1.0
       typescript: ~5.0.2
     dependencies:
-      '@itwin/imodels-client-management': 5.8.1
+      '@itwin/imodels-client-management': 5.9.0
       '@itwin/viewer-react': link:../viewer-react
     devDependencies:
-      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/appui-layout-react': 4.8.3_jscgs7su4cyo55wt5klvj3iepa
-      '@itwin/appui-react': 4.15.1_yrqai5hl5gvsf4dek6el5aloii
-      '@itwin/build-tools': 4.7.4_@types+node@18.19.39
-      '@itwin/components-react': 4.15.1_jscgs7su4cyo55wt5klvj3iepa
-      '@itwin/core-backend': 4.7.4_zzr6hivuljmnvzdhcyobjpaqme
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
-      '@itwin/core-electron': 4.7.4_hworozxoblmw2cyo32mpk5ebjm
-      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
-      '@itwin/core-geometry': 4.7.4
-      '@itwin/core-markup': 4.7.4_aa3bt7vk4zzsxcvhcdi4ojlcwe
-      '@itwin/core-orbitgt': 4.7.4
-      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/core-react': 4.15.1_bpptdsfauwdziiwg4uklizbr74
-      '@itwin/core-telemetry': 4.7.4_@itwin+core-geometry@4.7.4
-      '@itwin/ecschema-metadata': 4.7.4_jokiwfzdpldlrb2ppvojwoxovq
-      '@itwin/electron-authorization': 0.15.0_4vf3fjdy4loqcqolj5aeocucyi
-      '@itwin/imodel-components-react': 4.15.1_avm2jbcgpodgccdhk4zetypeem
-      '@itwin/presentation-common': 4.7.4_jrcxtioaccikuahb3i3h6f5rhe
-      '@itwin/presentation-components': 5.4.1_tr757zhbqqbt4rcaxvlnctg2de
-      '@itwin/presentation-frontend': 4.7.4_lbci6e5ivpkspr33wpe53pcp5i
-      '@itwin/webgl-compatibility': 4.7.4
+      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/appui-layout-react': 4.8.3_zs6rif5h5jixp3mcoeld6e43pu
+      '@itwin/appui-react': 4.17.2_ggnmyqo32cg3w26befg4w43y64
+      '@itwin/build-tools': 4.9.5_@types+node@18.19.62
+      '@itwin/components-react': 4.17.2_zs6rif5h5jixp3mcoeld6e43pu
+      '@itwin/core-backend': 4.9.5_r6lwpu3senlcflmx65u2gwowne
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/core-electron': 4.9.5_xnnzauzbsosxbhso2acbfdnloq
+      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
+      '@itwin/core-geometry': 4.9.5
+      '@itwin/core-markup': 4.9.5_rsqcs3hzbyxjzpttbshdocpt74
+      '@itwin/core-orbitgt': 4.9.5
+      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/core-react': 4.17.2_b5szh4swag42x6ykxwn6buimra
+      '@itwin/core-telemetry': 4.9.5_@itwin+core-geometry@4.9.5
+      '@itwin/ecschema-metadata': 4.9.5_ht7pcu4cvk5h6sxcpkl7x76mje
+      '@itwin/electron-authorization': 0.15.0_a56cjor36hmzwips5mhrqrpbva
+      '@itwin/imodel-components-react': 4.17.2_inn3jcow7lwqfeofdqhb3etkfi
+      '@itwin/presentation-common': 4.9.5_752sgixgtdkx2uobp37xqv5rci
+      '@itwin/presentation-components': 5.6.0_hb7vovirygu74f3smprdxccedu
+      '@itwin/presentation-frontend': 4.9.5_cfzxbnb6dite7ncbt3vw277mvu
+      '@itwin/webgl-compatibility': 4.9.5
       '@testing-library/jest-dom': 4.2.4
       '@testing-library/react': 14.3.1_nnrd3gsncyragczmpvfhocinkq
       '@testing-library/user-event': 7.2.1
       '@types/jest': 26.0.24
-      '@types/node': 18.19.39
-      '@types/react': 18.3.3
-      '@types/react-dom': 18.3.0
-      '@types/react-redux': 7.1.33
+      '@types/node': 18.19.62
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
+      '@types/react-redux': 7.1.34
       concurrently: 5.3.0
       copyfiles: 2.4.1
       electron: 24.8.8
       identity-obj-proxy: 3.0.0
-      jest: 29.7.0_@types+node@18.19.39
+      jest: 29.7.0_@types+node@18.19.62
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
       react-redux: 7.2.9_nnrd3gsncyragczmpvfhocinkq
       redux: 4.2.1
       rimraf: 3.0.2
-      ts-jest: 29.2.0_qbbgenyc4wnry6yt7igwhfhjbm
+      ts-jest: 29.2.5_qbbgenyc4wnry6yt7igwhfhjbm
       typescript: 5.0.4
 
   ../../packages/modules/test-local-extension:
@@ -362,22 +362,22 @@ importers:
       serve: ^14.2.0
       typescript: ~5.0.2
     dependencies:
-      '@itwin/core-extension': 4.7.4_ieegwyxugmwu7xrlokpbnlonea
+      '@itwin/core-extension': 4.9.5_kyionygyo673et7f54wxvz6g2i
     devDependencies:
       '@esbuild-plugins/node-globals-polyfill': 0.1.1_esbuild@0.13.15
       '@esbuild-plugins/node-modules-polyfill': 0.1.4_esbuild@0.13.15
-      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/build-tools': 4.7.4
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
-      '@itwin/core-geometry': 4.7.4
-      '@itwin/core-orbitgt': 4.7.4
-      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/webgl-compatibility': 4.7.4
+      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/build-tools': 4.9.5
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/core-geometry': 4.9.5
+      '@itwin/core-orbitgt': 4.9.5
+      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/webgl-compatibility': 4.9.5
       esbuild: 0.13.15
       npm-run-all: 4.1.5
       rimraf: 3.0.2
-      serve: 14.2.3
+      serve: 14.2.4
       typescript: 5.0.4
 
   ../../packages/modules/test-remote-extension:
@@ -399,22 +399,22 @@ importers:
       serve: ^14.2.0
       typescript: ~5.0.2
     dependencies:
-      '@itwin/core-extension': 4.7.4_ieegwyxugmwu7xrlokpbnlonea
+      '@itwin/core-extension': 4.9.5_kyionygyo673et7f54wxvz6g2i
     devDependencies:
       '@esbuild-plugins/node-globals-polyfill': 0.1.1_esbuild@0.13.15
       '@esbuild-plugins/node-modules-polyfill': 0.1.4_esbuild@0.13.15
-      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/build-tools': 4.7.4
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
-      '@itwin/core-geometry': 4.7.4
-      '@itwin/core-orbitgt': 4.7.4
-      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/webgl-compatibility': 4.7.4
+      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/build-tools': 4.9.5
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/core-geometry': 4.9.5
+      '@itwin/core-orbitgt': 4.9.5
+      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/webgl-compatibility': 4.9.5
       esbuild: 0.13.15
       npm-run-all: 4.1.5
       rimraf: 3.0.2
-      serve: 14.2.3
+      serve: 14.2.4
       typescript: 5.0.4
 
   ../../packages/modules/viewer-react:
@@ -475,55 +475,55 @@ importers:
       '@bentley/icons-generic-webfont': 1.0.34
       '@itwin/itwinui-illustrations-react': 2.1.0_nnrd3gsncyragczmpvfhocinkq
       '@itwin/itwinui-react': 2.12.26_nnrd3gsncyragczmpvfhocinkq
-      '@itwin/presentation-core-interop': 0.2.4_rll2n26bhzrezeyt23jhdcbtsy
+      '@itwin/presentation-core-interop': 0.2.7_tm7n22tj7qb4kxylpvuy237mmy
       '@itwin/presentation-shared': 0.3.2
-      '@itwin/reality-data-client': 1.2.1_@itwin+core-bentley@4.7.4
-      '@itwin/unified-selection': 0.4.5
+      '@itwin/reality-data-client': 1.2.1_@itwin+core-bentley@4.9.5
+      '@itwin/unified-selection': 0.4.6
       lodash.isequal: 4.5.0
     devDependencies:
-      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/appui-layout-react': 4.8.3_jscgs7su4cyo55wt5klvj3iepa
-      '@itwin/appui-react': 4.15.1_yrqai5hl5gvsf4dek6el5aloii
-      '@itwin/build-tools': 4.7.4_@types+node@18.19.39
-      '@itwin/components-react': 4.15.1_jscgs7su4cyo55wt5klvj3iepa
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
-      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
-      '@itwin/core-geometry': 4.7.4
-      '@itwin/core-i18n': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/core-markup': 4.7.4_aa3bt7vk4zzsxcvhcdi4ojlcwe
-      '@itwin/core-orbitgt': 4.7.4
-      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/core-react': 4.15.1_bpptdsfauwdziiwg4uklizbr74
-      '@itwin/core-telemetry': 4.7.4_@itwin+core-geometry@4.7.4
-      '@itwin/ecschema-metadata': 4.7.4_jokiwfzdpldlrb2ppvojwoxovq
-      '@itwin/imodel-components-react': 4.15.1_avm2jbcgpodgccdhk4zetypeem
-      '@itwin/imodels-access-frontend': 5.2.1_r7pomf6q3izykcd6xffknqbpim
-      '@itwin/imodels-client-management': 5.8.1
-      '@itwin/presentation-common': 4.7.4_jrcxtioaccikuahb3i3h6f5rhe
-      '@itwin/presentation-components': 5.4.1_coeiqitrdc3kbyoxwt3ak4fycm
-      '@itwin/presentation-frontend': 4.7.4_lbci6e5ivpkspr33wpe53pcp5i
-      '@itwin/webgl-compatibility': 4.7.4
+      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/appui-layout-react': 4.8.3_zs6rif5h5jixp3mcoeld6e43pu
+      '@itwin/appui-react': 4.17.2_ggnmyqo32cg3w26befg4w43y64
+      '@itwin/build-tools': 4.9.5_@types+node@18.19.62
+      '@itwin/components-react': 4.17.2_zs6rif5h5jixp3mcoeld6e43pu
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
+      '@itwin/core-geometry': 4.9.5
+      '@itwin/core-i18n': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/core-markup': 4.9.5_rsqcs3hzbyxjzpttbshdocpt74
+      '@itwin/core-orbitgt': 4.9.5
+      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/core-react': 4.17.2_b5szh4swag42x6ykxwn6buimra
+      '@itwin/core-telemetry': 4.9.5_@itwin+core-geometry@4.9.5
+      '@itwin/ecschema-metadata': 4.9.5_ht7pcu4cvk5h6sxcpkl7x76mje
+      '@itwin/imodel-components-react': 4.17.2_inn3jcow7lwqfeofdqhb3etkfi
+      '@itwin/imodels-access-frontend': 5.2.3_x7r3qyjan52efy6jnvzj72woaa
+      '@itwin/imodels-client-management': 5.9.0
+      '@itwin/presentation-common': 4.9.5_752sgixgtdkx2uobp37xqv5rci
+      '@itwin/presentation-components': 5.6.0_pgm6v4yzke2vvcj2rwx47ufaoy
+      '@itwin/presentation-frontend': 4.9.5_cfzxbnb6dite7ncbt3vw277mvu
+      '@itwin/webgl-compatibility': 4.9.5
       '@testing-library/jest-dom': 4.2.4
       '@testing-library/react': 14.3.1_nnrd3gsncyragczmpvfhocinkq
       '@testing-library/user-event': 7.2.1
       '@types/jest': 26.0.24
       '@types/lodash.isequal': 4.5.8
-      '@types/node': 18.19.39
-      '@types/react': 18.3.3
-      '@types/react-dom': 18.3.0
-      '@types/react-redux': 7.1.33
+      '@types/node': 18.19.62
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
+      '@types/react-redux': 7.1.34
       concurrently: 5.3.0
       copyfiles: 2.4.1
       identity-obj-proxy: 3.0.0
-      jest: 29.7.0_@types+node@18.19.39
+      jest: 29.7.0_@types+node@18.19.62
       jest-environment-jsdom: 29.7.0
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
       react-redux: 7.2.9_nnrd3gsncyragczmpvfhocinkq
       redux: 4.2.1
       rimraf: 3.0.2
-      ts-jest: 29.2.0_qbbgenyc4wnry6yt7igwhfhjbm
+      ts-jest: 29.2.5_qbbgenyc4wnry6yt7igwhfhjbm
       typescript: 5.0.4
 
   ../../packages/modules/web-viewer-react:
@@ -571,48 +571,48 @@ importers:
       ts-jest: ^29.1.0
       typescript: ~5.0.2
     dependencies:
-      '@itwin/imodels-client-management': 5.8.1
+      '@itwin/imodels-client-management': 5.9.0
       '@itwin/viewer-react': link:../viewer-react
     devDependencies:
-      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/appui-layout-react': 4.8.3_jscgs7su4cyo55wt5klvj3iepa
-      '@itwin/appui-react': 4.15.1_yrqai5hl5gvsf4dek6el5aloii
-      '@itwin/build-tools': 4.7.4_@types+node@18.19.39
-      '@itwin/components-react': 4.15.1_jscgs7su4cyo55wt5klvj3iepa
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
-      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
-      '@itwin/core-geometry': 4.7.4
-      '@itwin/core-markup': 4.7.4_aa3bt7vk4zzsxcvhcdi4ojlcwe
-      '@itwin/core-orbitgt': 4.7.4
-      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/core-react': 4.15.1_bpptdsfauwdziiwg4uklizbr74
-      '@itwin/core-telemetry': 4.7.4_@itwin+core-geometry@4.7.4
-      '@itwin/ecschema-metadata': 4.7.4_jokiwfzdpldlrb2ppvojwoxovq
-      '@itwin/imodel-components-react': 4.15.1_avm2jbcgpodgccdhk4zetypeem
-      '@itwin/presentation-common': 4.7.4_jrcxtioaccikuahb3i3h6f5rhe
-      '@itwin/presentation-components': 5.4.1_tr757zhbqqbt4rcaxvlnctg2de
-      '@itwin/presentation-frontend': 4.7.4_lbci6e5ivpkspr33wpe53pcp5i
-      '@itwin/webgl-compatibility': 4.7.4
+      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/appui-layout-react': 4.8.3_zs6rif5h5jixp3mcoeld6e43pu
+      '@itwin/appui-react': 4.17.2_ggnmyqo32cg3w26befg4w43y64
+      '@itwin/build-tools': 4.9.5_@types+node@18.19.62
+      '@itwin/components-react': 4.17.2_zs6rif5h5jixp3mcoeld6e43pu
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
+      '@itwin/core-geometry': 4.9.5
+      '@itwin/core-markup': 4.9.5_rsqcs3hzbyxjzpttbshdocpt74
+      '@itwin/core-orbitgt': 4.9.5
+      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/core-react': 4.17.2_b5szh4swag42x6ykxwn6buimra
+      '@itwin/core-telemetry': 4.9.5_@itwin+core-geometry@4.9.5
+      '@itwin/ecschema-metadata': 4.9.5_ht7pcu4cvk5h6sxcpkl7x76mje
+      '@itwin/imodel-components-react': 4.17.2_inn3jcow7lwqfeofdqhb3etkfi
+      '@itwin/presentation-common': 4.9.5_752sgixgtdkx2uobp37xqv5rci
+      '@itwin/presentation-components': 5.6.0_hb7vovirygu74f3smprdxccedu
+      '@itwin/presentation-frontend': 4.9.5_cfzxbnb6dite7ncbt3vw277mvu
+      '@itwin/webgl-compatibility': 4.9.5
       '@testing-library/jest-dom': 4.2.4
       '@testing-library/react': 14.3.1_nnrd3gsncyragczmpvfhocinkq
       '@testing-library/user-event': 7.2.1
       '@types/jest': 26.0.24
-      '@types/node': 18.19.39
-      '@types/react': 18.3.3
-      '@types/react-dom': 18.3.0
-      '@types/react-redux': 7.1.33
+      '@types/node': 18.19.62
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
+      '@types/react-redux': 7.1.34
       concurrently: 5.3.0
       copyfiles: 2.4.1
       identity-obj-proxy: 3.0.0
-      jest: 29.7.0_@types+node@18.19.39
+      jest: 29.7.0_@types+node@18.19.62
       jest-environment-jsdom: 29.7.0
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
       react-redux: 7.2.9_nnrd3gsncyragczmpvfhocinkq
       redux: 4.2.1
       rimraf: 3.0.2
-      ts-jest: 29.2.0_qbbgenyc4wnry6yt7igwhfhjbm
+      ts-jest: 29.2.5_qbbgenyc4wnry6yt7igwhfhjbm
       typescript: 5.0.4
 
   ../../packages/templates/cra-template-desktop-viewer:
@@ -649,16 +649,16 @@ importers:
       '@typescript-eslint/eslint-plugin': 4.33.0_ffi3uiz42rv3jyhs6cr7p7qqry
       '@typescript-eslint/parser': 4.33.0_eslint@7.32.0
       eslint: 7.32.0
-      eslint-config-airbnb: 18.2.1_cb6pno7fzmlsn2yskxvbihgdme
+      eslint-config-airbnb: 18.2.1_j47woh5gdjkhehtho5cd7z7hme
       eslint-config-prettier: 6.15.0_eslint@7.32.0
-      eslint-config-react-app: 6.0.0_ssuykkwe44xqfk7ygtu5dsspum
+      eslint-config-react-app: 6.0.0_vblgvs7dq6s2rjad5szwfif2ae
       eslint-plugin-deprecation: 1.2.1_eslint@7.32.0
       eslint-plugin-flowtype: 5.10.0_eslint@7.32.0
-      eslint-plugin-import: 2.29.1_eslint@7.32.0
-      eslint-plugin-jsx-a11y: 6.9.0_eslint@7.32.0
+      eslint-plugin-import: 2.31.0_eslint@7.32.0
+      eslint-plugin-jsx-a11y: 6.10.2_eslint@7.32.0
       eslint-plugin-prefer-arrow: 1.2.3_eslint@7.32.0
       eslint-plugin-prettier: 3.4.1_6l26irxuevddeh5uhyzqivbl64
-      eslint-plugin-react: 7.34.3_eslint@7.32.0
+      eslint-plugin-react: 7.37.2_eslint@7.32.0
       eslint-plugin-react-hooks: 4.6.2_eslint@7.32.0
       eslint-plugin-simple-import-sort: 5.0.3_eslint@7.32.0
       lint-staged: 10.5.4
@@ -689,13 +689,13 @@ packages:
       '@jridgewell/trace-mapping': 0.3.25
     dev: true
 
-  /@apideck/better-ajv-errors/0.3.6_ajv@8.16.0:
+  /@apideck/better-ajv-errors/0.3.6_ajv@8.17.1:
     resolution: {integrity: sha512-P+ZygBLZtkp0qqOAJJVX4oX/sFo5JR3eBWwwuqHHhK0GIgQOKWrAfiAaWX0aArHkRWHMuggFEgAZNxVPwPZYaA==}
     engines: {node: '>=10'}
     peerDependencies:
       ajv: '>=8'
     dependencies:
-      ajv: 8.16.0
+      ajv: 8.17.1
       json-schema: 0.4.0
       jsonpointer: 5.0.1
       leven: 3.1.0
@@ -705,33 +705,34 @@ packages:
     resolution: {integrity: sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.0
+    dev: false
 
   /@azure/abort-controller/2.1.2:
     resolution: {integrity: sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.0
 
-  /@azure/core-auth/1.7.2:
-    resolution: {integrity: sha512-Igm/S3fDYmnMq1uKS38Ae1/m37B3zigdlZw+kocwEhh5GjyKjPrXKO2J6rzpC1wAxrNil/jX9BJRqBshyjnF3g==}
+  /@azure/core-auth/1.9.0:
+    resolution: {integrity: sha512-FPwHpZywuyasDSLMqJ6fhbOK3TqUdviZNF8OqRGA4W5Ewib2lEEZ+pBsYcBa88B2NGO/SEnYPGhyBqNlE8ilSw==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-util': 1.9.0
-      tslib: 2.6.3
+      '@azure/core-util': 1.11.0
+      tslib: 2.8.0
 
   /@azure/core-client/1.9.2:
     resolution: {integrity: sha512-kRdry/rav3fUKHl/aDLd/pDLcB+4pOFwPPTVEExuMyaI5r+JBbMWqRbCY1pn5BniDaU3lRxO9eaQ1AmSMehl/w==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.7.2
-      '@azure/core-rest-pipeline': 1.16.1
-      '@azure/core-tracing': 1.1.2
-      '@azure/core-util': 1.9.0
-      '@azure/logger': 1.1.2
-      tslib: 2.6.3
+      '@azure/core-auth': 1.9.0
+      '@azure/core-rest-pipeline': 1.17.0
+      '@azure/core-tracing': 1.2.0
+      '@azure/core-util': 1.11.0
+      '@azure/logger': 1.1.4
+      tslib: 2.8.0
     transitivePeerDependencies:
       - supports-color
 
@@ -741,7 +742,7 @@ packages:
     dependencies:
       '@azure/abort-controller': 2.1.2
       '@azure/core-client': 1.9.2
-      '@azure/core-rest-pipeline': 1.16.1
+      '@azure/core-rest-pipeline': 1.17.0
     transitivePeerDependencies:
       - supports-color
 
@@ -750,111 +751,113 @@ packages:
     engines: {node: '>=18.0.0'}
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-util': 1.9.0
-      '@azure/logger': 1.1.2
-      tslib: 2.6.3
+      '@azure/core-util': 1.11.0
+      '@azure/logger': 1.1.4
+      tslib: 2.8.0
 
   /@azure/core-paging/1.6.2:
     resolution: {integrity: sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.0
 
-  /@azure/core-rest-pipeline/1.16.1:
-    resolution: {integrity: sha512-ExPSbgjwCoht6kB7B4MeZoBAxcQSIl29r/bPeazZJx50ej4JJCByimLOrZoIsurISNyJQQHf30b3JfqC3Hb88A==}
+  /@azure/core-rest-pipeline/1.17.0:
+    resolution: {integrity: sha512-62Vv8nC+uPId3j86XJ0WI+sBf0jlqTqPUFCBNrGtlaUeQUIXWV/D8GE5A1d+Qx8H7OQojn2WguC8kChD6v0shA==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.7.2
-      '@azure/core-tracing': 1.1.2
-      '@azure/core-util': 1.9.0
-      '@azure/logger': 1.1.2
+      '@azure/core-auth': 1.9.0
+      '@azure/core-tracing': 1.2.0
+      '@azure/core-util': 1.11.0
+      '@azure/logger': 1.1.4
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.5
-      tslib: 2.6.3
+      tslib: 2.8.0
     transitivePeerDependencies:
       - supports-color
 
-  /@azure/core-tracing/1.1.2:
-    resolution: {integrity: sha512-dawW9ifvWAWmUm9/h+/UQ2jrdvjCJ7VJEuCJ6XVNudzcOwm53BFZH4Q845vjfgoUAM8ZxokvVNxNxAITc502YA==}
+  /@azure/core-tracing/1.2.0:
+    resolution: {integrity: sha512-UKTiEJPkWcESPYJz3X5uKRYyOcJD+4nYph+KpfdPRnQJVrZfk0KJgdnaAWKfhsBBtAf/D58Az4AvCJEmWgIBAg==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.0
 
-  /@azure/core-util/1.9.0:
-    resolution: {integrity: sha512-AfalUQ1ZppaKuxPPMsFEUdX6GZPB3d9paR9d/TTL7Ow2De8cJaC7ibi7kWVlFAVPCYo31OcnGymc0R89DX8Oaw==}
+  /@azure/core-util/1.11.0:
+    resolution: {integrity: sha512-DxOSLua+NdpWoSqULhjDyAZTXFdP/LKkqtYuxxz1SCN289zk3OG8UOpnCQAz/tygyACBtWp/BoO72ptK7msY8g==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@azure/abort-controller': 2.1.2
-      tslib: 2.6.3
+      tslib: 2.8.0
 
-  /@azure/core-xml/1.4.2:
-    resolution: {integrity: sha512-CW3MZhApe/S4iikbYKE7s83fjDBPIr2kpidX+hlGRwh7N4o1nIpQ/PfJTeioqhfqdMvRtheEl+ft64fyTaLNaA==}
+  /@azure/core-xml/1.4.4:
+    resolution: {integrity: sha512-J4FYAqakGXcbfeZjwjMzjNcpcH4E+JtEBv+xcV1yL0Ydn/6wbQfeFKTCHh9wttAi0lmajHw7yBbHPRG+YHckZQ==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      fast-xml-parser: 4.4.1
-      tslib: 2.6.3
+      fast-xml-parser: 4.5.0
+      tslib: 2.8.0
 
-  /@azure/logger/1.1.2:
-    resolution: {integrity: sha512-l170uE7bsKpIU6B/giRc9i4NI0Mj+tANMMMxf7Zi/5cKzEqPayP7+X1WPrG7e+91JgY8N+7K7nF2WOi7iVhXvg==}
+  /@azure/logger/1.1.4:
+    resolution: {integrity: sha512-4IXXzcCdLdlXuCG+8UKEwLA1T1NHqUfanhXYHiQTn+6sfWCZXduqbtXDGceg3Ce5QxTGo7EqmbV6Bi+aqKuClQ==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.0
 
-  /@azure/storage-blob/12.23.0:
-    resolution: {integrity: sha512-c1KJ5R5hqR/HtvmFtTn/Y1BNMq45NUBp0LZH7yF8WFMET+wmESgEr0FVTu/Z5NonmfUjbgJZG5Nh8xHc5RdWGQ==}
+  /@azure/storage-blob/12.25.0:
+    resolution: {integrity: sha512-oodouhA3nCCIh843tMMbxty3WqfNT+Vgzj3Xo5jqR9UPnzq3d7mzLjlHAYz7lW+b4km3SIgz+NAgztvhm7Z6kQ==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@azure/abort-controller': 1.1.0
-      '@azure/core-auth': 1.7.2
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.9.0
       '@azure/core-client': 1.9.2
       '@azure/core-http-compat': 2.1.2
       '@azure/core-lro': 2.7.2
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.16.1
-      '@azure/core-tracing': 1.1.2
-      '@azure/core-util': 1.9.0
-      '@azure/core-xml': 1.4.2
-      '@azure/logger': 1.1.2
+      '@azure/core-rest-pipeline': 1.17.0
+      '@azure/core-tracing': 1.2.0
+      '@azure/core-util': 1.11.0
+      '@azure/core-xml': 1.4.4
+      '@azure/logger': 1.1.4
       events: 3.3.0
-      tslib: 2.6.3
+      tslib: 2.8.0
     transitivePeerDependencies:
       - supports-color
 
   /@babel/code-frame/7.12.11:
     resolution: {integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==}
     dependencies:
-      '@babel/highlight': 7.24.7
+      '@babel/highlight': 7.25.9
     dev: true
 
-  /@babel/code-frame/7.24.7:
-    resolution: {integrity: sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==}
+  /@babel/code-frame/7.26.2:
+    resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/highlight': 7.24.7
-      picocolors: 1.0.1
+      '@babel/helper-validator-identifier': 7.25.9
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+    dev: true
 
-  /@babel/compat-data/7.24.7:
-    resolution: {integrity: sha512-qJzAIcv03PyaWqxRgO4mSU3lihncDT296vnyuE2O8uA4w3UHWI4S3hgeZd1L8W1Bft40w9JxJ2b412iDUFFRhw==}
+  /@babel/compat-data/7.26.2:
+    resolution: {integrity: sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg==}
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/core/7.24.7:
-    resolution: {integrity: sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==}
+  /@babel/core/7.26.0:
+    resolution: {integrity: sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@babel/code-frame': 7.24.7
-      '@babel/generator': 7.24.7
-      '@babel/helper-compilation-targets': 7.24.7
-      '@babel/helper-module-transforms': 7.24.7_@babel+core@7.24.7
-      '@babel/helpers': 7.24.7
-      '@babel/parser': 7.24.7
-      '@babel/template': 7.24.7
-      '@babel/traverse': 7.24.7
-      '@babel/types': 7.24.7
+      '@babel/code-frame': 7.26.2
+      '@babel/generator': 7.26.2
+      '@babel/helper-compilation-targets': 7.25.9
+      '@babel/helper-module-transforms': 7.26.0_@babel+core@7.26.0
+      '@babel/helpers': 7.26.0
+      '@babel/parser': 7.26.2
+      '@babel/template': 7.25.9
+      '@babel/traverse': 7.25.9
+      '@babel/types': 7.26.0
       convert-source-map: 2.0.0
-      debug: 4.3.5
+      debug: 4.3.7
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -862,1468 +865,1437 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/eslint-parser/7.24.7_ivopgdbs46443pcald3k67gmwm:
-    resolution: {integrity: sha512-SO5E3bVxDuxyNxM5agFv480YA2HO6ohZbGxbazZdIk3KQOPOGVNw6q78I9/lbviIf95eq6tPozeYnJLbjnC8IA==}
+  /@babel/eslint-parser/7.25.9_ug2igzfsn2htp6pvbk547j4y6y:
+    resolution: {integrity: sha512-5UXfgpK0j0Xr/xIdgdLEhOFxaDZ0bRPWJJchRpqOSur/3rZoPbqqki5mm0p4NE2cs28krBEiSM2MB7//afRSQQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
     peerDependencies:
       '@babel/core': ^7.11.0
       eslint: ^7.5.0 || ^8.0.0 || ^9.0.0
     dependencies:
-      '@babel/core': 7.24.7
+      '@babel/core': 7.26.0
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 8.57.0
+      eslint: 8.57.1
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
     dev: true
 
-  /@babel/generator/7.24.7:
-    resolution: {integrity: sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==}
+  /@babel/generator/7.26.2:
+    resolution: {integrity: sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.24.7
+      '@babel/parser': 7.26.2
+      '@babel/types': 7.26.0
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
-      jsesc: 2.5.2
-
-  /@babel/helper-annotate-as-pure/7.24.7:
-    resolution: {integrity: sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.24.7
+      jsesc: 3.0.2
     dev: true
 
-  /@babel/helper-builder-binary-assignment-operator-visitor/7.24.7:
-    resolution: {integrity: sha512-xZeCVVdwb4MsDBkkyZ64tReWYrLRHlMN72vP7Bdm3OUOuyFZExhsHUUnuWnm2/XOlAJzR0LfPpB56WXZn0X/lA==}
+  /@babel/helper-annotate-as-pure/7.25.9:
+    resolution: {integrity: sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/traverse': 7.24.7
-      '@babel/types': 7.24.7
+      '@babel/types': 7.26.0
+    dev: true
+
+  /@babel/helper-builder-binary-assignment-operator-visitor/7.25.9:
+    resolution: {integrity: sha512-C47lC7LIDCnz0h4vai/tpNOI95tCd5ZT3iBt/DBH5lXKHZsyNQv18yf1wIIg2ntiQNgmAvA+DgZ82iW8Qdym8g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/traverse': 7.25.9
+      '@babel/types': 7.26.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/helper-compilation-targets/7.24.7:
-    resolution: {integrity: sha512-ctSdRHBi20qWOfy27RUb4Fhp07KSJ3sXcuSvTrXrc4aG8NSYDo1ici3Vhg9bg69y5bj0Mr1lh0aeEgTvc12rMg==}
+  /@babel/helper-compilation-targets/7.25.9:
+    resolution: {integrity: sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/compat-data': 7.24.7
-      '@babel/helper-validator-option': 7.24.7
-      browserslist: 4.23.2
+      '@babel/compat-data': 7.26.2
+      '@babel/helper-validator-option': 7.25.9
+      browserslist: 4.24.2
       lru-cache: 5.1.1
       semver: 6.3.1
     dev: true
 
-  /@babel/helper-create-class-features-plugin/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-kTkaDl7c9vO80zeX1rJxnuRpEsD5tA81yh11X1gQo+PhSti3JS+7qeZo9U4RHobKRiFPKaGK3svUAeb8D0Q7eg==}
+  /@babel/helper-create-class-features-plugin/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-annotate-as-pure': 7.24.7
-      '@babel/helper-environment-visitor': 7.24.7
-      '@babel/helper-function-name': 7.24.7
-      '@babel/helper-member-expression-to-functions': 7.24.7
-      '@babel/helper-optimise-call-expression': 7.24.7
-      '@babel/helper-replace-supers': 7.24.7_@babel+core@7.24.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
-      '@babel/helper-split-export-declaration': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-member-expression-to-functions': 7.25.9
+      '@babel/helper-optimise-call-expression': 7.25.9
+      '@babel/helper-replace-supers': 7.25.9_@babel+core@7.26.0
+      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
+      '@babel/traverse': 7.25.9
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/helper-create-regexp-features-plugin/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-03TCmXy2FtXJEZfbXDTSqq1fRJArk7lX9DOFC/47VthYcxyIOx+eXQmdo6DOQvrbpIix+KfXwvuXdFDZHxt+rA==}
+  /@babel/helper-create-regexp-features-plugin/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-ORPNZ3h6ZRkOyAa/SaHU+XsLZr0UQzRwuDQ0cczIA17nAzZ+85G5cVkOJIj7QavLZGSe8QXUmNFxSZzjcZF9bw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-annotate-as-pure': 7.24.7
-      regexpu-core: 5.3.2
+      '@babel/core': 7.26.0
+      '@babel/helper-annotate-as-pure': 7.25.9
+      regexpu-core: 6.1.1
       semver: 6.3.1
     dev: true
 
-  /@babel/helper-define-polyfill-provider/0.6.2_@babel+core@7.24.7:
+  /@babel/helper-define-polyfill-provider/0.6.2_@babel+core@7.26.0:
     resolution: {integrity: sha512-LV76g+C502biUK6AyZ3LK10vDpDyCzZnhZFXkH1L75zHPj68+qc8Zfpx2th+gzwA2MzyK+1g/3EPl62yFnVttQ==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-compilation-targets': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      debug: 4.3.5
+      '@babel/core': 7.26.0
+      '@babel/helper-compilation-targets': 7.25.9
+      '@babel/helper-plugin-utils': 7.25.9
+      debug: 4.3.7
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/helper-environment-visitor/7.24.7:
-    resolution: {integrity: sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==}
+  /@babel/helper-member-expression-to-functions/7.25.9:
+    resolution: {integrity: sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.24.7
-
-  /@babel/helper-function-name/7.24.7:
-    resolution: {integrity: sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/template': 7.24.7
-      '@babel/types': 7.24.7
-
-  /@babel/helper-hoist-variables/7.24.7:
-    resolution: {integrity: sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.24.7
-
-  /@babel/helper-member-expression-to-functions/7.24.7:
-    resolution: {integrity: sha512-LGeMaf5JN4hAT471eJdBs/GK1DoYIJ5GCtZN/EsL6KUiiDZOvO/eKE11AMZJa2zP4zk4qe9V2O/hxAmkRc8p6w==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/traverse': 7.24.7
-      '@babel/types': 7.24.7
+      '@babel/traverse': 7.25.9
+      '@babel/types': 7.26.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/helper-module-imports/7.24.7:
-    resolution: {integrity: sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==}
+  /@babel/helper-module-imports/7.25.9:
+    resolution: {integrity: sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/traverse': 7.24.7
-      '@babel/types': 7.24.7
+      '@babel/traverse': 7.25.9
+      '@babel/types': 7.26.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
-  /@babel/helper-module-transforms/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-1fuJEwIrp+97rM4RWdO+qrRsZlAeL1lQJoPqtCYWv0NL115XM93hIH4CSRln2w52SqvmY5hqdtauB6QFCDiZNQ==}
+  /@babel/helper-module-transforms/7.26.0_@babel+core@7.26.0:
+    resolution: {integrity: sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-environment-visitor': 7.24.7
-      '@babel/helper-module-imports': 7.24.7
-      '@babel/helper-simple-access': 7.24.7
-      '@babel/helper-split-export-declaration': 7.24.7
-      '@babel/helper-validator-identifier': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/traverse': 7.25.9
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/helper-optimise-call-expression/7.24.7:
-    resolution: {integrity: sha512-jKiTsW2xmWwxT1ixIdfXUZp+P5yURx2suzLZr5Hi64rURpDYdMW0pv+Uf17EYk2Rd428Lx4tLsnjGJzYKDM/6A==}
+  /@babel/helper-optimise-call-expression/7.25.9:
+    resolution: {integrity: sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.24.7
+      '@babel/types': 7.26.0
     dev: true
 
-  /@babel/helper-plugin-utils/7.24.7:
-    resolution: {integrity: sha512-Rq76wjt7yz9AAc1KnlRKNAi/dMSVWgDRx43FHoJEbcYU6xOWaE2dVPwcdTukJrjxS65GITyfbvEYHvkirZ6uEg==}
+  /@babel/helper-plugin-utils/7.25.9:
+    resolution: {integrity: sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==}
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/helper-remap-async-to-generator/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-9pKLcTlZ92hNZMQfGCHImUpDOlAgkkpqalWEeftW5FBya75k8Li2ilerxkM/uBEj01iBZXcCIB/bwvDYgWyibA==}
+  /@babel/helper-remap-async-to-generator/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-IZtukuUeBbhgOcaW2s06OXTzVNJR0ybm4W5xC1opWFFJMZbwRj5LCk+ByYH7WdZPZTt8KnFwA8pvjN2yqcPlgw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-annotate-as-pure': 7.24.7
-      '@babel/helper-environment-visitor': 7.24.7
-      '@babel/helper-wrap-function': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-wrap-function': 7.25.9
+      '@babel/traverse': 7.25.9
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/helper-replace-supers/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-qTAxxBM81VEyoAY0TtLrx1oAEJc09ZK67Q9ljQToqCnA+55eNwCORaxlKyu+rNfX86o8OXRUSNUnrtsAZXM9sg==}
+  /@babel/helper-replace-supers/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-IiDqTOTBQy0sWyeXyGSC5TBJpGFXBkRynjBeXsvbhQFKj2viwJC76Epz35YLU1fpe/Am6Vppb7W7zM4fPQzLsQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-environment-visitor': 7.24.7
-      '@babel/helper-member-expression-to-functions': 7.24.7
-      '@babel/helper-optimise-call-expression': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-member-expression-to-functions': 7.25.9
+      '@babel/helper-optimise-call-expression': 7.25.9
+      '@babel/traverse': 7.25.9
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/helper-simple-access/7.24.7:
-    resolution: {integrity: sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==}
+  /@babel/helper-simple-access/7.25.9:
+    resolution: {integrity: sha512-c6WHXuiaRsJTyHYLJV75t9IqsmTbItYfdj99PnzYGQZkYKvan5/2jKJ7gu31J3/BJ/A18grImSPModuyG/Eo0Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/traverse': 7.24.7
-      '@babel/types': 7.24.7
+      '@babel/traverse': 7.25.9
+      '@babel/types': 7.26.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/helper-skip-transparent-expression-wrappers/7.24.7:
-    resolution: {integrity: sha512-IO+DLT3LQUElMbpzlatRASEyQtfhSE0+m465v++3jyyXeBTBUjtVZg28/gHeV5mrTJqvEKhKroBGAvhW+qPHiQ==}
+  /@babel/helper-skip-transparent-expression-wrappers/7.25.9:
+    resolution: {integrity: sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/traverse': 7.24.7
-      '@babel/types': 7.24.7
+      '@babel/traverse': 7.25.9
+      '@babel/types': 7.26.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/helper-split-export-declaration/7.24.7:
-    resolution: {integrity: sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.24.7
-
-  /@babel/helper-string-parser/7.24.7:
-    resolution: {integrity: sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==}
-    engines: {node: '>=6.9.0'}
-
-  /@babel/helper-validator-identifier/7.24.7:
-    resolution: {integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==}
-    engines: {node: '>=6.9.0'}
-
-  /@babel/helper-validator-option/7.24.7:
-    resolution: {integrity: sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw==}
+  /@babel/helper-string-parser/7.25.9:
+    resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/helper-wrap-function/7.24.7:
-    resolution: {integrity: sha512-N9JIYk3TD+1vq/wn77YnJOqMtfWhNewNE+DJV4puD2X7Ew9J4JvrzrFDfTfyv5EgEXVy9/Wt8QiOErzEmv5Ifw==}
+  /@babel/helper-validator-identifier/7.25.9:
+    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-validator-option/7.25.9:
+    resolution: {integrity: sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-wrap-function/7.25.9:
+    resolution: {integrity: sha512-ETzz9UTjQSTmw39GboatdymDq4XIQbR8ySgVrylRhPOFpsd+JrKHIuF0de7GCWmem+T4uC5z7EZguod7Wj4A4g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-function-name': 7.24.7
-      '@babel/template': 7.24.7
-      '@babel/traverse': 7.24.7
-      '@babel/types': 7.24.7
+      '@babel/template': 7.25.9
+      '@babel/traverse': 7.25.9
+      '@babel/types': 7.26.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/helpers/7.24.7:
-    resolution: {integrity: sha512-NlmJJtvcw72yRJRcnCmGvSi+3jDEg8qFu3z0AFoymmzLx5ERVWyzd9kVXr7Th9/8yIJi2Zc6av4Tqz3wFs8QWg==}
+  /@babel/helpers/7.26.0:
+    resolution: {integrity: sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.24.7
-      '@babel/types': 7.24.7
+      '@babel/template': 7.25.9
+      '@babel/types': 7.26.0
     dev: true
 
-  /@babel/highlight/7.24.7:
-    resolution: {integrity: sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==}
+  /@babel/highlight/7.25.9:
+    resolution: {integrity: sha512-llL88JShoCsth8fF8R4SJnIn+WLvR6ccFxu1H3FlMhDontdcmZWf2HgIZ7AIqV3Xcck1idlohrN4EUBQz6klbw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-validator-identifier': 7.24.7
+      '@babel/helper-validator-identifier': 7.25.9
       chalk: 2.4.2
       js-tokens: 4.0.0
-      picocolors: 1.0.1
+      picocolors: 1.1.1
+    dev: true
 
-  /@babel/parser/7.24.7:
-    resolution: {integrity: sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==}
+  /@babel/parser/7.26.2:
+    resolution: {integrity: sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+    dependencies:
+      '@babel/types': 7.26.0
+    dev: true
 
-  /@babel/plugin-bugfix-firefox-class-in-computed-class-key/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-TiT1ss81W80eQsN+722OaeQMY/G4yTb4G9JrqeiDADs3N8lbPMGldWi9x8tyqCW5NLx1Jh2AvkE6r6QvEltMMQ==}
+  /@babel/plugin-bugfix-firefox-class-in-computed-class-key/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-ZkRyVkThtxQ/J6nv3JFYv1RYY+JT5BvU0y3k5bWrmuG4woXypRa4PXmm9RhOwodRkYFWqC0C0cqcJ4OqR7kW+g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-environment-visitor': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/traverse': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-unaQgZ/iRu/By6tsjMZzpeBZjChYfLYry6HrEXPoz3KmfF0sVBQ1l8zKMQ4xRGLWVsjuvB8nQfjNP/DcfEOCsg==}
+  /@babel/plugin-bugfix-safari-class-field-initializer-scope/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-MrGRLZxLD/Zjj0gdU15dfs+HH/OXvnw/U4jJD8vpcP2CJQapPEv1IWwjc/qMg7ItBlPwSv1hRBbb7LeuANdcnw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-+izXIbke1T33mY4MSNnrqhPXDz01WYhEf3yF5NbnUtkiNnm+XBZJl3kNfoK6NKmYlz/D07+l2GWVK/QfDkNCuQ==}
+  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-2qUwwfAFpJLZqxd02YW9btUCZHl+RFvdDkNfZwaIJrvB8Tesjsk8pEQkTvGwZXLqXUx/2oyY3ySRhm6HOXuCug==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+    dev: true
+
+  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-6xWgLZTJXwilVjlnV7ospI3xi+sl8lN8rXXbBD6vYn3UYDlGsag8wrZkKcSI8G6KgqKP7vNFaDgeDnfAABq61g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.13.0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
-      '@babel/plugin-transform-optional-chaining': 7.24.7_@babel+core@7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
+      '@babel/plugin-transform-optional-chaining': 7.25.9_@babel+core@7.26.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-utA4HuR6F4Vvcr+o4DnjL8fCOlgRFGbeeBEGNg3ZTrLFw6VWG5XmUrvcQ0FjIYMU2ST4XcR2Wsp7t9qOAPnxMg==}
+  /@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-aLnMXYPnzwwqhYSCyXfKkIkYgJ8zv9RK+roo9DkTXz38ynIhd9XCbN08s3MGvqL2MYGVUGdRQLL/JqBIeJhJBg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-environment-visitor': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/traverse': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@babel/plugin-proposal-class-properties/7.18.6_@babel+core@7.24.7:
+  /@babel/plugin-proposal-class-properties/7.18.6_@babel+core@7.26.0:
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
     engines: {node: '>=6.9.0'}
     deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-create-class-features-plugin': 7.24.7_@babel+core@7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-create-class-features-plugin': 7.25.9_@babel+core@7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-decorators/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-RL9GR0pUG5Kc8BUWLNDm2T5OpYwSX15r98I0IkgmRQTXuELq/OynH8xtMTMvTJFjXbMWFVTKtYkTaYQsuAwQlQ==}
+  /@babel/plugin-proposal-decorators/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-smkNLL/O1ezy9Nhy4CNosc4Va+1wo5w4gzSZeLe6y6dM4mmHfYOCPolXQPHQxonZCF+ZyebxN9vqOolkYrSn5g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-create-class-features-plugin': 7.24.7_@babel+core@7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/plugin-syntax-decorators': 7.24.7_@babel+core@7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-create-class-features-plugin': 7.25.9_@babel+core@7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/plugin-syntax-decorators': 7.25.9_@babel+core@7.26.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-nullish-coalescing-operator/7.18.6_@babel+core@7.24.7:
+  /@babel/plugin-proposal-nullish-coalescing-operator/7.18.6_@babel+core@7.26.0:
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
     engines: {node: '>=6.9.0'}
     deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-nullish-coalescing-operator instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.26.0
     dev: true
 
-  /@babel/plugin-proposal-numeric-separator/7.18.6_@babel+core@7.24.7:
+  /@babel/plugin-proposal-numeric-separator/7.18.6_@babel+core@7.26.0:
     resolution: {integrity: sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==}
     engines: {node: '>=6.9.0'}
     deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-numeric-separator instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.26.0
     dev: true
 
-  /@babel/plugin-proposal-optional-chaining/7.21.0_@babel+core@7.24.7:
+  /@babel/plugin-proposal-optional-chaining/7.21.0_@babel+core@7.26.0:
     resolution: {integrity: sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==}
     engines: {node: '>=6.9.0'}
     deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-chaining instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.26.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-private-methods/7.18.6_@babel+core@7.24.7:
+  /@babel/plugin-proposal-private-methods/7.18.6_@babel+core@7.26.0:
     resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
     engines: {node: '>=6.9.0'}
     deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-create-class-features-plugin': 7.24.7_@babel+core@7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-create-class-features-plugin': 7.25.9_@babel+core@7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-private-property-in-object/7.21.0-placeholder-for-preset-env.2_@babel+core@7.24.7:
+  /@babel/plugin-proposal-private-property-in-object/7.21.0-placeholder-for-preset-env.2_@babel+core@7.26.0:
     resolution: {integrity: sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
+      '@babel/core': 7.26.0
     dev: true
 
-  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.24.7:
+  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.26.0:
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.24.7:
+  /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.26.0:
     resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.24.7:
+  /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.26.0:
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-syntax-class-static-block/7.14.5_@babel+core@7.24.7:
+  /@babel/plugin-syntax-class-static-block/7.14.5_@babel+core@7.26.0:
     resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-syntax-decorators/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-Ui4uLJJrRV1lb38zg1yYTmRKmiZLiftDEvZN2iq3kd9kUFU+PttmzTbAFC2ucRk/XJmtek6G23gPsuZbhrT8fQ==}
+  /@babel/plugin-syntax-decorators/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-ryzI0McXUPJnRCvMo4lumIKZUzhYUO/ScI+Mz4YVaTLt04DHNSjEUjKVvbzQjZFLuod/cYEc07mJWhzl6v4DPg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.24.7:
-    resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.24.7:
-    resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-syntax-flow/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-9G8GYT/dxn/D1IIKOUBmGX0mnmj46mGH9NnZyJLwtCpgh5f7D2VbuKodb+2s9m1Yavh1s7ASQN8lf0eqrb1LTw==}
+  /@babel/plugin-syntax-flow/7.26.0_@babel+core@7.26.0:
+    resolution: {integrity: sha512-B+O2DnPc0iG+YXFqOxv2WNuNU97ToWjOomUQ78DouOENWUaM5sVrmet9mcomUGQFwpJd//gvUagXBSdzO1fRKg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-syntax-import-assertions/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-Ec3NRUMoi8gskrkBe3fNmEQfxDvY8bgfQpz6jlk/41kX9eUjvpyqWU7PBP/pLAvMaSQjbMNKJmvX57jP+M6bPg==}
+  /@babel/plugin-syntax-import-assertions/7.26.0_@babel+core@7.26.0:
+    resolution: {integrity: sha512-QCWT5Hh830hK5EQa7XzuqIkQU9tT/whqbDz7kuaZMHFl1inRRg7JnuAEOQ0Ur0QUl0NufCk1msK2BeY79Aj/eg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-syntax-import-attributes/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-hbX+lKKeUMGihnK8nvKqmXBInriT3GVjzXKFriV3YC6APGxMbP8RZNFwy91+hocLXq90Mta+HshoB31802bb8A==}
+  /@babel/plugin-syntax-import-attributes/7.26.0_@babel+core@7.26.0:
+    resolution: {integrity: sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.24.7:
+  /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.26.0:
     resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.24.7:
+  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.26.0:
     resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-syntax-jsx/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==}
+  /@babel/plugin-syntax-jsx/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.24.7:
+  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.26.0:
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.24.7:
+  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.26.0:
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.24.7:
+  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.26.0:
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.24.7:
+  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.26.0:
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.24.7:
+  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.26.0:
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.24.7:
+  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.26.0:
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-syntax-private-property-in-object/7.14.5_@babel+core@7.24.7:
+  /@babel/plugin-syntax-private-property-in-object/7.14.5_@babel+core@7.26.0:
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.24.7:
+  /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.26.0:
     resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-syntax-typescript/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-c/+fVeJBB0FeKsFvwytYiUD+LBvhHjGSI0g446PRGdSVGZLRNArBUno2PETbAly3tpiNAQR5XaZ+JslxkotsbA==}
+  /@babel/plugin-syntax-typescript/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-syntax-unicode-sets-regex/7.18.6_@babel+core@7.24.7:
+  /@babel/plugin-syntax-unicode-sets-regex/7.18.6_@babel+core@7.26.0:
     resolution: {integrity: sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-create-regexp-features-plugin': 7.24.7_@babel+core@7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-create-regexp-features-plugin': 7.25.9_@babel+core@7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-transform-arrow-functions/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-Dt9LQs6iEY++gXUwY03DNFat5C2NbO48jj+j/bSAz6b3HgPs39qcPiYt77fDObIcFwj3/C2ICX9YMwGflUoSHQ==}
+  /@babel/plugin-transform-arrow-functions/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-6jmooXYIwn9ca5/RylZADJ+EnSxVUS5sjeJ9UPk6RWRzXCmOJCy6dqItPJFpw2cuCangPK4OYr5uhGKcmrm5Qg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-transform-async-generator-functions/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-o+iF77e3u7ZS4AoAuJvapz9Fm001PuD2V3Lp6OSE4FYQke+cSewYtnek+THqGRWyQloRCyvWL1OkyfNEl9vr/g==}
+  /@babel/plugin-transform-async-generator-functions/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-RXV6QAzTBbhDMO9fWwOmwwTuYaiPbggWQ9INdZqAYeSHyG7FzQ+nOZaUUjNwKv9pV3aE4WFqFm1Hnbci5tBCAw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-environment-visitor': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/helper-remap-async-to-generator': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-remap-async-to-generator': 7.25.9_@babel+core@7.26.0
+      '@babel/traverse': 7.25.9
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-async-to-generator/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-SQY01PcJfmQ+4Ash7NE+rpbLFbmqA2GPIgqzxfFTL4t1FKRq4zTms/7htKpoCUI9OcFYgzqfmCdH53s6/jn5fA==}
+  /@babel/plugin-transform-async-to-generator/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-NT7Ejn7Z/LjUH0Gv5KsBCxh7BH3fbLTV0ptHvpeMvrt3cPThHfJfst9Wrb7S8EvJ7vRTFI7z+VAvFVEQn/m5zQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-module-imports': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/helper-remap-async-to-generator': 7.24.7_@babel+core@7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-remap-async-to-generator': 7.25.9_@babel+core@7.26.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-block-scoped-functions/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-yO7RAz6EsVQDaBH18IDJcMB1HnrUn2FJ/Jslc/WtPPWcjhpUJXU/rjbwmluzp7v/ZzWcEhTMXELnnsz8djWDwQ==}
+  /@babel/plugin-transform-block-scoped-functions/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-toHc9fzab0ZfenFpsyYinOX0J/5dgJVA2fm64xPewu7CoYHWEivIWKxkK2rMi4r3yQqLnVmheMXRdG+k239CgA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-transform-block-scoping/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-Nd5CvgMbWc+oWzBsuaMcbwjJWAcp5qzrbg69SZdHSP7AMY0AbWFqFO0WTFCA1jxhMCwodRwvRec8k0QUbZk7RQ==}
+  /@babel/plugin-transform-block-scoping/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-1F05O7AYjymAtqbsFETboN1NvBdcnzMerO+zlMyJBEz6WkMdejvGWw9p05iTSjC85RLlBseHHQpYaM4gzJkBGg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-transform-class-properties/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-vKbfawVYayKcSeSR5YYzzyXvsDFWU2mD8U5TFeXtbCPLFUqe7GyCgvO6XDHzje862ODrOwy6WCPmKeWHbCFJ4w==}
+  /@babel/plugin-transform-class-properties/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-bbMAII8GRSkcd0h0b4X+36GksxuheLFjP65ul9w6C3KgAamI3JqErNgSrosX6ZPj+Mpim5VvEbawXxJCyEUV3Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-create-class-features-plugin': 7.24.7_@babel+core@7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-create-class-features-plugin': 7.25.9_@babel+core@7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-class-static-block/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-HMXK3WbBPpZQufbMG4B46A90PkuuhN9vBCb5T8+VAHqvAqvcLi+2cKoukcpmUYkszLhScU3l1iudhrks3DggRQ==}
+  /@babel/plugin-transform-class-static-block/7.26.0_@babel+core@7.26.0:
+    resolution: {integrity: sha512-6J2APTs7BDDm+UMqP1useWqhcRAXo0WIoVj26N7kPFB6S73Lgvyka4KTZYIxtgYXiN5HTyRObA72N2iu628iTQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.12.0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-create-class-features-plugin': 7.24.7_@babel+core@7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-create-class-features-plugin': 7.25.9_@babel+core@7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-classes/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-CFbbBigp8ln4FU6Bpy6g7sE8B/WmCmzvivzUC6xDAdWVsjYTXijpuuGJmYkAaoWAzcItGKT3IOAbxRItZ5HTjw==}
+  /@babel/plugin-transform-classes/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-mD8APIXmseE7oZvZgGABDyM34GUmK45Um2TXiBUt7PnuAxrgoSVf123qUzPxEr/+/BHrRn5NMZCdE2m/1F8DGg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-annotate-as-pure': 7.24.7
-      '@babel/helper-compilation-targets': 7.24.7
-      '@babel/helper-environment-visitor': 7.24.7
-      '@babel/helper-function-name': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/helper-replace-supers': 7.24.7_@babel+core@7.24.7
-      '@babel/helper-split-export-declaration': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-compilation-targets': 7.25.9
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-replace-supers': 7.25.9_@babel+core@7.26.0
+      '@babel/traverse': 7.25.9
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-computed-properties/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-25cS7v+707Gu6Ds2oY6tCkUwsJ9YIDbggd9+cu9jzzDgiNq7hR/8dkzxWfKWnTic26vsI3EsCXNd4iEB6e8esQ==}
+  /@babel/plugin-transform-computed-properties/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-HnBegGqXZR12xbcTHlJ9HGxw1OniltT26J5YpfruGqtUHlz/xKf/G2ak9e+t0rVqrjXa9WOhvYPz1ERfMj23AA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/template': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/template': 7.25.9
     dev: true
 
-  /@babel/plugin-transform-destructuring/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-19eJO/8kdCQ9zISOf+SEUJM/bAUIsvY3YDnXZTupUCQ8LgrWnsG/gFB9dvXqdXnRXMAM8fvt7b0CBKQHNGy1mw==}
+  /@babel/plugin-transform-destructuring/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-WkCGb/3ZxXepmMiX101nnGiU+1CAdut8oHyEOHxkKuS1qKpU2SMXE2uSvfz8PBuLd49V6LEsbtyPhWC7fnkgvQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-transform-dotall-regex/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-ZOA3W+1RRTSWvyqcMJDLqbchh7U4NRGqwRfFSVbOLS/ePIP4vHB5e8T8eXcuqyN1QkgKyj5wuW0lcS85v4CrSw==}
+  /@babel/plugin-transform-dotall-regex/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-t7ZQ7g5trIgSRYhI9pIJtRl64KHotutUJsh4Eze5l7olJv+mRSg4/MmbZ0tv1eeqRbdvo/+trvJD/Oc5DmW2cA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-create-regexp-features-plugin': 7.24.7_@babel+core@7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-create-regexp-features-plugin': 7.25.9_@babel+core@7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-transform-duplicate-keys/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-JdYfXyCRihAe46jUIliuL2/s0x0wObgwwiGxw/UbgJBr20gQBThrokO4nYKgWkD7uBaqM7+9x5TU7NkExZJyzw==}
+  /@babel/plugin-transform-duplicate-keys/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-LZxhJ6dvBb/f3x8xwWIuyiAHy56nrRG3PeYTpBkkzkYRRQ6tJLu68lEF5VIqMUZiAV7a8+Tb78nEoMCMcqjXBw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-transform-dynamic-import/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-sc3X26PhZQDb3JhORmakcbvkeInvxz+A8oda99lj7J60QRuPZvNAk9wQlTBS1ZynelDrDmTU4pw1tyc5d5ZMUg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.24.7
-    dev: true
-
-  /@babel/plugin-transform-exponentiation-operator/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-Rqe/vSc9OYgDajNIK35u7ot+KeCoetqQYFXM4Epf7M7ez3lWlOjrDjrwMei6caCVhfdw+mIKD4cgdGNy5JQotQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-builder-binary-assignment-operator-visitor': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-export-namespace-from/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-v0K9uNYsPL3oXZ/7F9NNIbAj2jv1whUEtyA6aujhekLs56R++JDQuzRcP2/z4WX5Vg/c5lE9uWZA0/iUoFhLTA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.24.7
-    dev: true
-
-  /@babel/plugin-transform-flow-strip-types/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-cjRKJ7FobOH2eakx7Ja+KpJRj8+y+/SiB3ooYm/n2UJfxu0oEaOoxOinitkJcPqv9KxS0kxTGPUaR7L2XcXDXA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/plugin-syntax-flow': 7.24.7_@babel+core@7.24.7
-    dev: true
-
-  /@babel/plugin-transform-for-of/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-wo9ogrDG1ITTTBsy46oGiN1dS9A7MROBTcYsfS8DtsImMkHk9JXJ3EWQM6X2SUw4x80uGPlwj0o00Uoc6nEE3g==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-function-name/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-U9FcnA821YoILngSmYkW6FjyQe2TyZD5pHt4EVIhmcTkrJw/3KqcrRSxuOo5tFZJi7TE19iDyI1u+weTI7bn2w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-compilation-targets': 7.24.7
-      '@babel/helper-function-name': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-json-strings/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-2yFnBGDvRuxAaE/f0vfBKvtnvvqU8tGpMHqMNpTN2oWMKIR3NqFkjaAgGwawhqK/pIN2T3XdjGPdaG0vDhOBGw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.24.7
-    dev: true
-
-  /@babel/plugin-transform-literals/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-vcwCbb4HDH+hWi8Pqenwnjy+UiklO4Kt1vfspcQYFhJdpthSnW8XvWGyDZWKNVrVbVViI/S7K9PDJZiUmP2fYQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-logical-assignment-operators/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-4D2tpwlQ1odXmTEIFWy9ELJcZHqrStlzK/dAOWYyxX3zT0iXQB6banjgeOJQXzEc4S0E0a5A+hahxPaEFYftsw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.24.7
-    dev: true
-
-  /@babel/plugin-transform-member-expression-literals/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-T/hRC1uqrzXMKLQ6UCwMT85S3EvqaBXDGf0FaMf4446Qx9vKwlghvee0+uuZcDUCZU5RuNi4781UQ7R308zzBw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-modules-amd/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-9+pB1qxV3vs/8Hdmz/CulFB8w2tuu6EB94JZFsjdqxQokwGa9Unap7Bo2gGBGIvPmDIVvQrom7r5m/TCDMURhg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-module-transforms': 7.24.7_@babel+core@7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-modules-commonjs/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-iFI8GDxtevHJ/Z22J5xQpVqFLlMNstcLXh994xifFwxxGslr2ZXXLWgtBeLctOD63UFDArdvN6Tg8RFw+aEmjQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-module-transforms': 7.24.7_@babel+core@7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/helper-simple-access': 7.24.7
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-modules-systemjs/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-GYQE0tW7YoaN13qFh3O1NCY4MPkUiAH3fiF7UcV/I3ajmDKEdG3l+UOcbAm4zUE3gnvUU+Eni7XrVKo9eO9auw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-hoist-variables': 7.24.7
-      '@babel/helper-module-transforms': 7.24.7_@babel+core@7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/helper-validator-identifier': 7.24.7
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-modules-umd/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-3aytQvqJ/h9z4g8AsKPLvD4Zqi2qT+L3j7XoFFu1XBlZWEl2/1kWnhmAbxpLgPrHSY0M6UA02jyTiwUVtiKR6A==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-module-transforms': 7.24.7_@babel+core@7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-named-capturing-groups-regex/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-/jr7h/EWeJtk1U/uz2jlsCioHkZk1JJZVcc8oQsJ1dUlaJD83f4/6Zeh2aHt9BIFokHIsSeDfhUmju0+1GPd6g==}
+  /@babel/plugin-transform-duplicate-named-capturing-groups-regex/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-0UfuJS0EsXbRvKnwcLjFtJy/Sxc5J5jhLHnFhy7u4zih97Hz6tJkLU+O+FMMrNZrosUPxDi6sYxJ/EA8jDiAog==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-create-regexp-features-plugin': 7.24.7_@babel+core@7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-create-regexp-features-plugin': 7.25.9_@babel+core@7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-transform-new-target/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-RNKwfRIXg4Ls/8mMTza5oPF5RkOW8Wy/WgMAp1/F1yZ8mMbtwXW+HDoJiOsagWrAhI5f57Vncrmr9XeT4CVapA==}
+  /@babel/plugin-transform-dynamic-import/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-GCggjexbmSLaFhqsojeugBpeaRIgWNTcgKVq/0qIteFEqY2A+b9QidYadrWlnbWQUrW5fn+mCvf3tr7OeBFTyg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-transform-nullish-coalescing-operator/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-Ts7xQVk1OEocqzm8rHMXHlxvsfZ0cEF2yomUqpKENHWMF4zKk175Y4q8H5knJes6PgYad50uuRmt3UJuhBw8pQ==}
+  /@babel/plugin-transform-exponentiation-operator/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-KRhdhlVk2nObA5AYa7QMgTMTVJdfHprfpAk4DjZVtllqRg9qarilstTKEhpVjyt+Npi8ThRyiV8176Am3CodPA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.24.7
-    dev: true
-
-  /@babel/plugin-transform-numeric-separator/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-e6q1TiVUzvH9KRvicuxdBTUj4AdKSRwzIyFFnfnezpCfP2/7Qmbb8qbU2j7GODbl4JMkblitCQjKYUaX/qkkwA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.24.7
-    dev: true
-
-  /@babel/plugin-transform-object-rest-spread/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-4QrHAr0aXQCEFni2q4DqKLD31n2DL+RxcwnNjDFkSG0eNQ/xCavnRkfCUjsyqGC2OviNJvZOF/mQqZBw7i2C5Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-compilation-targets': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.24.7
-      '@babel/plugin-transform-parameters': 7.24.7_@babel+core@7.24.7
-    dev: true
-
-  /@babel/plugin-transform-object-super/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-A/vVLwN6lBrMFmMDmPPz0jnE6ZGx7Jq7d6sT/Ev4H65RER6pZ+kczlf1DthF5N0qaPHBsI7UXiE8Zy66nmAovg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/helper-replace-supers': 7.24.7_@babel+core@7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-builder-binary-assignment-operator-visitor': 7.25.9
+      '@babel/helper-plugin-utils': 7.25.9
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-optional-catch-binding/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-uLEndKqP5BfBbC/5jTwPxLh9kqPWWgzN/f8w6UwAIirAEqiIVJWWY312X72Eub09g5KF9+Zn7+hT7sDxmhRuKA==}
+  /@babel/plugin-transform-export-namespace-from/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-2NsEz+CxzJIVOPx2o9UsW1rXLqtChtLoVnwYHHiB04wS5sgn7mrV45fWMBX0Kk+ub9uXytVYfNP2HjbVbCB3Ww==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/plugin-transform-optional-chaining/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-tK+0N9yd4j+x/4hxF3F0e0fu/VdcxU18y5SevtyM/PCFlQvXbR0Zmlo2eBrKtVipGNFzpq56o8WsIIKcJFUCRQ==}
+  /@babel/plugin-transform-flow-strip-types/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-/VVukELzPDdci7UUsWQaSkhgnjIWXnIyRpM02ldxaVoFK96c41So8JcKT3m0gYjyv7j5FNPGS5vfELrWalkbDA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/plugin-syntax-flow': 7.26.0_@babel+core@7.26.0
+    dev: true
+
+  /@babel/plugin-transform-for-of/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-LqHxduHoaGELJl2uhImHwRQudhCM50pT46rIBNvtT/Oql3nqiS3wOwP+5ten7NpYSXrrVLgtZU3DZmPtWZo16A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-parameters/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-yGWW5Rr+sQOhK0Ot8hjDJuxU3XLRQGflvT4lhlSY0DFvdb3TwKaY26CJzHtYllU0vT9j58hc37ndFPsqT1SrzA==}
+  /@babel/plugin-transform-function-name/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-8lP+Yxjv14Vc5MuWBpJsoUCd3hD6V9DgBon2FVYL4jJgbnVQ9fTgYmonchzZJOVNgzEgbxp4OwAf6xz6M/14XA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-private-methods/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-COTCOkG2hn4JKGEKBADkA8WNb35TGkkRbI5iT845dB+NyqgO8Hn+ajPbSnIQznneJTa3d30scb6iz/DhH8GsJQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-create-class-features-plugin': 7.24.7_@babel+core@7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-compilation-targets': 7.25.9
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/traverse': 7.25.9
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-private-property-in-object/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-9z76mxwnwFxMyxZWEgdgECQglF2Q7cFLm0kMf8pGwt+GSJsY0cONKj/UuO4bOH0w/uAel3ekS4ra5CEAyJRmDA==}
+  /@babel/plugin-transform-json-strings/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-xoTMk0WXceiiIvsaquQQUaLLXSW1KJ159KP87VilruQm0LNNGxWzahxSS6T6i4Zg3ezp4vA4zuwiNUR53qmQAw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-annotate-as-pure': 7.24.7
-      '@babel/helper-create-class-features-plugin': 7.24.7_@babel+core@7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+    dev: true
+
+  /@babel/plugin-transform-literals/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-9N7+2lFziW8W9pBl2TzaNht3+pgMIRP74zizeCSrtnSKVdUl8mAjjOP2OOVQAfZ881P2cNjDj1uAMEdeD50nuQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+    dev: true
+
+  /@babel/plugin-transform-logical-assignment-operators/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-wI4wRAzGko551Y8eVf6iOY9EouIDTtPb0ByZx+ktDGHwv6bHFimrgJM/2T021txPZ2s4c7bqvHbd+vXG6K948Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+    dev: true
+
+  /@babel/plugin-transform-member-expression-literals/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-PYazBVfofCQkkMzh2P6IdIUaCEWni3iYEerAsRWuVd8+jlM1S9S9cz1dF9hIzyoZ8IA3+OwVYIp9v9e+GbgZhA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+    dev: true
+
+  /@babel/plugin-transform-modules-amd/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-g5T11tnI36jVClQlMlt4qKDLlWnG5pP9CSM4GhdRciTNMRgkfpo5cR6b4rGIOYPgRRuFAvwjPQ/Yk+ql4dyhbw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-module-transforms': 7.26.0_@babel+core@7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-property-literals/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-EMi4MLQSHfd2nrCqQEWxFdha2gBCqU4ZcCng4WBGZ5CJL4bBRW0ptdqqDdeirGZcpALazVVNJqRmsO8/+oNCBA==}
+  /@babel/plugin-transform-modules-commonjs/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-dwh2Ol1jWwL2MgkCzUSOvfmKElqQcuswAZypBSUsScMXvgdT8Ekq5YA6TtqpTVWH+4903NmboMuH1o9i8Rxlyg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-react-constant-elements/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-7LidzZfUXyfZ8/buRW6qIIHBY8wAZ1OrY9c/wTr8YhZ6vMPo+Uc/CVFLYY1spZrEQlD4w5u8wjqk5NQ3OVqQKA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-react-display-name/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-H/Snz9PFxKsS1JLI4dJLtnJgCJRoo0AUm3chP6NYr+9En1JMKloheEiLIhlp5MDVznWo+H3AAC1Mc8lmUEpsgg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-react-jsx-development/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-QG9EnzoGn+Qar7rxuW+ZOsbWOt56FvvI93xInqsZDC5fsekx1AlIO4KIJ5M+D0p0SqSH156EpmZyXq630B8OlQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/plugin-transform-react-jsx': 7.24.7_@babel+core@7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-module-transforms': 7.26.0_@babel+core@7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-simple-access': 7.25.9
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-react-jsx/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-+Dj06GDZEFRYvclU6k4bme55GKBEWUmByM/eoKuqg4zTNQHiApWRhQph5fxQB2wAEFvRzL1tOEj1RJ19wJrhoA==}
+  /@babel/plugin-transform-modules-systemjs/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-hyss7iIlH/zLHaehT+xwiymtPOpsiwIIRlCAOwBB04ta5Tt+lNItADdlXw3jAWZ96VJ2jlhl/c+PNIQPKNfvcA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-annotate-as-pure': 7.24.7
-      '@babel/helper-module-imports': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/plugin-syntax-jsx': 7.24.7_@babel+core@7.24.7
-      '@babel/types': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-module-transforms': 7.26.0_@babel+core@7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/traverse': 7.25.9
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-react-pure-annotations/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-PLgBVk3fzbmEjBJ/u8kFzOqS9tUeDjiaWud/rRym/yjCo/M9cASPlnrd2ZmmZpQT40fOOrvR8jh+n8jikrOhNA==}
+  /@babel/plugin-transform-modules-umd/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-bS9MVObUgE7ww36HEfwe6g9WakQ0KF07mQF74uuXdkoziUPfKyu/nIm663kz//e5O1nPInPFx36z7WJmJ4yNEw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-annotate-as-pure': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-module-transforms': 7.26.0_@babel+core@7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@babel/plugin-transform-regenerator/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-lq3fvXPdimDrlg6LWBoqj+r/DEWgONuwjuOuQCSYgRroXDH/IdM1C0IZf59fL5cHLpjEH/O6opIRBbqv7ELnuA==}
+  /@babel/plugin-transform-named-capturing-groups-regex/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-oqB6WHdKTGl3q/ItQhpLSnWWOpjUJLsOCLVyeFgeTktkBSCiurvPOsyt93gibI9CmuKvTUEtWmG5VhZD+5T/KA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-create-regexp-features-plugin': 7.25.9_@babel+core@7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+    dev: true
+
+  /@babel/plugin-transform-new-target/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-U/3p8X1yCSoKyUj2eOBIx3FOn6pElFOKvAAGf8HTtItuPyB+ZeOqfn+mvTtg9ZlOAjsPdK3ayQEjqHjU/yLeVQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+    dev: true
+
+  /@babel/plugin-transform-nullish-coalescing-operator/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-ENfftpLZw5EItALAD4WsY/KUWvhUlZndm5GC7G3evUsVeSJB6p0pBeLQUnRnBCBx7zV0RKQjR9kCuwrsIrjWog==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+    dev: true
+
+  /@babel/plugin-transform-numeric-separator/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-TlprrJ1GBZ3r6s96Yq8gEQv82s8/5HnCVHtEJScUj90thHQbwe+E5MLhi2bbNHBEJuzrvltXSru+BUxHDoog7Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+    dev: true
+
+  /@babel/plugin-transform-object-rest-spread/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-fSaXafEE9CVHPweLYw4J0emp1t8zYTXyzN3UuG+lylqkvYd7RMrsOQ8TYx5RF231be0vqtFC6jnx3UmpJmKBYg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-compilation-targets': 7.25.9
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/plugin-transform-parameters': 7.25.9_@babel+core@7.26.0
+    dev: true
+
+  /@babel/plugin-transform-object-super/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-Kj/Gh+Rw2RNLbCK1VAWj2U48yxxqL2x0k10nPtSdRa0O2xnHXalD0s+o1A6a0W43gJ00ANo38jxkQreckOzv5A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-replace-supers': 7.25.9_@babel+core@7.26.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/plugin-transform-optional-catch-binding/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-qM/6m6hQZzDcZF3onzIhZeDHDO43bkNNlOX0i8n3lR6zLbu0GN2d8qfM/IERJZYauhAHSLHy39NF0Ctdvcid7g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+    dev: true
+
+  /@babel/plugin-transform-optional-chaining/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-6AvV0FsLULbpnXeBjrY4dmWF8F7gf8QnvTEoO/wX/5xm/xE1Xo8oPuD3MPS+KS9f9XBEAWN7X1aWr4z9HdOr7A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/plugin-transform-parameters/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-wzz6MKwpnshBAiRmn4jR8LYz/g8Ksg0o80XmwZDlordjwEk9SxBzTWC7F5ef1jhbrbOW2DJ5J6ayRukrJmnr0g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+    dev: true
+
+  /@babel/plugin-transform-private-methods/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-D/JUozNpQLAPUVusvqMxyvjzllRaF8/nSrP1s2YGQT/W4LHK4xxsMcHjhOGTS01mp9Hda8nswb+FblLdJornQw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-create-class-features-plugin': 7.25.9_@babel+core@7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/plugin-transform-private-property-in-object/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-Evf3kcMqzXA3xfYJmZ9Pg1OvKdtqsDMSWBDzZOPLvHiTt36E75jLDQo5w1gtRU95Q4E5PDttrTf25Fw8d/uWLw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-create-class-features-plugin': 7.25.9_@babel+core@7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/plugin-transform-property-literals/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-IvIUeV5KrS/VPavfSM/Iu+RE6llrHrYIKY1yfCzyO/lMXHQ+p7uGhonmGVisv6tSBSVgWzMBohTcvkC9vQcQFA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+    dev: true
+
+  /@babel/plugin-transform-react-constant-elements/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-Ncw2JFsJVuvfRsa2lSHiC55kETQVLSnsYGQ1JDDwkUeWGTL/8Tom8aLTnlqgoeuopWrbbGndrc9AlLYrIosrow==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+    dev: true
+
+  /@babel/plugin-transform-react-display-name/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-KJfMlYIUxQB1CJfO3e0+h0ZHWOTLCPP115Awhaz8U0Zpq36Gl/cXlpoyMRnUWlhNUBAzldnCiAZNvCDj7CrKxQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+    dev: true
+
+  /@babel/plugin-transform-react-jsx-development/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-9mj6rm7XVYs4mdLIpbZnHOYdpW42uoiBCTVowg7sP1thUOiANgMb4UtpRivR0pp5iL+ocvUv7X4mZgFRpJEzGw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/plugin-transform-react-jsx': 7.25.9_@babel+core@7.26.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/plugin-transform-react-jsx/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-s5XwpQYCqGerXl+Pu6VDL3x0j2d82eiV77UJ8a2mDHAW7j9SWRqQ2y1fNo1Z74CdcYipl5Z41zvjj4Nfzq36rw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/plugin-syntax-jsx': 7.25.9_@babel+core@7.26.0
+      '@babel/types': 7.26.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/plugin-transform-react-pure-annotations/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-KQ/Takk3T8Qzj5TppkS1be588lkbTp5uj7w6a0LeQaTMSckU/wK0oJ/pih+T690tkgI5jfmg2TqDJvd41Sj1Cg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-plugin-utils': 7.25.9
+    dev: true
+
+  /@babel/plugin-transform-regenerator/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-vwDcDNsgMPDGP0nMqzahDWE5/MLcX8sv96+wfX7as7LoF/kr97Bo/7fI00lXY4wUXYfVmwIIyG80fGZ1uvt2qg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
       regenerator-transform: 0.15.2
     dev: true
 
-  /@babel/plugin-transform-reserved-words/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-0DUq0pHcPKbjFZCfTss/pGkYMfy3vFWydkUBd9r0GHpIyfs2eCDENvqadMycRS9wZCXR41wucAfJHJmwA0UmoQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-runtime/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-YqXjrk4C+a1kZjewqt+Mmu2UuV1s07y8kqcUf4qYLnoqemhR4gRQikhdAhSVJioMjVTu6Mo6pAbaypEA3jY6fw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-module-imports': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      babel-plugin-polyfill-corejs2: 0.4.11_@babel+core@7.24.7
-      babel-plugin-polyfill-corejs3: 0.10.4_@babel+core@7.24.7
-      babel-plugin-polyfill-regenerator: 0.6.2_@babel+core@7.24.7
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-shorthand-properties/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-KsDsevZMDsigzbA09+vacnLpmPH4aWjcZjXdyFKGzpplxhbeB4wYtury3vglQkg6KM/xEPKt73eCjPPf1PgXBA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-spread/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-x96oO0I09dgMDxJaANcRyD4ellXFLLiWhuwDxKZX5g2rWP1bTPkBSwCYv96VDXVT1bD9aPj8tppr5ITIh8hBng==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-sticky-regex/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-kHPSIJc9v24zEml5geKg9Mjx5ULpfncj0wRpYtxbvKyTtHCYDkVE3aHQ03FrpEo4gEe2vrJJS1Y9CJTaThA52g==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-template-literals/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-AfDTQmClklHCOLxtGoP7HkeMw56k1/bTQjwsfhL6pppo/M4TOBSq+jjBUBLmV/4oeFg4GWMavIl44ZeCtmmZTw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-typeof-symbol/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-VtR8hDy7YLB7+Pet9IarXjg/zgCMSF+1mNS/EQEiEaUPoFXCVsHG64SIxcaaI2zJgRiv+YmgaQESUfWAdbjzgg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-typescript/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-iLD3UNkgx2n/HrjBesVbYX6j0yqn/sJktvbtKKgcaLIQ4bTTQ8obAypc1VpyHPD2y4Phh9zHOaAt8e/L14wCpw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-annotate-as-pure': 7.24.7
-      '@babel/helper-create-class-features-plugin': 7.24.7_@babel+core@7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/plugin-syntax-typescript': 7.24.7_@babel+core@7.24.7
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-unicode-escapes/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-U3ap1gm5+4edc2Q/P+9VrBNhGkfnf+8ZqppY71Bo/pzZmXhhLdqgaUl6cuB07O1+AQJtCLfaOmswiNbSQ9ivhw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-unicode-property-regex/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-uH2O4OV5M9FZYQrwc7NdVmMxQJOCCzFeYudlZSzUAHRFeOujQefa92E74TQDVskNHCzOXoigEuoyzHDhaEaK5w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-create-regexp-features-plugin': 7.24.7_@babel+core@7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-unicode-regex/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-hlQ96MBZSAXUq7ltkjtu3FJCCSMx/j629ns3hA3pXnBXjanNP0LHi+JpPeA81zaWgVK1VGH95Xuy7u0RyQ8kMg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-create-regexp-features-plugin': 7.24.7_@babel+core@7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-    dev: true
-
-  /@babel/plugin-transform-unicode-sets-regex/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-2G8aAvF4wy1w/AGZkemprdGMRg5o6zPNhbHVImRz3lss55TYCBd6xStN19rt8XJHq20sqV0JbyWjOWwQRwV/wg==}
+  /@babel/plugin-transform-regexp-modifiers/7.26.0_@babel+core@7.26.0:
+    resolution: {integrity: sha512-vN6saax7lrA2yA/Pak3sCxuD6F5InBjn9IcrIKQPjpsLvuHYLVroTxjdlVRHjjBWxKOqIwpTXDkOssYT4BFdRw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-create-regexp-features-plugin': 7.24.7_@babel+core@7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-create-regexp-features-plugin': 7.25.9_@babel+core@7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
     dev: true
 
-  /@babel/preset-env/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-1YZNsc+y6cTvWlDHidMBsQZrZfEFjRIo/BZCT906PMdzOyXtSLTgqGdrpcuTDCXyd11Am5uQULtDIcCfnTc8fQ==}
+  /@babel/plugin-transform-reserved-words/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-7DL7DKYjn5Su++4RXu8puKZm2XBPHyjWLUidaPEkCUBbE7IPcsrkRHggAOOKydH1dASWdcUBxrkOGNxUv5P3Jg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.24.7
-      '@babel/core': 7.24.7
-      '@babel/helper-compilation-targets': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/helper-validator-option': 7.24.7
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2_@babel+core@7.24.7
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.24.7
-      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.24.7
-      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.24.7
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.24.7
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.24.7
-      '@babel/plugin-syntax-import-assertions': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-syntax-import-attributes': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.24.7
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.24.7
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.24.7
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.24.7
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.24.7
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.24.7
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.24.7
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.24.7
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.24.7
-      '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.24.7
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6_@babel+core@7.24.7
-      '@babel/plugin-transform-arrow-functions': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-async-generator-functions': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-async-to-generator': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-block-scoped-functions': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-block-scoping': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-class-properties': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-class-static-block': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-classes': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-computed-properties': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-destructuring': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-dotall-regex': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-duplicate-keys': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-dynamic-import': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-exponentiation-operator': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-export-namespace-from': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-for-of': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-function-name': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-json-strings': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-literals': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-logical-assignment-operators': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-member-expression-literals': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-modules-amd': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-modules-commonjs': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-modules-systemjs': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-modules-umd': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-new-target': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-numeric-separator': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-object-rest-spread': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-object-super': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-optional-catch-binding': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-optional-chaining': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-parameters': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-private-methods': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-private-property-in-object': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-property-literals': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-regenerator': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-reserved-words': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-shorthand-properties': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-spread': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-sticky-regex': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-template-literals': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-typeof-symbol': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-unicode-escapes': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-unicode-property-regex': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-unicode-regex': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-unicode-sets-regex': 7.24.7_@babel+core@7.24.7
-      '@babel/preset-modules': 0.1.6-no-external-plugins_@babel+core@7.24.7
-      babel-plugin-polyfill-corejs2: 0.4.11_@babel+core@7.24.7
-      babel-plugin-polyfill-corejs3: 0.10.4_@babel+core@7.24.7
-      babel-plugin-polyfill-regenerator: 0.6.2_@babel+core@7.24.7
-      core-js-compat: 3.37.1
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+    dev: true
+
+  /@babel/plugin-transform-runtime/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-nZp7GlEl+yULJrClz0SwHPqir3lc0zsPrDHQUcxGspSL7AKrexNSEfTbfqnDNJUO13bgKyfuOLMF8Xqtu8j3YQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-plugin-utils': 7.25.9
+      babel-plugin-polyfill-corejs2: 0.4.11_@babel+core@7.26.0
+      babel-plugin-polyfill-corejs3: 0.10.6_@babel+core@7.26.0
+      babel-plugin-polyfill-regenerator: 0.6.2_@babel+core@7.26.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/preset-modules/0.1.6-no-external-plugins_@babel+core@7.24.7:
+  /@babel/plugin-transform-shorthand-properties/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-MUv6t0FhO5qHnS/W8XCbHmiRWOphNufpE1IVxhK5kuN3Td9FT1x4rx4K42s3RYdMXCXpfWkGSbCSd0Z64xA7Ng==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+    dev: true
+
+  /@babel/plugin-transform-spread/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-oNknIB0TbURU5pqJFVbOOFspVlrpVwo2H1+HUIsVDvp5VauGGDP1ZEvO8Nn5xyMEs3dakajOxlmkNW7kNgSm6A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/plugin-transform-sticky-regex/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-WqBUSgeVwucYDP9U/xNRQam7xV8W5Zf+6Eo7T2SRVUFlhRiMNFdFz58u0KZmCVVqs2i7SHgpRnAhzRNmKfi2uA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+    dev: true
+
+  /@babel/plugin-transform-template-literals/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-o97AE4syN71M/lxrCtQByzphAdlYluKPDBzDVzMmfCobUjjhAryZV0AIpRPrxN0eAkxXO6ZLEScmt+PNhj2OTw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+    dev: true
+
+  /@babel/plugin-transform-typeof-symbol/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-v61XqUMiueJROUv66BVIOi0Fv/CUuZuZMl5NkRoCVxLAnMexZ0A3kMe7vvZ0nulxMuMp0Mk6S5hNh48yki08ZA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+    dev: true
+
+  /@babel/plugin-transform-typescript/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-7PbZQZP50tzv2KGGnhh82GSyMB01yKY9scIjf1a+GfZCtInOWqUH5+1EBU4t9fyR5Oykkkc9vFTs4OHrhHXljQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-create-class-features-plugin': 7.25.9_@babel+core@7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
+      '@babel/plugin-syntax-typescript': 7.25.9_@babel+core@7.26.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/plugin-transform-unicode-escapes/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-s5EDrE6bW97LtxOcGj1Khcx5AaXwiMmi4toFWRDP9/y0Woo6pXC+iyPu/KuhKtfSrNFd7jJB+/fkOtZy6aIC6Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+    dev: true
+
+  /@babel/plugin-transform-unicode-property-regex/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-Jt2d8Ga+QwRluxRQ307Vlxa6dMrYEMZCgGxoPR8V52rxPyldHu3hdlHspxaqYmE7oID5+kB+UKUB/eWS+DkkWg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-create-regexp-features-plugin': 7.25.9_@babel+core@7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+    dev: true
+
+  /@babel/plugin-transform-unicode-regex/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-yoxstj7Rg9dlNn9UQxzk4fcNivwv4nUYz7fYXBaKxvw/lnmPuOm/ikoELygbYq68Bls3D/D+NBPHiLwZdZZ4HA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-create-regexp-features-plugin': 7.25.9_@babel+core@7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+    dev: true
+
+  /@babel/plugin-transform-unicode-sets-regex/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-8BYqO3GeVNHtx69fdPshN3fnzUNLrWdHhk/icSwigksJGczKSizZ+Z6SBCxTs723Fr5VSNorTIK7a+R2tISvwQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-create-regexp-features-plugin': 7.25.9_@babel+core@7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+    dev: true
+
+  /@babel/preset-env/7.26.0_@babel+core@7.26.0:
+    resolution: {integrity: sha512-H84Fxq0CQJNdPFT2DrfnylZ3cf5K43rGfWK4LJGPpjKHiZlk0/RzwEus3PDDZZg+/Er7lCA03MVacueUuXdzfw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/compat-data': 7.26.2
+      '@babel/core': 7.26.0
+      '@babel/helper-compilation-targets': 7.25.9
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-validator-option': 7.25.9
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2_@babel+core@7.26.0
+      '@babel/plugin-syntax-import-assertions': 7.26.0_@babel+core@7.26.0
+      '@babel/plugin-syntax-import-attributes': 7.26.0_@babel+core@7.26.0
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6_@babel+core@7.26.0
+      '@babel/plugin-transform-arrow-functions': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-async-generator-functions': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-async-to-generator': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-block-scoped-functions': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-block-scoping': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-class-properties': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-class-static-block': 7.26.0_@babel+core@7.26.0
+      '@babel/plugin-transform-classes': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-computed-properties': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-destructuring': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-dotall-regex': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-duplicate-keys': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-dynamic-import': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-exponentiation-operator': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-export-namespace-from': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-for-of': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-function-name': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-json-strings': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-literals': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-logical-assignment-operators': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-member-expression-literals': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-modules-amd': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-modules-commonjs': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-modules-systemjs': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-modules-umd': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-new-target': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-numeric-separator': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-object-rest-spread': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-object-super': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-optional-catch-binding': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-optional-chaining': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-parameters': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-private-methods': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-private-property-in-object': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-property-literals': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-regenerator': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-regexp-modifiers': 7.26.0_@babel+core@7.26.0
+      '@babel/plugin-transform-reserved-words': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-shorthand-properties': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-spread': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-sticky-regex': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-template-literals': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-typeof-symbol': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-unicode-escapes': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-unicode-property-regex': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-unicode-regex': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-unicode-sets-regex': 7.25.9_@babel+core@7.26.0
+      '@babel/preset-modules': 0.1.6-no-external-plugins_@babel+core@7.26.0
+      babel-plugin-polyfill-corejs2: 0.4.11_@babel+core@7.26.0
+      babel-plugin-polyfill-corejs3: 0.10.6_@babel+core@7.26.0
+      babel-plugin-polyfill-regenerator: 0.6.2_@babel+core@7.26.0
+      core-js-compat: 3.39.0
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/preset-modules/0.1.6-no-external-plugins_@babel+core@7.26.0:
     resolution: {integrity: sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/types': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/types': 7.26.0
       esutils: 2.0.3
     dev: true
 
-  /@babel/preset-react/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-AAH4lEkpmzFWrGVlHaxJB7RLH21uPQ9+He+eFLWHmF9IuFQVugz8eAsamaW0DXRrTfco5zj1wWtpdcXJUOfsag==}
+  /@babel/preset-react/7.25.9_@babel+core@7.26.0:
+    resolution: {integrity: sha512-D3to0uSPiWE7rBrdIICCd0tJSIGpLaaGptna2+w7Pft5xMqLpA1sz99DK5TZ1TjGbdQ/VI1eCSZ06dv3lT4JOw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/helper-validator-option': 7.24.7
-      '@babel/plugin-transform-react-display-name': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-react-jsx': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-react-jsx-development': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-react-pure-annotations': 7.24.7_@babel+core@7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-validator-option': 7.25.9
+      '@babel/plugin-transform-react-display-name': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-react-jsx': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-react-jsx-development': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-react-pure-annotations': 7.25.9_@babel+core@7.26.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/preset-typescript/7.24.7_@babel+core@7.24.7:
-    resolution: {integrity: sha512-SyXRe3OdWwIwalxDg5UtJnJQO+YPcTfwiIY2B0Xlddh9o7jpWLvv8X1RthIeDOxQ+O1ML5BLPCONToObyVQVuQ==}
+  /@babel/preset-typescript/7.26.0_@babel+core@7.26.0:
+    resolution: {integrity: sha512-NMk1IGZ5I/oHhoXEElcm+xUnL/szL6xflkFZmoEU9xj1qSJXpiS7rsspYo92B4DRCDvZn2erT5LdsCeXAKNCkg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/helper-validator-option': 7.24.7
-      '@babel/plugin-syntax-jsx': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-modules-commonjs': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-typescript': 7.24.7_@babel+core@7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-validator-option': 7.25.9
+      '@babel/plugin-syntax-jsx': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-modules-commonjs': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-typescript': 7.25.9_@babel+core@7.26.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/regjsgen/0.8.0:
-    resolution: {integrity: sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==}
-    dev: true
-
-  /@babel/runtime/7.24.7:
-    resolution: {integrity: sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==}
+  /@babel/runtime/7.26.0:
+    resolution: {integrity: sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.14.1
 
-  /@babel/template/7.24.7:
-    resolution: {integrity: sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==}
+  /@babel/template/7.25.9:
+    resolution: {integrity: sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.24.7
-      '@babel/parser': 7.24.7
-      '@babel/types': 7.24.7
+      '@babel/code-frame': 7.26.2
+      '@babel/parser': 7.26.2
+      '@babel/types': 7.26.0
+    dev: true
 
-  /@babel/traverse/7.24.7:
-    resolution: {integrity: sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==}
+  /@babel/traverse/7.25.9:
+    resolution: {integrity: sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.24.7
-      '@babel/generator': 7.24.7
-      '@babel/helper-environment-visitor': 7.24.7
-      '@babel/helper-function-name': 7.24.7
-      '@babel/helper-hoist-variables': 7.24.7
-      '@babel/helper-split-export-declaration': 7.24.7
-      '@babel/parser': 7.24.7
-      '@babel/types': 7.24.7
-      debug: 4.3.5
+      '@babel/code-frame': 7.26.2
+      '@babel/generator': 7.26.2
+      '@babel/parser': 7.26.2
+      '@babel/template': 7.25.9
+      '@babel/types': 7.26.0
+      debug: 4.3.7
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
-  /@babel/types/7.24.7:
-    resolution: {integrity: sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==}
+  /@babel/types/7.26.0:
+    resolution: {integrity: sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-string-parser': 7.24.7
-      '@babel/helper-validator-identifier': 7.24.7
-      to-fast-properties: 2.0.0
+      '@babel/helper-string-parser': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
+    dev: true
 
   /@bcoe/v8-coverage/0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -2336,8 +2308,8 @@ packages:
   /@bentley/icons-generic/1.0.34:
     resolution: {integrity: sha512-IIs1wDcY2oZ8tJ3EZRw0U51M+0ZL3MvwoDYYmhUXaa9/UZqpFoOyLBGaxjirQteWXqTIMm3mFvmC+Nbn1ok4Iw==}
 
-  /@bentley/imodeljs-native/4.7.29:
-    resolution: {integrity: sha512-zJNHKurImoPk+8DbTUFAs6Pph56c1do/S/eFRfqnKPcxQGS6nfvrxBWyEulwmslnt1zMYdB766+myuJlPVXxFw==}
+  /@bentley/imodeljs-native/4.9.35:
+    resolution: {integrity: sha512-45MM6aYmcMpg81SyNtdRZ2z2e+lFSresnrvsPO/28mC/79k1WHk727R8B3OglvR9/Qob6rX0rG1lC+POeodUHQ==}
     requiresBuild: true
 
   /@bentley/react-scripts/5.0.7_pe74uhjrq4tiyv4442ml54dfiu:
@@ -2351,62 +2323,62 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@babel/core': 7.24.7
-      '@itwin/core-webpack-tools': 3.8.0_webpack@5.92.1
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15_zciuhk7ajont242gc253fauh24
+      '@babel/core': 7.26.0
+      '@itwin/core-webpack-tools': 3.8.0_webpack@5.95.0
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15_e3ej43g5iw5szlea4i3o2x6iq4
       '@svgr/webpack': 6.5.1
-      babel-jest: 27.5.1_@babel+core@7.24.7
-      babel-loader: 8.3.0_z5hqyrl7ys5omqq6tawbtvekhm
+      babel-jest: 27.5.1_@babel+core@7.26.0
+      babel-loader: 8.4.1_i3bi27r3gwde5aemtthvmmugoi
       babel-plugin-import-remove-resource-query: 1.0.0
-      babel-plugin-named-asset-import: 0.3.8_@babel+core@7.24.7
+      babel-plugin-named-asset-import: 0.3.8_@babel+core@7.26.0
       babel-preset-react-app: 10.0.1
       bfj: 7.1.0
-      browserslist: 4.23.2
+      browserslist: 4.24.2
       camelcase: 6.3.0
       case-sensitive-paths-webpack-plugin: 2.4.0
-      copy-webpack-plugin: 10.2.4_webpack@5.92.1
-      css-loader: 6.11.0_webpack@5.92.1
-      css-minimizer-webpack-plugin: 3.4.1_webpack@5.92.1
+      copy-webpack-plugin: 10.2.4_webpack@5.95.0
+      css-loader: 6.11.0_webpack@5.95.0
+      css-minimizer-webpack-plugin: 3.4.1_webpack@5.95.0
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
-      eslint: 8.57.0
-      eslint-config-react-app: 7.0.1_rxydg5byhhw2ikqe4ecaedklea
-      eslint-webpack-plugin: 3.2.0_2razpbuuqgklq63beclqevrxh4
-      fast-sass-loader: 2.0.1_sass@1.77.7+webpack@5.92.1
-      file-loader: 6.2.0_webpack@5.92.1
+      eslint: 8.57.1
+      eslint-config-react-app: 7.0.1_l6sf7e4olydjhtf3qe76zuqhfi
+      eslint-webpack-plugin: 3.2.0_23g3mlqifdeyf7a5itkkqemkee
+      fast-sass-loader: 2.0.1_sass@1.80.5+webpack@5.95.0
+      file-loader: 6.2.0_webpack@5.95.0
       fs-extra: 10.1.0
-      html-webpack-plugin: 5.6.0_webpack@5.92.1
+      html-webpack-plugin: 5.6.3_webpack@5.95.0
       identity-obj-proxy: 3.0.0
       jest: 27.5.1
       jest-resolve: 27.5.1
       jest-watch-typeahead: 1.1.0_jest@27.5.1
-      mini-css-extract-plugin: 2.9.0_webpack@5.92.1
-      postcss: 8.4.39
-      postcss-flexbugs-fixes: 5.0.2_postcss@8.4.39
-      postcss-loader: 6.2.1_h7ybz3vosd2sabh3expkxy422u
-      postcss-normalize: 10.0.1_73z3fjs2jrhgsuowbj3qmsq6yu
-      postcss-preset-env: 7.8.3_postcss@8.4.39
+      mini-css-extract-plugin: 2.9.1_webpack@5.95.0
+      postcss: 8.4.47
+      postcss-flexbugs-fixes: 5.0.2_postcss@8.4.47
+      postcss-loader: 6.2.1_ttspydkdwnlpk544tqarzu6cim
+      postcss-normalize: 10.0.1_22bcdb3nr4qkkg7bvewmb25sri
+      postcss-preset-env: 7.8.3_postcss@8.4.47
       prompts: 2.4.2
       react: 18.3.1
       react-app-polyfill: 3.0.0
-      react-dev-utils: 12.0.1_vmohbas7cixbs7dvjlkwhs5g3i
+      react-dev-utils: 12.0.1_z6tosmbba6a4h5dofl3zomc5vu
       react-refresh: 0.11.0
       resolve: 1.22.8
       resolve-url-loader: 4.0.0
-      sass: 1.77.7
-      sass-loader: 12.6.0_sass@1.77.7+webpack@5.92.1
-      semver: 7.6.2
-      source-map-loader: 3.0.2_webpack@5.92.1
-      style-loader: 3.3.4_webpack@5.92.1
+      sass: 1.80.5
+      sass-loader: 12.6.0_sass@1.80.5+webpack@5.95.0
+      semver: 7.6.3
+      source-map-loader: 3.0.2_webpack@5.95.0
+      style-loader: 3.3.4_webpack@5.95.0
       svg-sprite-loader: 6.0.11
-      tailwindcss: 3.4.4
-      terser-webpack-plugin: 5.3.10_webpack@5.92.1
-      ts-jest: 27.1.5_ffc5qouy45v3zjlzng7flfczky
+      tailwindcss: 3.4.14
+      terser-webpack-plugin: 5.3.10_webpack@5.95.0
+      ts-jest: 27.1.5_6i3m6jxo354ochmqovrdrplut4
       typescript: 5.0.4
-      webpack: 5.92.1
-      webpack-dev-server: 4.15.2_webpack@5.92.1
-      webpack-manifest-plugin: 4.1.1_webpack@5.92.1
-      workbox-webpack-plugin: 6.6.0_webpack@5.92.1
+      webpack: 5.95.0
+      webpack-dev-server: 4.15.2_webpack@5.95.0
+      webpack-manifest-plugin: 4.1.1_webpack@5.95.0
+      workbox-webpack-plugin: 6.6.0_webpack@5.95.0
     optionalDependencies:
       fsevents: 2.3.3
     transitivePeerDependencies:
@@ -2446,164 +2418,164 @@ packages:
     resolution: {integrity: sha512-YAYeJ+Xqh7fUou1d1j9XHl44BmsuThiTr4iNrgCQ3J27IbhXsxXDGZ1cXv8Qvs99d4rBbLiSKy3+WZiet32PcQ==}
     dev: true
 
-  /@csstools/postcss-cascade-layers/1.1.1_postcss@8.4.39:
+  /@csstools/postcss-cascade-layers/1.1.1_postcss@8.4.47:
     resolution: {integrity: sha512-+KdYrpKC5TgomQr2DlZF4lDEpHcoxnj5IGddYYfBWJAKfj1JtuHUIqMa+E1pJJ+z3kvDViWMqyqPlG4Ja7amQA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/selector-specificity': 2.2.0_jbx4mus4njtel3ypyfykqgp6rq
-      postcss: 8.4.39
-      postcss-selector-parser: 6.1.0
+      '@csstools/selector-specificity': 2.2.0_j747yjqyvnzekvomyruvypt3ti
+      postcss: 8.4.47
+      postcss-selector-parser: 6.1.2
     dev: true
 
-  /@csstools/postcss-color-function/1.1.1_postcss@8.4.39:
+  /@csstools/postcss-color-function/1.1.1_postcss@8.4.47:
     resolution: {integrity: sha512-Bc0f62WmHdtRDjf5f3e2STwRAl89N2CLb+9iAwzrv4L2hncrbDwnQD9PCq0gtAt7pOI2leIV08HIBUd4jxD8cw==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 1.3.0_postcss@8.4.39
-      postcss: 8.4.39
+      '@csstools/postcss-progressive-custom-properties': 1.3.0_postcss@8.4.47
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-font-format-keywords/1.0.1_postcss@8.4.39:
+  /@csstools/postcss-font-format-keywords/1.0.1_postcss@8.4.47:
     resolution: {integrity: sha512-ZgrlzuUAjXIOc2JueK0X5sZDjCtgimVp/O5CEqTcs5ShWBa6smhWYbS0x5cVc/+rycTDbjjzoP0KTDnUneZGOg==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-hwb-function/1.0.2_postcss@8.4.39:
+  /@csstools/postcss-hwb-function/1.0.2_postcss@8.4.47:
     resolution: {integrity: sha512-YHdEru4o3Rsbjmu6vHy4UKOXZD+Rn2zmkAmLRfPet6+Jz4Ojw8cbWxe1n42VaXQhD3CQUXXTooIy8OkVbUcL+w==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-ic-unit/1.0.1_postcss@8.4.39:
+  /@csstools/postcss-ic-unit/1.0.1_postcss@8.4.47:
     resolution: {integrity: sha512-Ot1rcwRAaRHNKC9tAqoqNZhjdYBzKk1POgWfhN4uCOE47ebGcLRqXjKkApVDpjifL6u2/55ekkpnFcp+s/OZUw==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 1.3.0_postcss@8.4.39
-      postcss: 8.4.39
+      '@csstools/postcss-progressive-custom-properties': 1.3.0_postcss@8.4.47
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-is-pseudo-class/2.0.7_postcss@8.4.39:
+  /@csstools/postcss-is-pseudo-class/2.0.7_postcss@8.4.47:
     resolution: {integrity: sha512-7JPeVVZHd+jxYdULl87lvjgvWldYu+Bc62s9vD/ED6/QTGjy0jy0US/f6BG53sVMTBJ1lzKZFpYmofBN9eaRiA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/selector-specificity': 2.2.0_jbx4mus4njtel3ypyfykqgp6rq
-      postcss: 8.4.39
-      postcss-selector-parser: 6.1.0
+      '@csstools/selector-specificity': 2.2.0_j747yjqyvnzekvomyruvypt3ti
+      postcss: 8.4.47
+      postcss-selector-parser: 6.1.2
     dev: true
 
-  /@csstools/postcss-nested-calc/1.0.0_postcss@8.4.39:
+  /@csstools/postcss-nested-calc/1.0.0_postcss@8.4.47:
     resolution: {integrity: sha512-JCsQsw1wjYwv1bJmgjKSoZNvf7R6+wuHDAbi5f/7MbFhl2d/+v+TvBTU4BJH3G1X1H87dHl0mh6TfYogbT/dJQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-normalize-display-values/1.0.1_postcss@8.4.39:
+  /@csstools/postcss-normalize-display-values/1.0.1_postcss@8.4.47:
     resolution: {integrity: sha512-jcOanIbv55OFKQ3sYeFD/T0Ti7AMXc9nM1hZWu8m/2722gOTxFg7xYu4RDLJLeZmPUVQlGzo4jhzvTUq3x4ZUw==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-oklab-function/1.1.1_postcss@8.4.39:
+  /@csstools/postcss-oklab-function/1.1.1_postcss@8.4.47:
     resolution: {integrity: sha512-nJpJgsdA3dA9y5pgyb/UfEzE7W5Ka7u0CX0/HIMVBNWzWemdcTH3XwANECU6anWv/ao4vVNLTMxhiPNZsTK6iA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 1.3.0_postcss@8.4.39
-      postcss: 8.4.39
+      '@csstools/postcss-progressive-custom-properties': 1.3.0_postcss@8.4.47
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-progressive-custom-properties/1.3.0_postcss@8.4.39:
+  /@csstools/postcss-progressive-custom-properties/1.3.0_postcss@8.4.47:
     resolution: {integrity: sha512-ASA9W1aIy5ygskZYuWams4BzafD12ULvSypmaLJT2jvQ8G0M3I8PRQhC0h7mG0Z3LI05+agZjqSR9+K9yaQQjA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.3
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-stepped-value-functions/1.0.1_postcss@8.4.39:
+  /@csstools/postcss-stepped-value-functions/1.0.1_postcss@8.4.47:
     resolution: {integrity: sha512-dz0LNoo3ijpTOQqEJLY8nyaapl6umbmDcgj4AD0lgVQ572b2eqA1iGZYTTWhrcrHztWDDRAX2DGYyw2VBjvCvQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-text-decoration-shorthand/1.0.0_postcss@8.4.39:
+  /@csstools/postcss-text-decoration-shorthand/1.0.0_postcss@8.4.47:
     resolution: {integrity: sha512-c1XwKJ2eMIWrzQenN0XbcfzckOLLJiczqy+YvfGmzoVXd7pT9FfObiSEfzs84bpE/VqfpEuAZ9tCRbZkZxxbdw==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-trigonometric-functions/1.0.2_postcss@8.4.39:
+  /@csstools/postcss-trigonometric-functions/1.0.2_postcss@8.4.47:
     resolution: {integrity: sha512-woKaLO///4bb+zZC2s80l+7cm07M7268MsyG3M0ActXXEFi6SuhvriQYcb58iiKGbjwwIU7n45iRLEHypB47Og==}
     engines: {node: ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /@csstools/postcss-unset-value/1.0.2_postcss@8.4.39:
+  /@csstools/postcss-unset-value/1.0.2_postcss@8.4.47:
     resolution: {integrity: sha512-c8J4roPBILnelAsdLr4XOAR/GsTm0GJi4XpcfvoWk3U6KiTCqiFYc63KhRMQQX35jYMp4Ao8Ij9+IZRgMfJp1g==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
     dev: true
 
-  /@csstools/selector-specificity/2.2.0_jbx4mus4njtel3ypyfykqgp6rq:
+  /@csstools/selector-specificity/2.2.0_j747yjqyvnzekvomyruvypt3ti:
     resolution: {integrity: sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==}
     engines: {node: ^14 || ^16 || >=18}
     peerDependencies:
       postcss-selector-parser: ^6.0.10
     dependencies:
-      postcss-selector-parser: 6.1.0
+      postcss-selector-parser: 6.1.2
     dev: true
 
   /@electron/get/2.0.3:
     resolution: {integrity: sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==}
     engines: {node: '>=12'}
     dependencies:
-      debug: 4.3.5
+      debug: 4.3.7
       env-paths: 2.2.1
       fs-extra: 8.1.0
       got: 11.8.6
@@ -2614,88 +2586,6 @@ packages:
       global-agent: 3.0.0
     transitivePeerDependencies:
       - supports-color
-
-  /@emotion/babel-plugin/11.11.0:
-    resolution: {integrity: sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==}
-    dependencies:
-      '@babel/helper-module-imports': 7.24.7
-      '@babel/runtime': 7.24.7
-      '@emotion/hash': 0.9.1
-      '@emotion/memoize': 0.8.1
-      '@emotion/serialize': 1.1.4
-      babel-plugin-macros: 3.1.0
-      convert-source-map: 1.9.0
-      escape-string-regexp: 4.0.0
-      find-root: 1.1.0
-      source-map: 0.5.7
-      stylis: 4.2.0
-    transitivePeerDependencies:
-      - supports-color
-
-  /@emotion/cache/11.11.0:
-    resolution: {integrity: sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==}
-    dependencies:
-      '@emotion/memoize': 0.8.1
-      '@emotion/sheet': 1.2.2
-      '@emotion/utils': 1.2.1
-      '@emotion/weak-memoize': 0.3.1
-      stylis: 4.2.0
-
-  /@emotion/hash/0.9.1:
-    resolution: {integrity: sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==}
-
-  /@emotion/memoize/0.8.1:
-    resolution: {integrity: sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==}
-
-  /@emotion/react/11.11.4_3vdbhqr2ncalcx7opnshezpx3q:
-    resolution: {integrity: sha512-t8AjMlF0gHpvvxk5mAtCqR4vmxiGHCeJBaQO6gncUSdklELOgtwjerNY2yuJNfwnc6vi16U/+uMF+afIawJ9iw==}
-    peerDependencies:
-      '@types/react': '*'
-      react: '>=16.8.0'
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@emotion/babel-plugin': 11.11.0
-      '@emotion/cache': 11.11.0
-      '@emotion/serialize': 1.1.4
-      '@emotion/use-insertion-effect-with-fallbacks': 1.0.1_react@18.3.1
-      '@emotion/utils': 1.2.1
-      '@emotion/weak-memoize': 0.3.1
-      '@types/react': 18.3.3
-      hoist-non-react-statics: 3.3.2
-      react: 18.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  /@emotion/serialize/1.1.4:
-    resolution: {integrity: sha512-RIN04MBT8g+FnDwgvIUi8czvr1LU1alUMI05LekWB5DGyTm8cCBMCRpq3GqaiyEDRptEXOyXnvZ58GZYu4kBxQ==}
-    dependencies:
-      '@emotion/hash': 0.9.1
-      '@emotion/memoize': 0.8.1
-      '@emotion/unitless': 0.8.1
-      '@emotion/utils': 1.2.1
-      csstype: 3.1.3
-
-  /@emotion/sheet/1.2.2:
-    resolution: {integrity: sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA==}
-
-  /@emotion/unitless/0.8.1:
-    resolution: {integrity: sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==}
-
-  /@emotion/use-insertion-effect-with-fallbacks/1.0.1_react@18.3.1:
-    resolution: {integrity: sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==}
-    peerDependencies:
-      react: '>=16.8.0'
-    dependencies:
-      react: 18.3.1
-
-  /@emotion/utils/1.2.1:
-    resolution: {integrity: sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg==}
-
-  /@emotion/weak-memoize/0.3.1:
-    resolution: {integrity: sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==}
 
   /@esbuild-plugins/node-globals-polyfill/0.1.1_esbuild@0.13.15:
     resolution: {integrity: sha512-MR0oAA+mlnJWrt1RQVQ+4VYuRJW/P2YmRTv1AsplObyvuBMnPHiizUF95HHYiSsMGLhyGtWufaq2XQg6+iurBg==}
@@ -2715,18 +2605,18 @@ packages:
       rollup-plugin-node-polyfills: 0.2.1
     dev: true
 
-  /@eslint-community/eslint-utils/4.4.0_eslint@8.57.0:
-    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
+  /@eslint-community/eslint-utils/4.4.1_eslint@8.57.1:
+    resolution: {integrity: sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
     dependencies:
-      eslint: 8.57.0
+      eslint: 8.57.1
       eslint-visitor-keys: 3.4.3
     dev: true
 
-  /@eslint-community/regexpp/4.11.0:
-    resolution: {integrity: sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==}
+  /@eslint-community/regexpp/4.12.1:
+    resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
     dev: true
 
@@ -2735,7 +2625,7 @@ packages:
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.5
+      debug: 4.3.7
       espree: 7.3.1
       globals: 13.24.0
       ignore: 4.0.6
@@ -2752,10 +2642,10 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.5
+      debug: 4.3.7
       espree: 9.6.1
       globals: 13.24.0
-      ignore: 5.3.1
+      ignore: 5.3.2
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       minimatch: 3.1.2
@@ -2764,54 +2654,54 @@ packages:
       - supports-color
     dev: true
 
-  /@eslint/js/8.57.0:
-    resolution: {integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==}
+  /@eslint/js/8.57.1:
+    resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@floating-ui/core/1.6.4:
-    resolution: {integrity: sha512-a4IowK4QkXl4SCWTGUR0INAfEOX3wtsYw3rKK5InQEHMGObkR8Xk44qYQD9P4r6HHw0iIfK6GUKECmY8sTkqRA==}
+  /@floating-ui/core/1.6.8:
+    resolution: {integrity: sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==}
     dependencies:
-      '@floating-ui/utils': 0.2.4
+      '@floating-ui/utils': 0.2.8
 
-  /@floating-ui/dom/1.6.7:
-    resolution: {integrity: sha512-wmVfPG5o2xnKDU4jx/m4w5qva9FWHcnZ8BvzEe90D/RpwsJaTAVYPEPdQ8sbr/N8zZTAHlZUTQdqg8ZUbzHmng==}
+  /@floating-ui/dom/1.6.12:
+    resolution: {integrity: sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w==}
     dependencies:
-      '@floating-ui/core': 1.6.4
-      '@floating-ui/utils': 0.2.4
+      '@floating-ui/core': 1.6.8
+      '@floating-ui/utils': 0.2.8
 
-  /@floating-ui/react-dom/2.1.1_nnrd3gsncyragczmpvfhocinkq:
-    resolution: {integrity: sha512-4h84MJt3CHrtG18mGsXuLCHMrug49d7DFkU0RMIyshRveBeyV2hmV/pDaF2Uxtu8kgq5r46llp5E5FQiR0K2Yg==}
+  /@floating-ui/react-dom/2.1.2_nnrd3gsncyragczmpvfhocinkq:
+    resolution: {integrity: sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
-      '@floating-ui/dom': 1.6.7
+      '@floating-ui/dom': 1.6.12
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
 
-  /@floating-ui/react/0.26.19_nnrd3gsncyragczmpvfhocinkq:
-    resolution: {integrity: sha512-Jk6zITdjjIvjO/VdQFvpRaD3qPwOHH6AoDHxjhpy+oK4KFgaSP871HYWUAPdnLmx1gQ+w/pB312co3tVml+BXA==}
+  /@floating-ui/react/0.26.26_nnrd3gsncyragczmpvfhocinkq:
+    resolution: {integrity: sha512-iv2BjdcyoF1j1708Z9CrGtMc9ZZvMPZnDqyB1FrSWYCi+/nlPArUO/u9QhwC4E1Pi4T0g18GZ4W702m0NDh9bw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
-      '@floating-ui/react-dom': 2.1.1_nnrd3gsncyragczmpvfhocinkq
-      '@floating-ui/utils': 0.2.4
+      '@floating-ui/react-dom': 2.1.2_nnrd3gsncyragczmpvfhocinkq
+      '@floating-ui/utils': 0.2.8
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
       tabbable: 6.2.0
 
-  /@floating-ui/utils/0.2.4:
-    resolution: {integrity: sha512-dWO2pw8hhi+WrXq1YJy2yCuWoL20PddgGaqTgVe4cOS9Q6qklXCiA1tJEqX6BEwRNSCP84/afac9hd4MS+zEUA==}
+  /@floating-ui/utils/0.2.8:
+    resolution: {integrity: sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==}
 
-  /@humanwhocodes/config-array/0.11.14:
-    resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
+  /@humanwhocodes/config-array/0.13.0:
+    resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
     deprecated: Use @eslint/config-array instead
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.5
+      debug: 4.3.7
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -2823,7 +2713,7 @@ packages:
     deprecated: Use @eslint/config-array instead
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.5
+      debug: 4.3.7
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -2872,14 +2762,14 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /@itwin/appui-abstract/4.7.4_@itwin+core-bentley@4.7.4:
-    resolution: {integrity: sha512-TdJyrPknK2BoptszkSoFaApyCD1sqi9S7EE8LvEJ8/yLObq7Kma1gno5NXpZ0DnJVWvE16TQv2aRh/Bu2T75xw==}
+  /@itwin/appui-abstract/4.9.5_@itwin+core-bentley@4.9.5:
+    resolution: {integrity: sha512-bFSe3Ewj5SGg5xW7VDjAr4znQQv8h/QkHhhcrTy2JmgRVONurz/PvyY1CeAiQL0wussrEU+t0vvd00zvLBWIgw==}
     peerDependencies:
-      '@itwin/core-bentley': ^4.7.4
+      '@itwin/core-bentley': ^4.9.5
     dependencies:
-      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-bentley': 4.9.5
 
-  /@itwin/appui-layout-react/4.8.3_jscgs7su4cyo55wt5klvj3iepa:
+  /@itwin/appui-layout-react/4.8.3_zs6rif5h5jixp3mcoeld6e43pu:
     resolution: {integrity: sha512-7jyEefXWeOXMxREE5+dON2IJ3KercWz7xkMvHSXzHZARjedHZRZKgrgMM5QETrEsRNDixxp0em23mIzwCpVSRg==}
     peerDependencies:
       '@itwin/appui-abstract': ^3.7.0 || ^4.0.0
@@ -2888,10 +2778,10 @@ packages:
       react: ^17.0.0 || ^18.0.0
       react-dom: ^17.0.0 || ^18.0.0
     dependencies:
-      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-react': 4.15.1_bpptdsfauwdziiwg4uklizbr74
-      '@itwin/itwinui-icons-react': 2.8.0_nnrd3gsncyragczmpvfhocinkq
+      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-react': 4.17.2_b5szh4swag42x6ykxwn6buimra
+      '@itwin/itwinui-icons-react': 2.9.0_nnrd3gsncyragczmpvfhocinkq
       '@itwin/itwinui-variables': 2.1.2
       classnames: 2.3.1
       immer: 9.0.6
@@ -2899,45 +2789,45 @@ packages:
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
       react-transition-group: 4.4.5_nnrd3gsncyragczmpvfhocinkq
-      ts-key-enum: 2.0.12
-      zustand: 4.5.4_djzcoonmr6xkxvxv5wbacldipi
+      ts-key-enum: 2.0.13
+      zustand: 4.5.5_esssjoahjgjy6wmb4kavvr2kri
     transitivePeerDependencies:
       - '@types/react'
 
-  /@itwin/appui-react/4.15.1_yrqai5hl5gvsf4dek6el5aloii:
-    resolution: {integrity: sha512-WwIDI0YgUjnlZjjJBMjWfrNsdcQKvXlu1RAhE8/8FkWejmwhrB+B07+15E4tDvCBAQpEyl1TroQo4pnfOmLpDg==}
+  /@itwin/appui-react/4.17.2_ggnmyqo32cg3w26befg4w43y64:
+    resolution: {integrity: sha512-l84r68gOhkkB1kTyP5PK5q7yasA3awj2xorMVZDOQ5GYJ+fTohDF8u8BTqarrhb6YxsGySTQuma7UTqdW9G6Ug==}
     peerDependencies:
       '@itwin/appui-abstract': ^3.7.0 || ^4.0.0
-      '@itwin/components-react': ^4.15.1
+      '@itwin/components-react': ^4.17.2
       '@itwin/core-bentley': ^3.7.0 || ^4.0.0
       '@itwin/core-common': ^3.7.0 || ^4.0.0
       '@itwin/core-frontend': ^3.7.0 || ^4.0.0
       '@itwin/core-geometry': ^3.7.0 || ^4.0.0
       '@itwin/core-quantity': ^3.7.0 || ^4.0.0
-      '@itwin/core-react': ^4.15.1
+      '@itwin/core-react': ^4.17.2
       '@itwin/core-telemetry': ^3.7.0 || ^4.0.0
-      '@itwin/imodel-components-react': ^4.15.1
+      '@itwin/imodel-components-react': ^4.17.2
       react: ^17.0.0 || ^18.0.0
       react-dom: ^17.0.0 || ^18.0.0
       react-redux: ^7.2.2
       redux: ^4.1.0
     dependencies:
       '@bentley/icons-generic': 1.0.34
-      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/components-react': 4.15.1_jscgs7su4cyo55wt5klvj3iepa
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
-      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
-      '@itwin/core-geometry': 4.7.4
-      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/core-react': 4.15.1_bpptdsfauwdziiwg4uklizbr74
-      '@itwin/core-telemetry': 4.7.4_@itwin+core-geometry@4.7.4
-      '@itwin/imodel-components-react': 4.15.1_avm2jbcgpodgccdhk4zetypeem
-      '@itwin/itwinui-icons-react': 2.8.0_nnrd3gsncyragczmpvfhocinkq
+      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/components-react': 4.17.2_zs6rif5h5jixp3mcoeld6e43pu
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
+      '@itwin/core-geometry': 4.9.5
+      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/core-react': 4.17.2_b5szh4swag42x6ykxwn6buimra
+      '@itwin/core-telemetry': 4.9.5_@itwin+core-geometry@4.9.5
+      '@itwin/imodel-components-react': 4.17.2_inn3jcow7lwqfeofdqhb3etkfi
+      '@itwin/itwinui-icons-react': 2.9.0_nnrd3gsncyragczmpvfhocinkq
       '@itwin/itwinui-illustrations-react': 2.1.0_nnrd3gsncyragczmpvfhocinkq
-      '@itwin/itwinui-react': 3.12.2_psuonouaqi5wuc37nxyknoubym
+      '@itwin/itwinui-react': 3.15.5_vsw25juzkyj7spaf6wjn5upvjq
       '@itwin/itwinui-react-v2': /@itwin/itwinui-react/2.12.26_nnrd3gsncyragczmpvfhocinkq
-      '@itwin/itwinui-variables': 3.2.0
+      '@itwin/itwinui-variables': 3.3.0
       classnames: 2.3.1
       immer: 9.0.6
       lodash: 4.17.21
@@ -2948,36 +2838,36 @@ packages:
       react-transition-group: 4.4.5_nnrd3gsncyragczmpvfhocinkq
       redux: 4.2.1
       rxjs: 7.8.1
-      ts-key-enum: 2.0.12
+      ts-key-enum: 2.0.13
       use-sync-external-store: 1.2.2_react@18.3.1
-      zustand: 4.5.4_djzcoonmr6xkxvxv5wbacldipi
+      zustand: 4.5.5_esssjoahjgjy6wmb4kavvr2kri
     transitivePeerDependencies:
       - '@types/react'
 
-  /@itwin/browser-authorization/1.1.2_7i4fuy3zzvrtjsnyekcav72ie4:
-    resolution: {integrity: sha512-OP27aV5nCYX3t+ux7E2Kzs/YDeMBMLWJFsa/m/u0gStaa+ywccIPCy6yVXMT9S2iB9kaRPrkdtLE2SkrjHndBg==}
+  /@itwin/browser-authorization/1.1.3_uihgl3rfhguqy2f4jpx67fyjwm:
+    resolution: {integrity: sha512-ErFv6QWp4FOR6jRKjKXYqzYTk3+9rOpMRjzsJs+P4QN6AYYeVY38gsIqAsPC7aj8bHpbHPsT2uzo5vw1/aMjlg==}
     peerDependencies:
       '@itwin/core-bentley': ^3.3.0 || ^4.0.0
     dependencies:
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
-      oidc-client-ts: 2.4.0
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      oidc-client-ts: 2.4.1
     transitivePeerDependencies:
       - '@itwin/core-geometry'
     dev: false
 
-  /@itwin/build-tools/4.7.4:
-    resolution: {integrity: sha512-eYMHVgTRfl1f+XGGZOiCWLTXFhd5m2P7hmMl4sI/RLxZ09iibgi8Ze5tqG4jF6ZRA/MCykOEcB/VKiIehogzXA==}
+  /@itwin/build-tools/4.9.5:
+    resolution: {integrity: sha512-cXFXEwUs96get8JDJJOCZ49ffnv5RmtI+boBB4WHXu1fOxR0frDflfQrn/QfM+8faesfZ2wj6NZCRd+ZNrwM4Q==}
     hasBin: true
     dependencies:
-      '@microsoft/api-extractor': 7.40.6
+      '@microsoft/api-extractor': 7.47.11
       chalk: 3.0.0
       cpx2: 3.0.2
       cross-spawn: 7.0.3
       fs-extra: 8.1.0
       glob: 10.4.5
-      mocha: 10.6.0
-      mocha-junit-reporter: 2.2.1_mocha@10.6.0
+      mocha: 10.8.2
+      mocha-junit-reporter: 2.2.1_mocha@10.8.2
       rimraf: 3.0.2
       tree-kill: 1.2.2
       typedoc: 0.25.13_typescript@5.3.3
@@ -2990,18 +2880,18 @@ packages:
       - supports-color
     dev: true
 
-  /@itwin/build-tools/4.7.4_@types+node@18.19.39:
-    resolution: {integrity: sha512-eYMHVgTRfl1f+XGGZOiCWLTXFhd5m2P7hmMl4sI/RLxZ09iibgi8Ze5tqG4jF6ZRA/MCykOEcB/VKiIehogzXA==}
+  /@itwin/build-tools/4.9.5_@types+node@18.19.62:
+    resolution: {integrity: sha512-cXFXEwUs96get8JDJJOCZ49ffnv5RmtI+boBB4WHXu1fOxR0frDflfQrn/QfM+8faesfZ2wj6NZCRd+ZNrwM4Q==}
     hasBin: true
     dependencies:
-      '@microsoft/api-extractor': 7.40.6_@types+node@18.19.39
+      '@microsoft/api-extractor': 7.47.11_@types+node@18.19.62
       chalk: 3.0.0
       cpx2: 3.0.2
       cross-spawn: 7.0.3
       fs-extra: 8.1.0
       glob: 10.4.5
-      mocha: 10.6.0
-      mocha-junit-reporter: 2.2.1_mocha@10.6.0
+      mocha: 10.8.2
+      mocha-junit-reporter: 2.2.1_mocha@10.8.2
       rimraf: 3.0.2
       tree-kill: 1.2.2
       typedoc: 0.25.13_typescript@5.3.3
@@ -3013,85 +2903,78 @@ packages:
       - '@types/node'
       - supports-color
     dev: true
-
-  /@itwin/cloud-agnostic-core/2.2.4:
-    resolution: {integrity: sha512-RDo8m4wmfNQJHQGsiwoFSAzuYFHDTDtgSWE8cAyuLTVRFAUZhoIU7CTvP2auUaa3+2DwAI2Bmh1hOIS6n7AMFg==}
-    peerDependencies:
-      inversify: ^6.0.1
-      reflect-metadata: ^0.1.13
-
-  /@itwin/cloud-agnostic-core/2.2.4_gteov7on4oycvgy3jqh4tz3uta:
-    resolution: {integrity: sha512-RDo8m4wmfNQJHQGsiwoFSAzuYFHDTDtgSWE8cAyuLTVRFAUZhoIU7CTvP2auUaa3+2DwAI2Bmh1hOIS6n7AMFg==}
-    peerDependencies:
-      inversify: ^6.0.1
-      reflect-metadata: ^0.1.13
-    dependencies:
-      inversify: 6.0.2
-      reflect-metadata: 0.1.14
 
   /@itwin/cloud-agnostic-core/2.2.5:
     resolution: {integrity: sha512-pLEWIjQ4Z1kos7z6RWu/kG2lTEyojr906WVGAXKouxA/BobWuUlb1HG1/Zw8+SovA284wauKhHJsydRhYeddIQ==}
     peerDependencies:
       inversify: ^6.0.1
       reflect-metadata: ^0.1.13
-    dev: false
 
-  /@itwin/components-react/4.15.1_jscgs7su4cyo55wt5klvj3iepa:
-    resolution: {integrity: sha512-MgqOwJoO+k+lyHC6NX2e7oGDftsvHAw2LYlQmG6HUwNGu8cLp5Qok7G0Ti+1yf2UtCrz5rA+dZQifB+IDQ1Afw==}
+  /@itwin/cloud-agnostic-core/2.2.5_jfjmifiz2mjvngwcpuojiclrrm:
+    resolution: {integrity: sha512-pLEWIjQ4Z1kos7z6RWu/kG2lTEyojr906WVGAXKouxA/BobWuUlb1HG1/Zw8+SovA284wauKhHJsydRhYeddIQ==}
+    peerDependencies:
+      inversify: ^6.0.1
+      reflect-metadata: ^0.1.13
+    dependencies:
+      inversify: 6.0.3
+      reflect-metadata: 0.1.14
+
+  /@itwin/components-react/4.17.2_zs6rif5h5jixp3mcoeld6e43pu:
+    resolution: {integrity: sha512-EaElyMpBb/cZcJ5N6jjCd06Lv4zzkuD2g83+C3z129uAuTzmvpvHQwd3JnIiYVKWPhc9YefJaWgZpgNwQO/bhQ==}
     peerDependencies:
       '@itwin/appui-abstract': ^3.7.0 || ^4.0.0
       '@itwin/core-bentley': ^3.7.0 || ^4.0.0
-      '@itwin/core-react': ^4.15.1
+      '@itwin/core-react': ^4.17.2
       react: ^17.0.0 || ^18.0.0
       react-dom: ^17.0.0 || ^18.0.0
     dependencies:
       '@bentley/icons-generic': 1.0.34
-      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-react': 4.15.1_bpptdsfauwdziiwg4uklizbr74
-      '@itwin/itwinui-icons-react': 2.8.0_nnrd3gsncyragczmpvfhocinkq
-      '@itwin/itwinui-react': 3.12.2_psuonouaqi5wuc37nxyknoubym
-      '@itwin/itwinui-variables': 3.2.0
+      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-react': 4.17.2_b5szh4swag42x6ykxwn6buimra
+      '@itwin/itwinui-icons-react': 2.9.0_nnrd3gsncyragczmpvfhocinkq
+      '@itwin/itwinui-react': 3.15.5_vsw25juzkyj7spaf6wjn5upvjq
+      '@itwin/itwinui-variables': 3.3.0
       classnames: 2.3.1
       immer: 9.0.6
       linkify-it: 2.2.0
       lodash: 4.17.21
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
-      react-highlight-words: 0.20.0_react@18.3.1
       react-window: 1.8.10_nnrd3gsncyragczmpvfhocinkq
       rxjs: 7.8.1
-      ts-key-enum: 2.0.12
+      ts-key-enum: 2.0.13
     transitivePeerDependencies:
       - '@types/react'
 
-  /@itwin/core-backend/4.7.4_zzr6hivuljmnvzdhcyobjpaqme:
-    resolution: {integrity: sha512-pHWHZdgn3dIuOjiC0eJIo8F3MapkeZBTHIwLJr57M3BJH0kyJ8zRy5fWvK20lE985m6VR7a2SxGcybgRVv4sBg==}
+  /@itwin/core-backend/4.9.5_r6lwpu3senlcflmx65u2gwowne:
+    resolution: {integrity: sha512-ea3P4ldooJGmBZq8Cj0yDtfdQWsGUiYpcn/Z9b1F+BP6oylwYhJA8Eyesc9zLswf+TDeY+G5avdivDeO7gskbw==}
     engines: {node: ^18.0.0 || ^20.0.0}
     peerDependencies:
-      '@itwin/core-bentley': ^4.7.4
-      '@itwin/core-common': ^4.7.4
-      '@itwin/core-geometry': ^4.7.4
+      '@itwin/core-bentley': ^4.9.5
+      '@itwin/core-common': ^4.9.5
+      '@itwin/core-geometry': ^4.9.5
       '@opentelemetry/api': ^1.0.4
     peerDependenciesMeta:
       '@opentelemetry/api':
         optional: true
     dependencies:
-      '@bentley/imodeljs-native': 4.7.29
-      '@itwin/cloud-agnostic-core': 2.2.4_gteov7on4oycvgy3jqh4tz3uta
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
-      '@itwin/core-geometry': 4.7.4
-      '@itwin/core-telemetry': 4.7.4_@itwin+core-geometry@4.7.4
-      '@itwin/object-storage-azure': 2.2.4_gteov7on4oycvgy3jqh4tz3uta
-      '@itwin/object-storage-core': 2.2.4_gteov7on4oycvgy3jqh4tz3uta
-      form-data: 2.5.1
+      '@bentley/imodeljs-native': 4.9.35
+      '@itwin/cloud-agnostic-core': 2.2.5_jfjmifiz2mjvngwcpuojiclrrm
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/core-geometry': 4.9.5
+      '@itwin/core-telemetry': 4.9.5_@itwin+core-geometry@4.9.5
+      '@itwin/object-storage-azure': 2.2.5_jfjmifiz2mjvngwcpuojiclrrm
+      '@itwin/object-storage-core': 2.2.5_jfjmifiz2mjvngwcpuojiclrrm
+      form-data: 2.5.2
       fs-extra: 8.1.0
-      inversify: 6.0.2
+      inversify: 6.0.3
       json5: 2.2.3
+      linebreak: 1.1.0
       multiparty: 4.2.3
       reflect-metadata: 0.1.14
-      semver: 7.6.2
+      semver: 7.6.3
       touch: 3.1.1
       ws: 7.5.10
     transitivePeerDependencies:
@@ -3100,34 +2983,34 @@ packages:
       - supports-color
       - utf-8-validate
 
-  /@itwin/core-bentley/4.7.4:
-    resolution: {integrity: sha512-iwMNTRTV2xtuJVa1QGWyn+XudrLssemvkmaGc3hJXCasqSB8bQfFTYSrYoiNxcjdv9N9i3r27XtC0XNIoL8tTg==}
+  /@itwin/core-bentley/4.9.5:
+    resolution: {integrity: sha512-2cFqJnWKdGyNgZziqYHg4KkYVXD3+f4WQ5xhVPkEYffcOpXXz4yFh8nDOZmhgOLAmJo6KDH2x+uNJembcX6wjQ==}
 
-  /@itwin/core-common/4.7.4_7i4fuy3zzvrtjsnyekcav72ie4:
-    resolution: {integrity: sha512-0Xd2E877gXVDP18YMCzsQU/XdTg6VoPFTwT6zlqTQ5XP6nEIZVQzwR/n3egCLc6bdSY0KoiG8RPajK9p7NqV8g==}
+  /@itwin/core-common/4.9.5_uihgl3rfhguqy2f4jpx67fyjwm:
+    resolution: {integrity: sha512-k3Pfyvm7q17m0ohQpWfBTOsdKCkPNgC0fQCpebs8WMFimoYuuxC2BJwUqKMyRcvesI+eT3pOHJ94DM4PH8i2uw==}
     peerDependencies:
-      '@itwin/core-bentley': ^4.7.4
-      '@itwin/core-geometry': ^4.7.4
+      '@itwin/core-bentley': ^4.9.5
+      '@itwin/core-geometry': ^4.9.5
     dependencies:
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-geometry': 4.7.4
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-geometry': 4.9.5
       flatbuffers: 1.12.0
       js-base64: 3.7.7
 
-  /@itwin/core-electron/4.7.4_hworozxoblmw2cyo32mpk5ebjm:
-    resolution: {integrity: sha512-5G50nqdJw+sih4eR3AjdzK/Q/DVzglxO33THVBu414MVDjaGoemWkUnpQFn3zFMxXWVeJHwCbZG/44hylsATvA==}
+  /@itwin/core-electron/4.9.5_xnnzauzbsosxbhso2acbfdnloq:
+    resolution: {integrity: sha512-0CvmxO1z50xMr+DIS1bc0fPNV+toCwCI0hw/DbMMEuLypt+/rJukm9/44YJybORiC68fYA7e7qbk1Mm/NIkWWg==}
     engines: {node: ^18.0.0 || ^20.0.0}
     peerDependencies:
-      '@itwin/core-backend': ^4.7.4
-      '@itwin/core-bentley': ^4.7.4
-      '@itwin/core-common': ^4.7.4
-      '@itwin/core-frontend': ^4.7.4
-      electron: '>=23.0.0 <31.0.0'
+      '@itwin/core-backend': ^4.9.5
+      '@itwin/core-bentley': ^4.9.5
+      '@itwin/core-common': ^4.9.5
+      '@itwin/core-frontend': ^4.9.5
+      electron: '>=23.0.0 <33.0.0'
     dependencies:
-      '@itwin/core-backend': 4.7.4_zzr6hivuljmnvzdhcyobjpaqme
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
-      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
+      '@itwin/core-backend': 4.9.5_r6lwpu3senlcflmx65u2gwowne
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
       '@openid/appauth': 1.3.2
       electron: 24.8.8
       open: 7.4.2
@@ -3135,11 +3018,11 @@ packages:
     transitivePeerDependencies:
       - debug
 
-  /@itwin/core-extension/4.7.4_ieegwyxugmwu7xrlokpbnlonea:
-    resolution: {integrity: sha512-q73YF9aLQv6bwTQzBUW3bSyxwoYzVhhD8wgUMqovBAEkeYCEfBheQt49lMpuWIzYE2lfh+jt7dAKCcp/0cYE1g==}
+  /@itwin/core-extension/4.9.5_kyionygyo673et7f54wxvz6g2i:
+    resolution: {integrity: sha512-SXoV5ZkK1tRqtxQ2AnRY2J9LYf72pmQNcssw9s9/nTr4cZ6WAPlJWOEE1tiq8zNdm167EzXhQ8dYPQ7DxJoAAQ==}
     dependencies:
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
-      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
     transitivePeerDependencies:
       - '@itwin/appui-abstract'
       - '@itwin/core-bentley'
@@ -3152,27 +3035,27 @@ packages:
       - reflect-metadata
     dev: false
 
-  /@itwin/core-frontend/4.7.4_phc4rse3pm3zzqfro3xbf2awbu:
-    resolution: {integrity: sha512-ZFfT5DQfwAO7xyYMhBN2o24bEHWnDYhZF6zilQn288Q5BeEkkh/fxLp2erAsCoNCvFAcrkjuBu4tZbLOVNPsKQ==}
+  /@itwin/core-frontend/4.9.5_ncnujt6vgqk6xsxosc75g3boci:
+    resolution: {integrity: sha512-fzpVHaCPyf7gACwZNTF2Ov+4idzGF40U0qS8g2Xa8Vm1aaj/jcjFjZDjpmv/db6nYU2Cc30zY3nkmsNWG1bZgA==}
     peerDependencies:
-      '@itwin/appui-abstract': ^4.7.4
-      '@itwin/core-bentley': ^4.7.4
-      '@itwin/core-common': ^4.7.4
-      '@itwin/core-geometry': ^4.7.4
-      '@itwin/core-orbitgt': ^4.7.4
-      '@itwin/core-quantity': ^4.7.4
+      '@itwin/appui-abstract': ^4.9.5
+      '@itwin/core-bentley': ^4.9.5
+      '@itwin/core-common': ^4.9.5
+      '@itwin/core-geometry': ^4.9.5
+      '@itwin/core-orbitgt': ^4.9.5
+      '@itwin/core-quantity': ^4.9.5
     dependencies:
-      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/cloud-agnostic-core': 2.2.4
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
-      '@itwin/core-geometry': 4.7.4
-      '@itwin/core-i18n': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/core-orbitgt': 4.7.4
-      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/core-telemetry': 4.7.4_@itwin+core-geometry@4.7.4
-      '@itwin/object-storage-core': 2.2.4
-      '@itwin/webgl-compatibility': 4.7.4
+      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/cloud-agnostic-core': 2.2.5
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/core-geometry': 4.9.5
+      '@itwin/core-i18n': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/core-orbitgt': 4.9.5
+      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/core-telemetry': 4.9.5_@itwin+core-geometry@4.9.5
+      '@itwin/object-storage-core': 2.2.5
+      '@itwin/webgl-compatibility': 4.9.5
       '@loaders.gl/core': 3.4.15
       '@loaders.gl/draco': 3.4.15
       fuse.js: 3.6.1
@@ -3184,50 +3067,50 @@ packages:
       - inversify
       - reflect-metadata
 
-  /@itwin/core-geometry/4.7.4:
-    resolution: {integrity: sha512-s8t8Kn7SjLqyfOiMhMekmf4Unwmi7ILEvIHODT/Mym8w5lYP43RFQpV0M3Rzm8uYQcF10+r7C+MrpIyRQqL58w==}
+  /@itwin/core-geometry/4.9.5:
+    resolution: {integrity: sha512-o2fe6/yuxo+9I9JS7o1nytv+CZ8XL8a1vVaDRwqqPAMwnHh7qwHgGfD7WuGyn7/NHbjPNv9Srrb9rtOMua8ryg==}
     dependencies:
-      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-bentley': 4.9.5
       flatbuffers: 1.12.0
 
-  /@itwin/core-i18n/4.7.4_@itwin+core-bentley@4.7.4:
-    resolution: {integrity: sha512-mux7dJk84X0Fsswah3n/LNlJcFyPqeXZG+YvtKV5GYaVg2LQOM+fIDL5/fjTiZNFWWKaqMHnA7r2BINwJk/R8g==}
+  /@itwin/core-i18n/4.9.5_@itwin+core-bentley@4.9.5:
+    resolution: {integrity: sha512-fwSc2XqdTTVJpPGvraZ/s5ShTjaa5XxGR4IfD2d2JdF6lJ9FML5SdMizO5Mu0cJUZyGz9lDRWlvPpgBF0lu7IQ==}
     peerDependencies:
-      '@itwin/core-bentley': ^4.7.4
+      '@itwin/core-bentley': ^4.9.5
     dependencies:
-      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-bentley': 4.9.5
       i18next: 21.10.0
       i18next-browser-languagedetector: 6.1.8
       i18next-http-backend: 1.4.5
     transitivePeerDependencies:
       - encoding
 
-  /@itwin/core-markup/4.7.4_aa3bt7vk4zzsxcvhcdi4ojlcwe:
-    resolution: {integrity: sha512-8MHRlaj3MSUNmcYol69lrfveln07JtgGHfAfKaJpE5bq4CDTXekUPZULOmFI8ysM4R2QhFg9ixaTlbFtpZwuag==}
+  /@itwin/core-markup/4.9.5_rsqcs3hzbyxjzpttbshdocpt74:
+    resolution: {integrity: sha512-XisxVLU3LXrwtrREmmqjhXb5SkmGCrC0pJbpb6afHQPj5BeKM70DdSRtArZvBJYmHRCNG+in2FGARiL3tTtA9w==}
     peerDependencies:
-      '@itwin/core-bentley': ^4.7.4
-      '@itwin/core-common': ^4.7.4
-      '@itwin/core-frontend': ^4.7.4
-      '@itwin/core-geometry': ^4.7.4
+      '@itwin/core-bentley': ^4.9.5
+      '@itwin/core-common': ^4.9.5
+      '@itwin/core-frontend': ^4.9.5
+      '@itwin/core-geometry': ^4.9.5
     dependencies:
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
-      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
-      '@itwin/core-geometry': 4.7.4
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
+      '@itwin/core-geometry': 4.9.5
       '@svgdotjs/svg.js': 3.0.13
 
-  /@itwin/core-orbitgt/4.7.4:
-    resolution: {integrity: sha512-f5PVvdRlUragskdDgpw4Q2vVUkFdYfqDr+9Py1Uq3uhKdcGl8s6RaMBJ+o41GgBbGu/3/5oSEMF19iFCZMsz9A==}
+  /@itwin/core-orbitgt/4.9.5:
+    resolution: {integrity: sha512-P3SVR1GrfbCSz330IqDF52HMp50V8VhpCEiBk33SiiqUsISvdfXmt75UhvGDM07KAYF5gvQ+HKO62z5A1+GZmw==}
 
-  /@itwin/core-quantity/4.7.4_@itwin+core-bentley@4.7.4:
-    resolution: {integrity: sha512-CrwTMq8X41MNa2uC+h2XnpkggVXRiqOu8j0mMaG3yVd3//YIEdRDyd23zilFrshdkSChFeTQhFQvm/gPMKgWww==}
+  /@itwin/core-quantity/4.9.5_@itwin+core-bentley@4.9.5:
+    resolution: {integrity: sha512-Dc0zcR/XLu5+aYDmxE4/mukiklKXDtfR0b2SD9h9MQJOeUz0zu6u1o5ozS3WTY8aCJAYSsu0KFS8JJrmLwuoPg==}
     peerDependencies:
-      '@itwin/core-bentley': ^4.7.4
+      '@itwin/core-bentley': ^4.9.5
     dependencies:
-      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-bentley': 4.9.5
 
-  /@itwin/core-react/4.15.1_bpptdsfauwdziiwg4uklizbr74:
-    resolution: {integrity: sha512-agy8StVVAtCshiheNoOQGxgUJzk00ilN5jCA/RfanmA9kx0EQ0FOePFjhbPNDaWY56RCgpYrlFwUv9bh8S5Rvw==}
+  /@itwin/core-react/4.17.2_b5szh4swag42x6ykxwn6buimra:
+    resolution: {integrity: sha512-wXAiFoBrBYEY82JTn0waUcVecpz11SesXxd8zgwl56JAdEJm8aTQx09zm6dbZHC6miBAOgwZqF5IzVzBJZGHGw==}
     peerDependencies:
       '@itwin/appui-abstract': ^3.7.0 || ^4.0.0
       '@itwin/core-bentley': ^3.7.0 || ^4.0.0
@@ -3235,97 +3118,96 @@ packages:
       react-dom: ^17.0.0 || ^18.0.0
     dependencies:
       '@bentley/icons-generic': 1.0.34
-      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/itwinui-icons-react': 2.8.0_nnrd3gsncyragczmpvfhocinkq
-      '@itwin/itwinui-react': 3.12.2_psuonouaqi5wuc37nxyknoubym
-      '@itwin/itwinui-variables': 3.2.0
+      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/itwinui-icons-react': 2.9.0_nnrd3gsncyragczmpvfhocinkq
+      '@itwin/itwinui-react': 3.15.5_vsw25juzkyj7spaf6wjn5upvjq
+      '@itwin/itwinui-variables': 3.3.0
       classnames: 2.3.1
-      dompurify: 2.5.6
+      dompurify: 2.5.7
       lodash: 4.17.21
       react: 18.3.1
       react-autosuggest: 10.1.0_react@18.3.1
       react-dom: 18.3.1_react@18.3.1
       resize-observer-polyfill: 1.5.1
-      ts-key-enum: 2.0.12
+      ts-key-enum: 2.0.13
     transitivePeerDependencies:
       - '@types/react'
 
-  /@itwin/core-telemetry/4.7.4_@itwin+core-geometry@4.7.4:
-    resolution: {integrity: sha512-4z0M4t8ONET66Mg3xRzRQrY2v4p5dNxrfOTghxFEbRWg7iocYN+YLrLXJCQyyAFaJhKaNCq9slqB/sqcaEjZCw==}
+  /@itwin/core-telemetry/4.9.5_@itwin+core-geometry@4.9.5:
+    resolution: {integrity: sha512-MBFQRj8rIlE1BfpzJzAmBhGT1dFQ1BclrVmt1vSTkkjj2XBqL/0WH4/0ij6xVN90LepFfTCQcBeiptc1amIZQA==}
     dependencies:
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
     transitivePeerDependencies:
       - '@itwin/core-geometry'
 
-  /@itwin/core-webpack-tools/3.8.0_webpack@5.92.1:
+  /@itwin/core-webpack-tools/3.8.0_webpack@5.95.0:
     resolution: {integrity: sha512-2QsexfnbO2a+ZpFvtq8qlTUrmXfVCDpaKpbsFOq8eAriRI+J8BlPmr4Y/l1zJlfTXD0dRkDcKl1iYCw1Sj5R1g==}
     peerDependencies:
       webpack: ^5.76.0
     dependencies:
       chalk: 3.0.0
-      copy-webpack-plugin: 11.0.0_webpack@5.92.1
-      file-loader: 6.2.0_webpack@5.92.1
+      copy-webpack-plugin: 11.0.0_webpack@5.95.0
+      file-loader: 6.2.0_webpack@5.95.0
       findup: 0.1.5
       fs-extra: 8.1.0
       glob: 7.2.3
       lodash: 4.17.21
       resolve: 1.19.0
-      source-map-loader: 4.0.2_webpack@5.92.1
-      webpack: 5.92.1
+      source-map-loader: 4.0.2_webpack@5.95.0
+      webpack: 5.95.0
     dev: true
 
-  /@itwin/ecschema-metadata/4.7.4_jokiwfzdpldlrb2ppvojwoxovq:
-    resolution: {integrity: sha512-YuLWJc34yj4g4vrjRWdu2Zv07LmV3/6kSsOoX2QivRNd+gu8z1ThcC+s++VZmzvIP8k9nGs1T3SKN86pz2K8uw==}
+  /@itwin/ecschema-metadata/4.9.5_ht7pcu4cvk5h6sxcpkl7x76mje:
+    resolution: {integrity: sha512-rYIh56N/Ob7lFpdimAvCH/pov44eWcUznRnpWbsfBKNyqTW8SAazr09Bdsf8rLbldOQOe2oav0i7JYvbOF5f7Q==}
     peerDependencies:
-      '@itwin/core-bentley': ^4.7.4
-      '@itwin/core-quantity': ^4.7.4
+      '@itwin/core-bentley': ^4.9.5
+      '@itwin/core-quantity': ^4.9.5
     dependencies:
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
-      almost-equal: 1.1.0
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
 
-  /@itwin/ecschema-rpcinterface-common/4.7.4_bcf6l4a62o6ayq645yaljtfq2i:
-    resolution: {integrity: sha512-ivN3l5OUy4xjv7tJTFYr9/+Vv1BuP9ut3D2sahgupEDQmHKqJP8ptY3QsfYKvb0sSn5wU1XtbRKZzWHgpTZORg==}
+  /@itwin/ecschema-rpcinterface-common/4.9.5_ubcdmbjl4iri5lyyvzc2dtfxiq:
+    resolution: {integrity: sha512-XGuOJpJARewWZ8lDpftxViKvxsFCQCsk2XLmcbyIq/+CYHVdeEHqtiTq7SJ+F9a+5JC/oyvqDJI022uKJ/GFRA==}
     peerDependencies:
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4
-      '@itwin/core-geometry': 4.7.4
-      '@itwin/ecschema-metadata': 4.7.4
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5
+      '@itwin/core-geometry': 4.9.5
+      '@itwin/ecschema-metadata': 4.9.5
     dependencies:
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
-      '@itwin/core-geometry': 4.7.4
-      '@itwin/ecschema-metadata': 4.7.4_jokiwfzdpldlrb2ppvojwoxovq
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/core-geometry': 4.9.5
+      '@itwin/ecschema-metadata': 4.9.5_ht7pcu4cvk5h6sxcpkl7x76mje
     dev: false
 
-  /@itwin/ecschema-rpcinterface-impl/4.7.4_5hmlesdtddppohhn2hwm7h44ha:
-    resolution: {integrity: sha512-pAdxXBIsDlNdAv0hPqE9COJGMtMZA3yu7yUtxoiem0acRcL8sY2GVM3FGWg012ho8nbKTMMhdK6bpExQ2hI1MA==}
+  /@itwin/ecschema-rpcinterface-impl/4.9.5_wkhnl5tbdp3ufasrx26orysshe:
+    resolution: {integrity: sha512-vgIDcHdcipQA4cEYpgm8dEOMvwunQdrCu1CxMCAANriKnbBcNE+YgREDaTQLCvki/MZL2ckrP/4/BHWsd+IOSw==}
     peerDependencies:
-      '@itwin/core-backend': 4.7.4
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4
-      '@itwin/core-geometry': 4.7.4
-      '@itwin/ecschema-metadata': 4.7.4
-      '@itwin/ecschema-rpcinterface-common': 4.7.4
+      '@itwin/core-backend': 4.9.5
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5
+      '@itwin/core-geometry': 4.9.5
+      '@itwin/ecschema-metadata': 4.9.5
+      '@itwin/ecschema-rpcinterface-common': 4.9.5
     dependencies:
-      '@itwin/core-backend': 4.7.4_zzr6hivuljmnvzdhcyobjpaqme
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
-      '@itwin/core-geometry': 4.7.4
-      '@itwin/ecschema-metadata': 4.7.4_jokiwfzdpldlrb2ppvojwoxovq
-      '@itwin/ecschema-rpcinterface-common': 4.7.4_bcf6l4a62o6ayq645yaljtfq2i
+      '@itwin/core-backend': 4.9.5_r6lwpu3senlcflmx65u2gwowne
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/core-geometry': 4.9.5
+      '@itwin/ecschema-metadata': 4.9.5_ht7pcu4cvk5h6sxcpkl7x76mje
+      '@itwin/ecschema-rpcinterface-common': 4.9.5_ubcdmbjl4iri5lyyvzc2dtfxiq
     dev: false
 
-  /@itwin/electron-authorization/0.15.0_4vf3fjdy4loqcqolj5aeocucyi:
+  /@itwin/electron-authorization/0.15.0_a56cjor36hmzwips5mhrqrpbva:
     resolution: {integrity: sha512-NdKsZTlvXlfCWI847nG2vbbFyHtmejnwqixaxR7ZfS8HuVzdO8sbFMqp8NaJmBpLJ4P7IA3WWWEM5Hsb4AteZg==}
     peerDependencies:
       '@itwin/core-bentley': ^3.3.0 || ^4.0.0
       electron: '>=23.0.0 <25.0.0'
     dependencies:
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
       '@openid/appauth': 1.3.2
       electron: 24.8.8
       electron-store: 8.2.0
@@ -3334,29 +3216,29 @@ packages:
       - '@itwin/core-geometry'
       - debug
 
-  /@itwin/express-server/4.7.4_7f6lob4dy5xhizoy2hu6gtyoy4:
-    resolution: {integrity: sha512-Frmkv1eA/Nia85qOPGJKlA1+3B5PltCU2g1W8qZn9o9wEzz4KLSmtOwYW+yXa62D9fHXZY9os5Iu8Ekz1jE8Wg==}
+  /@itwin/express-server/4.9.5_ghqkdihqtcgmxbakiynn72u3oi:
+    resolution: {integrity: sha512-HTVl410Y+LwLo14aLTZ1V5dae5OWFowwFIVmmharmcGRZcu/RWQauZvep+IVE9kHUJWvP9YzEiGeqNe2WLZuHQ==}
     engines: {node: ^18.0.0 || ^20.0.0}
     peerDependencies:
-      '@itwin/core-backend': 4.7.4
-      '@itwin/core-common': 4.7.4
+      '@itwin/core-backend': 4.9.5
+      '@itwin/core-common': 4.9.5
     dependencies:
-      '@itwin/core-backend': 4.7.4_zzr6hivuljmnvzdhcyobjpaqme
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
-      express: 4.19.2
-      express-ws: 5.0.2_express@4.19.2
+      '@itwin/core-backend': 4.9.5_r6lwpu3senlcflmx65u2gwowne
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      express: 4.21.1
+      express-ws: 5.0.2_express@4.21.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
     dev: false
 
-  /@itwin/frontend-devtools/4.7.4_7jxo73lwmrfxldbvkntwilqkhe:
-    resolution: {integrity: sha512-FEvmW05uF1ip8caV5mM+6Wv7jHRYxXaZRFeKNLPqFLtCKdapNT6glOcxtuiRBNHf7hLLhqkfUxU2PEbnbv2fjw==}
+  /@itwin/frontend-devtools/4.9.5_orynrjj7mkimir6kjmara2i7dq:
+    resolution: {integrity: sha512-/2yuOPeXMaVsBd8X5MKu8Qe7WGIu+713fctw+GW8VQloMXTeIuZXFg10OyDSBw185yYz1K+oyE/P5pcpir/cmQ==}
     dependencies:
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
-      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
-      '@itwin/core-geometry': 4.7.4
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
+      '@itwin/core-geometry': 4.9.5
       file-saver: 2.0.5
     transitivePeerDependencies:
       - '@itwin/appui-abstract'
@@ -3374,7 +3256,7 @@ packages:
       react: ^16.13.0 || ^17.0.2
       react-dom: ^16.13.0 || ^17.0.2
     dependencies:
-      '@itwin/itwinui-icons-react': 2.8.0_nnrd3gsncyragczmpvfhocinkq
+      '@itwin/itwinui-icons-react': 2.9.0_nnrd3gsncyragczmpvfhocinkq
       '@itwin/itwinui-react': 2.12.26_nnrd3gsncyragczmpvfhocinkq
       classnames: 2.5.1
       react: 18.3.1
@@ -3382,53 +3264,53 @@ packages:
       react-intersection-observer: 8.34.0_react@18.3.1
     dev: false
 
-  /@itwin/imodel-components-react/4.15.1_avm2jbcgpodgccdhk4zetypeem:
-    resolution: {integrity: sha512-IPMsMQRvadcGdE72vAlv6HQCrdc9oAE5TlFXen5S49XyOeqvCht6k8Eyec6Gt9i+StYYG3Owi5kbJiDuZioOOA==}
+  /@itwin/imodel-components-react/4.17.2_inn3jcow7lwqfeofdqhb3etkfi:
+    resolution: {integrity: sha512-Wj2BfE2h3xIbaiM8KBt/dOuMoVmYhR+FtLS2T0U4VqhoK1E5QtNZqTMPNuyCF7NlfIXX9x0Bg7ZS8nw26vPaZw==}
     peerDependencies:
       '@itwin/appui-abstract': ^3.7.0 || ^4.0.0
-      '@itwin/components-react': ^4.15.1
+      '@itwin/components-react': ^4.17.2
       '@itwin/core-bentley': ^3.7.0 || ^4.0.0
       '@itwin/core-common': ^3.7.0 || ^4.0.0
       '@itwin/core-frontend': ^3.7.0 || ^4.0.0
       '@itwin/core-geometry': ^3.7.0 || ^4.0.0
       '@itwin/core-quantity': ^3.7.0 || ^4.0.0
-      '@itwin/core-react': ^4.15.1
+      '@itwin/core-react': ^4.17.2
       react: ^17.0.0 || ^18.0.0
       react-dom: ^17.0.0 || ^18.0.0
     dependencies:
       '@bentley/icons-generic': 1.0.34
-      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/components-react': 4.15.1_jscgs7su4cyo55wt5klvj3iepa
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
-      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
-      '@itwin/core-geometry': 4.7.4
-      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/core-react': 4.15.1_bpptdsfauwdziiwg4uklizbr74
-      '@itwin/itwinui-icons-react': 2.8.0_nnrd3gsncyragczmpvfhocinkq
-      '@itwin/itwinui-react': 3.12.2_psuonouaqi5wuc37nxyknoubym
-      '@itwin/itwinui-variables': 3.2.0
+      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/components-react': 4.17.2_zs6rif5h5jixp3mcoeld6e43pu
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
+      '@itwin/core-geometry': 4.9.5
+      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/core-react': 4.17.2_b5szh4swag42x6ykxwn6buimra
+      '@itwin/itwinui-icons-react': 2.9.0_nnrd3gsncyragczmpvfhocinkq
+      '@itwin/itwinui-react': 3.15.5_vsw25juzkyj7spaf6wjn5upvjq
+      '@itwin/itwinui-variables': 3.3.0
       classnames: 2.3.1
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
-      ts-key-enum: 2.0.12
+      ts-key-enum: 2.0.13
     transitivePeerDependencies:
       - '@types/react'
 
-  /@itwin/imodels-access-backend/5.2.1_4z423c7twni3c7p4vwjttw7w4q:
-    resolution: {integrity: sha512-A913LDaA6K0va71s3hhqpiIHNUcX7TAIcOt1Qqvu84P57/DdR45fh3+bI0dWY4DqzD3Cu7cnFL9Qw1xSh3qP9w==}
+  /@itwin/imodels-access-backend/5.2.3_3pcl427xpsrwbipdq34svx7mdu:
+    resolution: {integrity: sha512-et2bNOgZWRS7UCChphdf9gTHjUqOj9Pig4xG8VFmKxVc3q+qSNzkvz7ZEbv4NYGg54sq743jxyIeeE8A6/B9aA==}
     peerDependencies:
       '@itwin/core-backend': ^4.0.0
       '@itwin/core-bentley': ^4.0.0
       '@itwin/core-common': ^4.0.0
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@itwin/core-backend': 4.7.4_zzr6hivuljmnvzdhcyobjpaqme
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
-      '@itwin/imodels-access-common': 5.2.1_hex34t7wgxyaranr6ig5prg5pi
-      '@itwin/imodels-client-authoring': 5.8.1
-      axios: 1.7.4
+      '@itwin/core-backend': 4.9.5_r6lwpu3senlcflmx65u2gwowne
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/imodels-access-common': 5.2.3_zddnpq3p4agzvhpjqixaraohjy
+      '@itwin/imodels-client-authoring': 5.9.0
+      axios: 1.7.7
     transitivePeerDependencies:
       - debug
       - inversify
@@ -3436,38 +3318,38 @@ packages:
       - supports-color
     dev: false
 
-  /@itwin/imodels-access-common/5.2.1_hex34t7wgxyaranr6ig5prg5pi:
-    resolution: {integrity: sha512-8pb9P12e5Tmb9nRUz+T9fnFdEdWmFsrYSdjCP+CwBZD8V/G1oeTlk7280YPNyl9XaIZwHhHsocECBsr1yqTM9Q==}
+  /@itwin/imodels-access-common/5.2.3_zddnpq3p4agzvhpjqixaraohjy:
+    resolution: {integrity: sha512-HP3oEe2715rr0EyExBkUgLxrCB6YbkkgiIQc4e8I0zzv/sW+7yygZOC/K/hd+/roTFkdNsiT+W446Bh5cnVuOg==}
     peerDependencies:
       '@itwin/core-bentley': ^4.0.0
       '@itwin/core-common': ^4.0.0
     dependencies:
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
-      '@itwin/imodels-client-management': 5.8.1
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/imodels-client-management': 5.9.0
     transitivePeerDependencies:
       - debug
 
-  /@itwin/imodels-access-frontend/5.2.1_r7pomf6q3izykcd6xffknqbpim:
-    resolution: {integrity: sha512-L2G7R4OAUFSNPkA7hwJcyRkYAvVhi/3nk8SMzfHyBY8FqymXNpjnhGqyKMbbVzNEZFtGU0yQfL/T/3AmarTuVg==}
+  /@itwin/imodels-access-frontend/5.2.3_x7r3qyjan52efy6jnvzj72woaa:
+    resolution: {integrity: sha512-jcfP4WvsTkRfP5r6MYE7FtEN4dw4f249G5TzltAOZGXCtiJjMvCgJ6JKnp6Bz95ZfLgSjZTkhowZGthOTLvuqA==}
     peerDependencies:
       '@itwin/core-bentley': ^4.0.0
       '@itwin/core-common': ^4.0.0
       '@itwin/core-frontend': ^4.0.0
     dependencies:
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
-      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
-      '@itwin/imodels-access-common': 5.2.1_hex34t7wgxyaranr6ig5prg5pi
-      '@itwin/imodels-client-management': 5.8.1
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
+      '@itwin/imodels-access-common': 5.2.3_zddnpq3p4agzvhpjqixaraohjy
+      '@itwin/imodels-client-management': 5.9.0
     transitivePeerDependencies:
       - debug
 
-  /@itwin/imodels-client-authoring/5.8.1:
-    resolution: {integrity: sha512-iRjzQ7xbp9bjEBFTOSYPjUergw9gwB7MAXr7n/VvOkL4UMan6VuQTqgGKDHamelUFbPcXu8ujU225F7QWRUlCQ==}
+  /@itwin/imodels-client-authoring/5.9.0:
+    resolution: {integrity: sha512-f34dKHccffjyukcBTF7bVZuoOvUi61z6sZ43YLcju/K7WS8dUdtkxaoGYe1Ub3lXg/irsAcBnVIr0j8NNYr+Gg==}
     dependencies:
-      '@azure/storage-blob': 12.23.0
-      '@itwin/imodels-client-management': 5.8.1
+      '@azure/storage-blob': 12.25.0
+      '@itwin/imodels-client-management': 5.9.0
       '@itwin/object-storage-azure': 2.2.5
       '@itwin/object-storage-core': 2.2.5
     transitivePeerDependencies:
@@ -3477,10 +3359,10 @@ packages:
       - supports-color
     dev: false
 
-  /@itwin/imodels-client-management/5.8.1:
-    resolution: {integrity: sha512-1L+oJeVColwMaq5fuAuserzABHOKhfEQKBIZnZgPyx93zeOP6ZbBYVnXjgrYBsPKJAJyvAgN/uMD4qdJX/vpIQ==}
+  /@itwin/imodels-client-management/5.9.0:
+    resolution: {integrity: sha512-bmnpST6Eq0D+CsBsLkOBqcxhRYdC9uJ2oONuIVcl1Ii91R82cXMx284UjtsKtXBzO/YKOhXWHFnQTdxQEa/x3w==}
     dependencies:
-      axios: 1.7.4
+      axios: 1.7.7
     transitivePeerDependencies:
       - debug
 
@@ -3488,8 +3370,8 @@ packages:
     resolution: {integrity: sha512-5zXM5WtaXt6X0oWJyjU9ICVMJyvfhXi3qkubwycCdFvH45qnSesmlhaZ5Z1D7I00fXLKdIukwqwTYfUkACZ57A==}
     dev: false
 
-  /@itwin/itwinui-icons-react/2.8.0_nnrd3gsncyragczmpvfhocinkq:
-    resolution: {integrity: sha512-FMXUrDFC7U827/QJNE603+FL6OvIngFss5B9YTSCXcrWuwVLAzJ+sFb+RQ/I1sc19qujYBkZ9asNqlHXM2O4Cg==}
+  /@itwin/itwinui-icons-react/2.9.0_nnrd3gsncyragczmpvfhocinkq:
+    resolution: {integrity: sha512-48oxHUuqEaJOwVRFED0yssfIriX/IQrHd67ffxvEAu7yW1f5a/qFDyImAlwjlzr+4+obBMweshJ8sI+OgziyvA==}
     peerDependencies:
       react: '>=16.8.6'
       react-dom: '>=16.8.6'
@@ -3540,17 +3422,18 @@ packages:
       react-transition-group: 4.4.5_nnrd3gsncyragczmpvfhocinkq
       tippy.js: 6.3.7
 
-  /@itwin/itwinui-react/3.12.2_psuonouaqi5wuc37nxyknoubym:
-    resolution: {integrity: sha512-ARRr8rx3YlBkL02gJ59wt7qVK93/qpB91neXMnXTJ1QkADIl32fUtzOXvx3nlgt9RzBnoj3NbswIm75HQd/joQ==}
+  /@itwin/itwinui-react/3.15.5_vsw25juzkyj7spaf6wjn5upvjq:
+    resolution: {integrity: sha512-AqoFWFGwgZUrGzxn1J8Ea/DKOcXUt0haLjZBQ3lPeCmO6tNQow9NrbHWn+B9KiMAENADwgS9ElqTseDrSRksig==}
     peerDependencies:
       react: '>= 17.0.0 < 19.0.0'
       react-dom: '>=17.0.0 < 19.0.0'
     dependencies:
-      '@floating-ui/react': 0.26.19_nnrd3gsncyragczmpvfhocinkq
+      '@floating-ui/react': 0.26.26_nnrd3gsncyragczmpvfhocinkq
       '@itwin/itwinui-illustrations-react': 2.1.0_nnrd3gsncyragczmpvfhocinkq
-      '@swc/helpers': 0.5.11
+      '@swc/helpers': 0.5.13
+      '@tanstack/react-virtual': 3.10.8_nnrd3gsncyragczmpvfhocinkq
       classnames: 2.5.1
-      jotai: 2.9.0_3vdbhqr2ncalcx7opnshezpx3q
+      jotai: 2.10.1_ryhct6r6jz2fex4xfo2quarxhi
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
       react-table: 7.8.0_react@18.3.1
@@ -3565,10 +3448,10 @@ packages:
   /@itwin/itwinui-variables/2.1.2:
     resolution: {integrity: sha512-bwaoiqJdPvMCEhccXh5jE/uF83IoHaHofURZV62t9BEhKXW0LF+iaAwCPC+G4Sttgs6tUtqEGsPqj5RnbdipsQ==}
 
-  /@itwin/itwinui-variables/3.2.0:
-    resolution: {integrity: sha512-YuJ3IyqRRynQRKPiTz6odF8hVxmAVABxitrqj2VZ1ZtKRVO6EyrWMgZP90cYF1l0EjqzOxG71focaHcZH5C6Ow==}
+  /@itwin/itwinui-variables/3.3.0:
+    resolution: {integrity: sha512-bnMlOaX+0Bh+bFdXD1KWBcsgeQTJDvaOY7HXI3ZIADRFy4qnx70DmRMp7w+ZA1FxrX2XTQNjt+kmcphaXTPGCw==}
 
-  /@itwin/measure-tools-react/0.13.0_hhvtoxm2vupiyzv3tuuiwwirjq:
+  /@itwin/measure-tools-react/0.13.0_i7qwmeovtjabsqcqehc6iw7vpa:
     resolution: {integrity: sha512-Gdog3IxNUR+bU5LZ7FDvUOVUbPOdPrWA0xPfrhhk5bQ7benzT9poU/kZx4R2tAvH/UmJ1/wn80ZLiXCNsJtCBQ==}
     peerDependencies:
       '@itwin/appui-abstract': ^4.0.0
@@ -3585,36 +3468,20 @@ packages:
       redux: ^4.2.1
     dependencies:
       '@bentley/icons-generic-webfont': 1.0.34
-      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/appui-layout-react': 4.8.3_jscgs7su4cyo55wt5klvj3iepa
-      '@itwin/appui-react': 4.15.1_yrqai5hl5gvsf4dek6el5aloii
-      '@itwin/components-react': 4.15.1_jscgs7su4cyo55wt5klvj3iepa
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
-      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
-      '@itwin/core-geometry': 4.7.4
-      '@itwin/core-react': 4.15.1_bpptdsfauwdziiwg4uklizbr74
-      '@itwin/core-telemetry': 4.7.4_@itwin+core-geometry@4.7.4
+      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/appui-layout-react': 4.8.3_zs6rif5h5jixp3mcoeld6e43pu
+      '@itwin/appui-react': 4.17.2_ggnmyqo32cg3w26befg4w43y64
+      '@itwin/components-react': 4.17.2_zs6rif5h5jixp3mcoeld6e43pu
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
+      '@itwin/core-geometry': 4.9.5
+      '@itwin/core-react': 4.17.2_b5szh4swag42x6ykxwn6buimra
+      '@itwin/core-telemetry': 4.9.5_@itwin+core-geometry@4.9.5
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
       redux: 4.2.1
     dev: false
-
-  /@itwin/object-storage-azure/2.2.4_gteov7on4oycvgy3jqh4tz3uta:
-    resolution: {integrity: sha512-mJjX090FBR//tqQfCjV01qYQsiU0wv2x+XTDx8sA+b8mQqYUHdCgeD55ZLecCQRihU0Aebd1qw3PadrLuv0GeQ==}
-    peerDependencies:
-      inversify: ^6.0.1
-      reflect-metadata: ^0.1.13
-    dependencies:
-      '@azure/core-paging': 1.6.2
-      '@azure/storage-blob': 12.23.0
-      '@itwin/cloud-agnostic-core': 2.2.4_gteov7on4oycvgy3jqh4tz3uta
-      '@itwin/object-storage-core': 2.2.4_gteov7on4oycvgy3jqh4tz3uta
-      inversify: 6.0.2
-      reflect-metadata: 0.1.14
-    transitivePeerDependencies:
-      - debug
-      - supports-color
 
   /@itwin/object-storage-azure/2.2.5:
     resolution: {integrity: sha512-LvnQupvyK28UhIimnEnZqKoBRSMwl3cw8wJ30mYu0UD5c+xuKAaphFCy79QXF2mENqC68uh0JKrFbaSAphwDHQ==}
@@ -3623,7 +3490,7 @@ packages:
       reflect-metadata: ^0.1.13
     dependencies:
       '@azure/core-paging': 1.6.2
-      '@azure/storage-blob': 12.23.0
+      '@azure/storage-blob': 12.25.0
       '@itwin/cloud-agnostic-core': 2.2.5
       '@itwin/object-storage-core': 2.2.5
     transitivePeerDependencies:
@@ -3631,29 +3498,21 @@ packages:
       - supports-color
     dev: false
 
-  /@itwin/object-storage-core/2.2.4:
-    resolution: {integrity: sha512-aZ4NRWFuukKrYdlF/kPepQ5JnpOe/DR3XlI5QwV/y4SV6HZaGyNj4iLL9DEUnCNGTMwTtTRAhOMsc8agqV0Eng==}
+  /@itwin/object-storage-azure/2.2.5_jfjmifiz2mjvngwcpuojiclrrm:
+    resolution: {integrity: sha512-LvnQupvyK28UhIimnEnZqKoBRSMwl3cw8wJ30mYu0UD5c+xuKAaphFCy79QXF2mENqC68uh0JKrFbaSAphwDHQ==}
     peerDependencies:
       inversify: ^6.0.1
       reflect-metadata: ^0.1.13
     dependencies:
-      '@itwin/cloud-agnostic-core': 2.2.4
-      axios: 1.7.4
-    transitivePeerDependencies:
-      - debug
-
-  /@itwin/object-storage-core/2.2.4_gteov7on4oycvgy3jqh4tz3uta:
-    resolution: {integrity: sha512-aZ4NRWFuukKrYdlF/kPepQ5JnpOe/DR3XlI5QwV/y4SV6HZaGyNj4iLL9DEUnCNGTMwTtTRAhOMsc8agqV0Eng==}
-    peerDependencies:
-      inversify: ^6.0.1
-      reflect-metadata: ^0.1.13
-    dependencies:
-      '@itwin/cloud-agnostic-core': 2.2.4_gteov7on4oycvgy3jqh4tz3uta
-      axios: 1.7.4
-      inversify: 6.0.2
+      '@azure/core-paging': 1.6.2
+      '@azure/storage-blob': 12.25.0
+      '@itwin/cloud-agnostic-core': 2.2.5_jfjmifiz2mjvngwcpuojiclrrm
+      '@itwin/object-storage-core': 2.2.5_jfjmifiz2mjvngwcpuojiclrrm
+      inversify: 6.0.3
       reflect-metadata: 0.1.14
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   /@itwin/object-storage-core/2.2.5:
     resolution: {integrity: sha512-IaGryht2Sg2piCVyrnzfTnxSClhi2k8Xv+OxFD2ARvd+J2o3XFgo5EJBezNe1gVz60+9tuqlczIU6blxfbX05g==}
@@ -3662,48 +3521,60 @@ packages:
       reflect-metadata: ^0.1.13
     dependencies:
       '@itwin/cloud-agnostic-core': 2.2.5
-      axios: 1.7.4
+      axios: 1.7.7
     transitivePeerDependencies:
       - debug
-    dev: false
 
-  /@itwin/presentation-backend/4.7.4_nztxufmverfbgaq2tic42bdzqu:
-    resolution: {integrity: sha512-kQzkSH003/mig1r3tVLhyzqinqQBIHfaxw1f9d1pfeSEw4XDzWgDjc0q40rnREh0moQdOnHZ50VJNzsl6SwZLg==}
+  /@itwin/object-storage-core/2.2.5_jfjmifiz2mjvngwcpuojiclrrm:
+    resolution: {integrity: sha512-IaGryht2Sg2piCVyrnzfTnxSClhi2k8Xv+OxFD2ARvd+J2o3XFgo5EJBezNe1gVz60+9tuqlczIU6blxfbX05g==}
     peerDependencies:
-      '@itwin/core-backend': ^4.7.4
-      '@itwin/core-bentley': ^4.7.4
-      '@itwin/core-common': ^4.7.4
-      '@itwin/core-quantity': ^4.7.4
-      '@itwin/ecschema-metadata': ^4.7.4
-      '@itwin/presentation-common': ^4.7.4
+      inversify: ^6.0.1
+      reflect-metadata: ^0.1.13
     dependencies:
-      '@itwin/core-backend': 4.7.4_zzr6hivuljmnvzdhcyobjpaqme
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
-      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/ecschema-metadata': 4.7.4_jokiwfzdpldlrb2ppvojwoxovq
-      '@itwin/presentation-common': 4.7.4_jrcxtioaccikuahb3i3h6f5rhe
+      '@itwin/cloud-agnostic-core': 2.2.5_jfjmifiz2mjvngwcpuojiclrrm
+      axios: 1.7.7
+      inversify: 6.0.3
+      reflect-metadata: 0.1.14
+    transitivePeerDependencies:
+      - debug
+
+  /@itwin/presentation-backend/4.9.5_6poatpavnnrtfvnacw25xntdke:
+    resolution: {integrity: sha512-Grb1f30l4u30sT9/V+KHx1gfWmj+irjNWeo13BPC1nh2EVcklZdBQaSxQynoBZUZDlPzYpucwf+KBMHnM4YOEQ==}
+    peerDependencies:
+      '@itwin/core-backend': ^4.9.5
+      '@itwin/core-bentley': ^4.9.5
+      '@itwin/core-common': ^4.9.5
+      '@itwin/core-quantity': ^4.9.5
+      '@itwin/ecschema-metadata': ^4.9.5
+      '@itwin/presentation-common': ^4.9.5
+    dependencies:
+      '@itwin/core-backend': 4.9.5_r6lwpu3senlcflmx65u2gwowne
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/ecschema-metadata': 4.9.5_ht7pcu4cvk5h6sxcpkl7x76mje
+      '@itwin/presentation-common': 4.9.5_752sgixgtdkx2uobp37xqv5rci
       object-hash: 1.3.1
       rxjs: 7.8.1
       rxjs-for-await: 1.0.0_rxjs@7.8.1
-      semver: 7.6.2
+      semver: 7.6.3
     dev: false
 
-  /@itwin/presentation-common/4.7.4_jrcxtioaccikuahb3i3h6f5rhe:
-    resolution: {integrity: sha512-Qujt2KSrYVS/OzVsRn6psuI7WqNM54FAaAHc+eq+XEIy+fffe+u3+D0GgjSVNN9g53y1Uo3+KqMWU0HxQ2yqWA==}
+  /@itwin/presentation-common/4.9.5_752sgixgtdkx2uobp37xqv5rci:
+    resolution: {integrity: sha512-8apEmM7f7apGzxpR93BLiJ4vber36sjjXdc+fHg2tS5M+lHJiLnaQtV+IS/kKnbFu5nhJS22SBlmme8Giz4aWQ==}
     peerDependencies:
-      '@itwin/core-bentley': ^4.7.4
-      '@itwin/core-common': ^4.7.4
-      '@itwin/core-quantity': ^4.7.4
-      '@itwin/ecschema-metadata': ^4.7.4
+      '@itwin/core-bentley': ^4.9.5
+      '@itwin/core-common': ^4.9.5
+      '@itwin/core-quantity': ^4.9.5
+      '@itwin/ecschema-metadata': ^4.9.5
     dependencies:
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
-      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/ecschema-metadata': 4.7.4_jokiwfzdpldlrb2ppvojwoxovq
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/ecschema-metadata': 4.9.5_ht7pcu4cvk5h6sxcpkl7x76mje
 
-  /@itwin/presentation-components/5.4.1_coeiqitrdc3kbyoxwt3ak4fycm:
-    resolution: {integrity: sha512-o1ysqcbyVAWHyYTGVisFNfbix7GJdXp69c3QAeX/Xv2K0AS1ce2qYDEQCGwxwL1qIseIBbq9pZXADYjf9GH2bQ==}
+  /@itwin/presentation-components/5.6.0_hb7vovirygu74f3smprdxccedu:
+    resolution: {integrity: sha512-bm3niBLKxO8KLjLETtXss74f0VBo4lAZinv2Oa4pfruU6wxYKmQURZ5Syha95lpDSYbahpcS69ioJG2SDHvshg==}
     peerDependencies:
       '@itwin/appui-abstract': ^4.4.0
       '@itwin/components-react': ^4.9.0
@@ -3720,82 +3591,72 @@ packages:
       react: ^17.0.0 || ^18.0.0
       react-dom: ^17.0.0 || ^18.0.0
     dependencies:
-      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/components-react': 4.15.1_jscgs7su4cyo55wt5klvj3iepa
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
-      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
-      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/core-react': 4.15.1_bpptdsfauwdziiwg4uklizbr74
-      '@itwin/ecschema-metadata': 4.7.4_jokiwfzdpldlrb2ppvojwoxovq
-      '@itwin/imodel-components-react': 4.15.1_avm2jbcgpodgccdhk4zetypeem
-      '@itwin/itwinui-icons-react': 2.8.0_nnrd3gsncyragczmpvfhocinkq
+      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/components-react': 4.17.2_zs6rif5h5jixp3mcoeld6e43pu
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
+      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/core-react': 4.17.2_b5szh4swag42x6ykxwn6buimra
+      '@itwin/ecschema-metadata': 4.9.5_ht7pcu4cvk5h6sxcpkl7x76mje
+      '@itwin/imodel-components-react': 4.17.2_inn3jcow7lwqfeofdqhb3etkfi
+      '@itwin/itwinui-icons-react': 2.9.0_nnrd3gsncyragczmpvfhocinkq
       '@itwin/itwinui-illustrations-react': 2.1.0_nnrd3gsncyragczmpvfhocinkq
-      '@itwin/itwinui-react': 2.12.26_nnrd3gsncyragczmpvfhocinkq
-      '@itwin/presentation-common': 4.7.4_jrcxtioaccikuahb3i3h6f5rhe
-      '@itwin/presentation-frontend': 4.7.4_lbci6e5ivpkspr33wpe53pcp5i
+      '@itwin/presentation-common': 4.9.5_752sgixgtdkx2uobp37xqv5rci
+      '@itwin/presentation-frontend': 4.9.5_cfzxbnb6dite7ncbt3vw277mvu
       classnames: 2.5.1
       fast-deep-equal: 3.1.3
-      fast-sort: 3.4.0
+      fast-sort: 3.4.1
       micro-memoize: 4.1.2
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
-      react-error-boundary: 4.0.13_react@18.3.1
-      react-select: 5.7.0_psuonouaqi5wuc37nxyknoubym
-      react-select-async-paginate: 0.7.2_kipqsbdvtmv5eumhayztwa7ftm
+      react-error-boundary: 4.1.2_react@18.3.1
       rxjs: 7.8.1
-    transitivePeerDependencies:
-      - '@types/react'
-      - supports-color
-
-  /@itwin/presentation-components/5.4.1_tr757zhbqqbt4rcaxvlnctg2de:
-    resolution: {integrity: sha512-o1ysqcbyVAWHyYTGVisFNfbix7GJdXp69c3QAeX/Xv2K0AS1ce2qYDEQCGwxwL1qIseIBbq9pZXADYjf9GH2bQ==}
-    peerDependencies:
-      '@itwin/appui-abstract': ^4.4.0
-      '@itwin/components-react': ^4.9.0
-      '@itwin/core-bentley': ^4.4.0
-      '@itwin/core-common': ^4.4.0
-      '@itwin/core-frontend': ^4.4.0
-      '@itwin/core-quantity': ^4.4.0
-      '@itwin/core-react': ^4.9.0
-      '@itwin/ecschema-metadata': ^4.4.0
-      '@itwin/imodel-components-react': ^4.9.0
-      '@itwin/itwinui-react': ^3.0.0
-      '@itwin/presentation-common': ^4.4.0
-      '@itwin/presentation-frontend': ^4.4.0
-      react: ^17.0.0 || ^18.0.0
-      react-dom: ^17.0.0 || ^18.0.0
-    dependencies:
-      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/components-react': 4.15.1_jscgs7su4cyo55wt5klvj3iepa
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
-      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
-      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/core-react': 4.15.1_bpptdsfauwdziiwg4uklizbr74
-      '@itwin/ecschema-metadata': 4.7.4_jokiwfzdpldlrb2ppvojwoxovq
-      '@itwin/imodel-components-react': 4.15.1_avm2jbcgpodgccdhk4zetypeem
-      '@itwin/itwinui-icons-react': 2.8.0_nnrd3gsncyragczmpvfhocinkq
-      '@itwin/itwinui-illustrations-react': 2.1.0_nnrd3gsncyragczmpvfhocinkq
-      '@itwin/presentation-common': 4.7.4_jrcxtioaccikuahb3i3h6f5rhe
-      '@itwin/presentation-frontend': 4.7.4_lbci6e5ivpkspr33wpe53pcp5i
-      classnames: 2.5.1
-      fast-deep-equal: 3.1.3
-      fast-sort: 3.4.0
-      micro-memoize: 4.1.2
-      react: 18.3.1
-      react-dom: 18.3.1_react@18.3.1
-      react-error-boundary: 4.0.13_react@18.3.1
-      react-select: 5.7.0_psuonouaqi5wuc37nxyknoubym
-      react-select-async-paginate: 0.7.2_kipqsbdvtmv5eumhayztwa7ftm
-      rxjs: 7.8.1
-    transitivePeerDependencies:
-      - '@types/react'
-      - supports-color
     dev: true
 
-  /@itwin/presentation-core-interop/0.2.4_rll2n26bhzrezeyt23jhdcbtsy:
-    resolution: {integrity: sha512-udofwj3KXjDIgW2FxJ/hblUNk/VQBZff/3eLjZUP3q2Jl6N116w0AqTP00aL/5p1RP2+E1yebP6gSno2iRS/EQ==}
+  /@itwin/presentation-components/5.6.0_pgm6v4yzke2vvcj2rwx47ufaoy:
+    resolution: {integrity: sha512-bm3niBLKxO8KLjLETtXss74f0VBo4lAZinv2Oa4pfruU6wxYKmQURZ5Syha95lpDSYbahpcS69ioJG2SDHvshg==}
+    peerDependencies:
+      '@itwin/appui-abstract': ^4.4.0
+      '@itwin/components-react': ^4.9.0
+      '@itwin/core-bentley': ^4.4.0
+      '@itwin/core-common': ^4.4.0
+      '@itwin/core-frontend': ^4.4.0
+      '@itwin/core-quantity': ^4.4.0
+      '@itwin/core-react': ^4.9.0
+      '@itwin/ecschema-metadata': ^4.4.0
+      '@itwin/imodel-components-react': ^4.9.0
+      '@itwin/itwinui-react': ^3.0.0
+      '@itwin/presentation-common': ^4.4.0
+      '@itwin/presentation-frontend': ^4.4.0
+      react: ^17.0.0 || ^18.0.0
+      react-dom: ^17.0.0 || ^18.0.0
+    dependencies:
+      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/components-react': 4.17.2_zs6rif5h5jixp3mcoeld6e43pu
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
+      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/core-react': 4.17.2_b5szh4swag42x6ykxwn6buimra
+      '@itwin/ecschema-metadata': 4.9.5_ht7pcu4cvk5h6sxcpkl7x76mje
+      '@itwin/imodel-components-react': 4.17.2_inn3jcow7lwqfeofdqhb3etkfi
+      '@itwin/itwinui-icons-react': 2.9.0_nnrd3gsncyragczmpvfhocinkq
+      '@itwin/itwinui-illustrations-react': 2.1.0_nnrd3gsncyragczmpvfhocinkq
+      '@itwin/itwinui-react': 2.12.26_nnrd3gsncyragczmpvfhocinkq
+      '@itwin/presentation-common': 4.9.5_752sgixgtdkx2uobp37xqv5rci
+      '@itwin/presentation-frontend': 4.9.5_cfzxbnb6dite7ncbt3vw277mvu
+      classnames: 2.5.1
+      fast-deep-equal: 3.1.3
+      fast-sort: 3.4.1
+      micro-memoize: 4.1.2
+      react: 18.3.1
+      react-dom: 18.3.1_react@18.3.1
+      react-error-boundary: 4.1.2_react@18.3.1
+      rxjs: 7.8.1
+
+  /@itwin/presentation-core-interop/0.2.7_tm7n22tj7qb4kxylpvuy237mmy:
+    resolution: {integrity: sha512-HBf8335imHgiXiAvtUmStHJzaYt0O4cXJYRZyjX9nMvy9P4Y0ne2gSlugYOUx4FOq1hMJ6qsnpyI89vWVb1Fjw==}
     peerDependencies:
       '@itwin/core-bentley': ^4.1.0
       '@itwin/core-common': ^4.1.0
@@ -3803,31 +3664,31 @@ packages:
       '@itwin/core-quantity': ^4.1.0
       '@itwin/ecschema-metadata': ^4.1.0
     dependencies:
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
-      '@itwin/core-geometry': 4.7.4
-      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/ecschema-metadata': 4.7.4_jokiwfzdpldlrb2ppvojwoxovq
-      '@itwin/presentation-shared': 0.3.2
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/core-geometry': 4.9.5
+      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/ecschema-metadata': 4.9.5_ht7pcu4cvk5h6sxcpkl7x76mje
+      '@itwin/presentation-shared': 0.5.0
       rxjs: 7.8.1
     dev: false
 
-  /@itwin/presentation-frontend/4.7.4_lbci6e5ivpkspr33wpe53pcp5i:
-    resolution: {integrity: sha512-o5ub8zPC8dkNOAwUGJMt0F0C8zUIqQyBRSGNJH5BJZE1tBnZlMzuEW4aY5fynesJSEoGUwoCMyjB8PtAZN54ug==}
+  /@itwin/presentation-frontend/4.9.5_cfzxbnb6dite7ncbt3vw277mvu:
+    resolution: {integrity: sha512-e9gZqAQaotuzeAtW0avTZvYBbY/np6B3jZjHvlo+E3e0wpgqWi+UK0bg5GbMToa2lq6wLO7Xj0xnhbHMxOS34A==}
     peerDependencies:
-      '@itwin/core-bentley': ^4.7.4
-      '@itwin/core-common': ^4.7.4
-      '@itwin/core-frontend': ^4.7.4
-      '@itwin/core-quantity': ^4.7.4
-      '@itwin/ecschema-metadata': ^4.7.4
-      '@itwin/presentation-common': ^4.7.4
+      '@itwin/core-bentley': ^4.9.5
+      '@itwin/core-common': ^4.9.5
+      '@itwin/core-frontend': ^4.9.5
+      '@itwin/core-quantity': ^4.9.5
+      '@itwin/ecschema-metadata': ^4.9.5
+      '@itwin/presentation-common': ^4.9.5
     dependencies:
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-common': 4.7.4_7i4fuy3zzvrtjsnyekcav72ie4
-      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
-      '@itwin/core-quantity': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/ecschema-metadata': 4.7.4_jokiwfzdpldlrb2ppvojwoxovq
-      '@itwin/presentation-common': 4.7.4_jrcxtioaccikuahb3i3h6f5rhe
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
+      '@itwin/core-quantity': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/ecschema-metadata': 4.9.5_ht7pcu4cvk5h6sxcpkl7x76mje
+      '@itwin/presentation-common': 4.9.5_752sgixgtdkx2uobp37xqv5rci
       '@itwin/unified-selection': 0.1.0
       rxjs: 7.8.1
       rxjs-for-await: 1.0.0_rxjs@7.8.1
@@ -3835,55 +3696,71 @@ packages:
   /@itwin/presentation-shared/0.3.2:
     resolution: {integrity: sha512-wrb1JiHsQmK/RhdpfQmDUkgbrGz2Y3VzpmA8R3Jr9lYuaW46f6BrlpUemY+V6tE9Gl5enkOMoLPDxYymKPiERA==}
     dependencies:
-      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-bentley': 4.9.5
     dev: false
 
-  /@itwin/property-grid-react/1.10.0_qjr4doayn7cutuokumbiwhomja:
-    resolution: {integrity: sha512-n5o+NnH8tGvLTkEHls6uZ7SmHBFby5LkZCVAcrY6cFsVD+tceIOZzgiIJbsEp/+OANGY3AnkAdg76yOrVQAxOg==}
+  /@itwin/presentation-shared/0.4.1:
+    resolution: {integrity: sha512-F/IBTZoMvCn23QJRkFwuXGHrDTNGuibKSHjLa7bFQqU9yZjbjkyQklBYxppdrvkZNh4VS2QjCt+I88g85bxpDw==}
+    dependencies:
+      '@itwin/core-bentley': 4.9.5
+    dev: false
+
+  /@itwin/presentation-shared/0.5.0:
+    resolution: {integrity: sha512-8mFpRE3Fzr9xKz3JnWQ/Wa36+v/2EtxYorKFUwna9f6XbRtRdzlNcI46ROjKkuDeJuDQZSTzSKew9FwR7EcVgg==}
+    dependencies:
+      '@itwin/core-bentley': 4.9.5
+    dev: false
+
+  /@itwin/property-grid-react/1.13.0_ogdchnjgcc3nlmep57rhegv4nu:
+    resolution: {integrity: sha512-rdGDkrD054B9czwkfb7Rahwb1ScC/Es9DFD2JjPDEgLO/qk3juDbq9y9akynhP0kPOisHYCo/bjbm12spGr/sg==}
     peerDependencies:
       '@itwin/appui-abstract': ^4.0.0
       '@itwin/appui-react': ^4.3.0
       '@itwin/components-react': ^4.3.0
       '@itwin/core-bentley': ^4.0.0
+      '@itwin/core-common': ^4.0.0
       '@itwin/core-frontend': ^4.0.0
       '@itwin/core-react': ^4.3.0
+      '@itwin/presentation-common': ^4.0.0
       '@itwin/presentation-components': ^4.0.0 || ^5.0.0
       '@itwin/presentation-frontend': ^4.0.0
       react: ^17.0.0 || ^18.0.0
       react-dom: ^17.0.0 || ^18.0.0
     dependencies:
-      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/appui-react': 4.15.1_yrqai5hl5gvsf4dek6el5aloii
-      '@itwin/components-react': 4.15.1_jscgs7su4cyo55wt5klvj3iepa
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
-      '@itwin/core-react': 4.15.1_bpptdsfauwdziiwg4uklizbr74
-      '@itwin/itwinui-icons-react': 2.8.0_nnrd3gsncyragczmpvfhocinkq
+      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/appui-react': 4.17.2_ggnmyqo32cg3w26befg4w43y64
+      '@itwin/components-react': 4.17.2_zs6rif5h5jixp3mcoeld6e43pu
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-common': 4.9.5_uihgl3rfhguqy2f4jpx67fyjwm
+      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
+      '@itwin/core-react': 4.17.2_b5szh4swag42x6ykxwn6buimra
+      '@itwin/itwinui-icons-react': 2.9.0_nnrd3gsncyragczmpvfhocinkq
       '@itwin/itwinui-illustrations-react': 2.1.0_nnrd3gsncyragczmpvfhocinkq
-      '@itwin/itwinui-react': 3.12.2_psuonouaqi5wuc37nxyknoubym
-      '@itwin/presentation-components': 5.4.1_coeiqitrdc3kbyoxwt3ak4fycm
-      '@itwin/presentation-frontend': 4.7.4_lbci6e5ivpkspr33wpe53pcp5i
+      '@itwin/itwinui-react': 3.15.5_vsw25juzkyj7spaf6wjn5upvjq
+      '@itwin/presentation-common': 4.9.5_752sgixgtdkx2uobp37xqv5rci
+      '@itwin/presentation-components': 5.6.0_pgm6v4yzke2vvcj2rwx47ufaoy
+      '@itwin/presentation-frontend': 4.9.5_cfzxbnb6dite7ncbt3vw277mvu
       classnames: 2.5.1
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
-      react-error-boundary: 4.0.13_react@18.3.1
+      react-error-boundary: 4.1.2_react@18.3.1
     transitivePeerDependencies:
       - '@types/react'
     dev: false
 
-  /@itwin/reality-data-client/1.2.1_@itwin+core-bentley@4.7.4:
+  /@itwin/reality-data-client/1.2.1_@itwin+core-bentley@4.9.5:
     resolution: {integrity: sha512-pNpnO1tbsM1HwyZcr6UkZLyMczNcYFHqsnREmjYJ4GIeCMdrWKGbH5ar4hyajqc/ZkV9zO4FXFMYgQx3yKK1zQ==}
     peerDependencies:
       '@itwin/core-bentley': ^4.0.0
     dependencies:
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/core-geometry': 4.7.4
-      axios: 1.7.4
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/core-geometry': 4.9.5
+      axios: 1.7.7
     transitivePeerDependencies:
       - debug
     dev: false
 
-  /@itwin/tree-widget-react/1.2.2_mwt5u2ylvl5wdlvny262vrwmma:
+  /@itwin/tree-widget-react/1.2.2_wdle7gtptdoktkpvzniwyk6jjq:
     resolution: {integrity: sha512-AJWgeK29NMC8zlHMfpIT0qbOLPQyJ1qmMX6AB/jaebjYipkBzG0HChrJN9vjcdMDcmCCPrnT1/uslQPTY1XUGw==}
     peerDependencies:
       '@itwin/appui-abstract': ^4.0.0
@@ -3896,46 +3773,46 @@ packages:
       react-dom: ^17.0.0
     dependencies:
       '@bentley/icons-generic': 1.0.34
-      '@itwin/appui-abstract': 4.7.4_@itwin+core-bentley@4.7.4
-      '@itwin/appui-react': 4.15.1_yrqai5hl5gvsf4dek6el5aloii
-      '@itwin/components-react': 4.15.1_jscgs7su4cyo55wt5klvj3iepa
-      '@itwin/core-frontend': 4.7.4_phc4rse3pm3zzqfro3xbf2awbu
-      '@itwin/core-react': 4.15.1_bpptdsfauwdziiwg4uklizbr74
-      '@itwin/itwinui-icons-react': 2.8.0_nnrd3gsncyragczmpvfhocinkq
+      '@itwin/appui-abstract': 4.9.5_@itwin+core-bentley@4.9.5
+      '@itwin/appui-react': 4.17.2_ggnmyqo32cg3w26befg4w43y64
+      '@itwin/components-react': 4.17.2_zs6rif5h5jixp3mcoeld6e43pu
+      '@itwin/core-frontend': 4.9.5_ncnujt6vgqk6xsxosc75g3boci
+      '@itwin/core-react': 4.17.2_b5szh4swag42x6ykxwn6buimra
+      '@itwin/itwinui-icons-react': 2.9.0_nnrd3gsncyragczmpvfhocinkq
       '@itwin/itwinui-illustrations-react': 2.1.0_nnrd3gsncyragczmpvfhocinkq
       '@itwin/itwinui-react': 2.12.26_nnrd3gsncyragczmpvfhocinkq
-      '@itwin/presentation-components': 5.4.1_coeiqitrdc3kbyoxwt3ak4fycm
+      '@itwin/presentation-components': 5.6.0_pgm6v4yzke2vvcj2rwx47ufaoy
       classnames: 2.5.1
       i18next: 10.6.0
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
-      react-error-boundary: 4.0.13_react@18.3.1
+      react-error-boundary: 4.1.2_react@18.3.1
       rxjs: 7.8.1
     dev: false
 
   /@itwin/unified-selection/0.1.0:
     resolution: {integrity: sha512-1Pe2i3sw5dK4h394uC5wTRWvnXxeBZGv+t9LcG7tQr2L+l0Hv+Ryo5+yTN34kABEhMe2UwSHnBRU8jOGsiorIQ==}
 
-  /@itwin/unified-selection/0.4.5:
-    resolution: {integrity: sha512-zqVHCEDTkaLQlFFdvBqn6VjapQTg8TaaXuNYLAIqZ0kmDCMxaGzcqvw7rJ8XaC6yboHYUe1UcFNBtSizOtSDwQ==}
+  /@itwin/unified-selection/0.4.6:
+    resolution: {integrity: sha512-uNklpeWLRLkacW8Zis3mkGjrjdzhiCOuQD9JtaoVifczf/2s82goDI9a+KyjtKvcBp/yzqMyL2KB1Z77p/0Bdw==}
     dependencies:
-      '@itwin/core-bentley': 4.7.4
-      '@itwin/presentation-shared': 0.3.2
+      '@itwin/core-bentley': 4.9.5
+      '@itwin/presentation-shared': 0.4.1
       rxjs: 7.8.1
       rxjs-for-await: 1.0.0_rxjs@7.8.1
     dev: false
 
-  /@itwin/webgl-compatibility/4.7.4:
-    resolution: {integrity: sha512-ZaVTHHrkbJoxYiMnWhN6+gru5yYcdhvrMb7jKVLxHhipHmJ3scCXNvZmEVkz0IVHVpTWodsApmfQnUYnLlbMQw==}
+  /@itwin/webgl-compatibility/4.9.5:
+    resolution: {integrity: sha512-eZ3lUsLSZ0iEdecTPnKczkU572gtcRxGs0p4gD7dsqMGewWDH6WzjxPocG2P495YaiBqf6V8qWnnpncUfjY7pg==}
     dependencies:
-      '@itwin/core-bentley': 4.7.4
+      '@itwin/core-bentley': 4.9.5
 
   /@jest/console/27.5.1:
     resolution: {integrity: sha512-kZ/tNpS3NXn0mlXXXPNuDZnb4c0oZ20r4K5eemM2k30ZC3G0T02nXUvyhf5YdbXWHPEJLc9qGLxEZ216MdL+Zg==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       chalk: 4.1.2
       jest-message-util: 27.5.1
       jest-util: 27.5.1
@@ -3947,7 +3824,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.3
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       chalk: 4.1.2
       jest-message-util: 28.1.3
       jest-util: 28.1.3
@@ -3959,7 +3836,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -3980,7 +3857,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.8.1
@@ -3999,7 +3876,7 @@ packages:
       jest-util: 27.5.1
       jest-validate: 27.5.1
       jest-watcher: 27.5.1
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       rimraf: 3.0.2
       slash: 3.0.0
       strip-ansi: 6.0.1
@@ -4025,14 +3902,14 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0_@types+node@18.19.39
+      jest-config: 29.7.0_@types+node@18.19.62
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -4044,7 +3921,7 @@ packages:
       jest-util: 29.7.0
       jest-validate: 29.7.0
       jest-watcher: 29.7.0
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-ansi: 6.0.1
@@ -4060,7 +3937,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       jest-mock: 27.5.1
     dev: true
 
@@ -4070,7 +3947,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       jest-mock: 29.7.0
     dev: true
 
@@ -4097,7 +3974,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@sinonjs/fake-timers': 8.1.0
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
@@ -4109,7 +3986,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -4150,7 +4027,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -4189,7 +4066,7 @@ packages:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -4299,7 +4176,7 @@ packages:
     resolution: {integrity: sha512-ipON6WtYgl/1329g5AIJVbUuEh0wZVbdpGwC99Jw4LwuoBNS95MVphU6zOeD9pDkon+LLbFL7lOQRapbB8SCHw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@babel/core': 7.24.7
+      '@babel/core': 7.26.0
       '@jest/types': 27.5.1
       babel-plugin-istanbul: 6.1.1
       chalk: 4.1.2
@@ -4309,7 +4186,7 @@ packages:
       jest-haste-map: 27.5.1
       jest-regex-util: 27.5.1
       jest-util: 27.5.1
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       pirates: 4.0.6
       slash: 3.0.0
       source-map: 0.6.1
@@ -4322,7 +4199,7 @@ packages:
     resolution: {integrity: sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@babel/core': 7.24.7
+      '@babel/core': 7.26.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
       babel-plugin-istanbul: 6.1.1
@@ -4333,7 +4210,7 @@ packages:
       jest-haste-map: 29.7.0
       jest-regex-util: 29.6.3
       jest-util: 29.7.0
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       pirates: 4.0.6
       slash: 3.0.0
       write-file-atomic: 4.0.2
@@ -4356,7 +4233,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       '@types/yargs': 15.0.19
       chalk: 4.1.2
     dev: true
@@ -4367,7 +4244,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       '@types/yargs': 16.0.9
       chalk: 4.1.2
     dev: true
@@ -4379,8 +4256,8 @@ packages:
       '@jest/schemas': 28.1.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 18.19.39
-      '@types/yargs': 17.0.32
+      '@types/node': 18.19.62
+      '@types/yargs': 17.0.33
       chalk: 4.1.2
     dev: true
 
@@ -4391,8 +4268,8 @@ packages:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 18.19.39
-      '@types/yargs': 17.0.32
+      '@types/node': 18.19.62
+      '@types/yargs': 17.0.33
       chalk: 4.1.2
     dev: true
 
@@ -4403,14 +4280,17 @@ packages:
       '@jridgewell/set-array': 1.2.1
       '@jridgewell/sourcemap-codec': 1.5.0
       '@jridgewell/trace-mapping': 0.3.25
+    dev: true
 
   /@jridgewell/resolve-uri/3.1.2:
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
+    dev: true
 
   /@jridgewell/set-array/1.2.1:
     resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
     engines: {node: '>=6.0.0'}
+    dev: true
 
   /@jridgewell/source-map/0.3.6:
     resolution: {integrity: sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==}
@@ -4421,12 +4301,14 @@ packages:
 
   /@jridgewell/sourcemap-codec/1.5.0:
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
+    dev: true
 
   /@jridgewell/trace-mapping/0.3.25:
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
+    dev: true
 
   /@leichtgewicht/ip-codec/2.0.5:
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
@@ -4435,7 +4317,7 @@ packages:
   /@loaders.gl/core/3.4.15:
     resolution: {integrity: sha512-rPOOTuusWlRRNMWg7hymZBoFmPCXWThsA5ZYRfqqXnsgVeQIi8hzcAhJ7zDUIFAd/OSR8ravtqb0SH+3k6MOFQ==}
     dependencies:
-      '@babel/runtime': 7.24.7
+      '@babel/runtime': 7.26.0
       '@loaders.gl/loader-utils': 3.4.15
       '@loaders.gl/worker-utils': 3.4.15
       '@probe.gl/log': 3.6.0
@@ -4443,7 +4325,7 @@ packages:
   /@loaders.gl/draco/3.4.15:
     resolution: {integrity: sha512-SStmyP0ZnS4JbWZb2NhrfiHW65uy3pVTTzQDTgXfkR5cD9oDAEu4nCaHbQ8x38/m39FHliCPgS9b1xWvLKQo8w==}
     dependencies:
-      '@babel/runtime': 7.24.7
+      '@babel/runtime': 7.26.0
       '@loaders.gl/loader-utils': 3.4.15
       '@loaders.gl/schema': 3.4.15
       '@loaders.gl/worker-utils': 3.4.15
@@ -4452,7 +4334,7 @@ packages:
   /@loaders.gl/loader-utils/3.4.15:
     resolution: {integrity: sha512-uUx6tCaky6QgCRkqCNuuXiUfpTzKV+ZlJOf6C9bKp62lpvFOv9AwqoXmL23j8nfsENdlzsX3vPhc3en6QQyksA==}
     dependencies:
-      '@babel/runtime': 7.24.7
+      '@babel/runtime': 7.26.0
       '@loaders.gl/worker-utils': 3.4.15
       '@probe.gl/stats': 3.6.0
 
@@ -4464,79 +4346,81 @@ packages:
   /@loaders.gl/worker-utils/3.4.15:
     resolution: {integrity: sha512-zUUepOYRYmcYIcr/c4Mchox9h5fBFNkD81rsGnLlZyq19QvyHzN+93SVxrLc078gw93t2RKrVcOOZY13zT3t1w==}
     dependencies:
-      '@babel/runtime': 7.24.7
+      '@babel/runtime': 7.26.0
 
-  /@microsoft/api-extractor-model/7.28.13:
-    resolution: {integrity: sha512-39v/JyldX4MS9uzHcdfmjjfS6cYGAoXV+io8B5a338pkHiSt+gy2eXQ0Q7cGFJ7quSa1VqqlMdlPrB6sLR/cAw==}
+  /@microsoft/api-extractor-model/7.29.8:
+    resolution: {integrity: sha512-t3Z/xcO6TRbMcnKGVMs4uMzv/gd5j0NhMiJIGjD4cJMeFJ1Hf8wnLSx37vxlRlL0GWlGJhnFgxvnaL6JlS+73g==}
     dependencies:
-      '@microsoft/tsdoc': 0.14.2
-      '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 4.0.2
+      '@microsoft/tsdoc': 0.15.0
+      '@microsoft/tsdoc-config': 0.17.0
+      '@rushstack/node-core-library': 5.9.0
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  /@microsoft/api-extractor-model/7.28.13_@types+node@18.19.39:
-    resolution: {integrity: sha512-39v/JyldX4MS9uzHcdfmjjfS6cYGAoXV+io8B5a338pkHiSt+gy2eXQ0Q7cGFJ7quSa1VqqlMdlPrB6sLR/cAw==}
+  /@microsoft/api-extractor-model/7.29.8_@types+node@18.19.62:
+    resolution: {integrity: sha512-t3Z/xcO6TRbMcnKGVMs4uMzv/gd5j0NhMiJIGjD4cJMeFJ1Hf8wnLSx37vxlRlL0GWlGJhnFgxvnaL6JlS+73g==}
     dependencies:
-      '@microsoft/tsdoc': 0.14.2
-      '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 4.0.2_@types+node@18.19.39
+      '@microsoft/tsdoc': 0.15.0
+      '@microsoft/tsdoc-config': 0.17.0
+      '@rushstack/node-core-library': 5.9.0_@types+node@18.19.62
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  /@microsoft/api-extractor/7.40.6:
-    resolution: {integrity: sha512-9N+XCIQB94Di+ETTzNGLqjgQydslynHou7QPgDhl5gZ+B/Q5hTv5jtqBglTUnTrC0trHdG5/YKN07ehGKlSb5g==}
+  /@microsoft/api-extractor/7.47.11:
+    resolution: {integrity: sha512-lrudfbPub5wzBhymfFtgZKuBvXxoSIAdrvS2UbHjoMT2TjIEddq6Z13pcve7A03BAouw0x8sW8G4txdgfiSwpQ==}
     hasBin: true
     dependencies:
-      '@microsoft/api-extractor-model': 7.28.13
-      '@microsoft/tsdoc': 0.14.2
-      '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 4.0.2
-      '@rushstack/rig-package': 0.5.2
-      '@rushstack/terminal': 0.9.0
-      '@rushstack/ts-command-line': 4.17.3
+      '@microsoft/api-extractor-model': 7.29.8
+      '@microsoft/tsdoc': 0.15.0
+      '@microsoft/tsdoc-config': 0.17.0
+      '@rushstack/node-core-library': 5.9.0
+      '@rushstack/rig-package': 0.5.3
+      '@rushstack/terminal': 0.14.2
+      '@rushstack/ts-command-line': 4.23.0
       lodash: 4.17.21
+      minimatch: 3.0.8
       resolve: 1.22.8
       semver: 7.5.4
       source-map: 0.6.1
-      typescript: 5.3.3
+      typescript: 5.4.2
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  /@microsoft/api-extractor/7.40.6_@types+node@18.19.39:
-    resolution: {integrity: sha512-9N+XCIQB94Di+ETTzNGLqjgQydslynHou7QPgDhl5gZ+B/Q5hTv5jtqBglTUnTrC0trHdG5/YKN07ehGKlSb5g==}
+  /@microsoft/api-extractor/7.47.11_@types+node@18.19.62:
+    resolution: {integrity: sha512-lrudfbPub5wzBhymfFtgZKuBvXxoSIAdrvS2UbHjoMT2TjIEddq6Z13pcve7A03BAouw0x8sW8G4txdgfiSwpQ==}
     hasBin: true
     dependencies:
-      '@microsoft/api-extractor-model': 7.28.13_@types+node@18.19.39
-      '@microsoft/tsdoc': 0.14.2
-      '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 4.0.2_@types+node@18.19.39
-      '@rushstack/rig-package': 0.5.2
-      '@rushstack/terminal': 0.9.0_@types+node@18.19.39
-      '@rushstack/ts-command-line': 4.17.3_@types+node@18.19.39
+      '@microsoft/api-extractor-model': 7.29.8_@types+node@18.19.62
+      '@microsoft/tsdoc': 0.15.0
+      '@microsoft/tsdoc-config': 0.17.0
+      '@rushstack/node-core-library': 5.9.0_@types+node@18.19.62
+      '@rushstack/rig-package': 0.5.3
+      '@rushstack/terminal': 0.14.2_@types+node@18.19.62
+      '@rushstack/ts-command-line': 4.23.0_@types+node@18.19.62
       lodash: 4.17.21
+      minimatch: 3.0.8
       resolve: 1.22.8
       semver: 7.5.4
       source-map: 0.6.1
-      typescript: 5.3.3
+      typescript: 5.4.2
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  /@microsoft/tsdoc-config/0.16.2:
-    resolution: {integrity: sha512-OGiIzzoBLgWWR0UdRJX98oYO+XKGf7tiK4Zk6tQ/E4IJqGCe7dvkTvgDZV5cFJUzLGDOjeAXrnZoA6QkVySuxw==}
+  /@microsoft/tsdoc-config/0.17.0:
+    resolution: {integrity: sha512-v/EYRXnCAIHxOHW+Plb6OWuUoMotxTN0GLatnpOb1xq0KuTNw/WI3pamJx/UbsoJP5k9MCw1QxvvhPcF9pH3Zg==}
     dependencies:
-      '@microsoft/tsdoc': 0.14.2
-      ajv: 6.12.6
+      '@microsoft/tsdoc': 0.15.0
+      ajv: 8.12.0
       jju: 1.4.0
-      resolve: 1.19.0
+      resolve: 1.22.8
     dev: true
 
-  /@microsoft/tsdoc/0.14.2:
-    resolution: {integrity: sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==}
+  /@microsoft/tsdoc/0.15.0:
+    resolution: {integrity: sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA==}
     dev: true
 
   /@nicolo-ribaudo/eslint-scope-5-internals/5.1.1-v1:
@@ -4570,13 +4454,144 @@ packages:
     resolution: {integrity: sha512-NoOejniaqzOEbHg3RcBZtTriYqhqpQFgTC4lDNaRbgRCnpz6n8PlxWlCbh2N1K5qKawfxRP29/Wiho3FrXQ3Qw==}
     dependencies:
       '@types/base64-js': 1.3.2
-      '@types/jquery': 3.5.30
+      '@types/jquery': 3.5.32
       base64-js: 1.5.1
-      follow-redirects: 1.15.6
-      form-data: 4.0.0
+      follow-redirects: 1.15.9
+      form-data: 4.0.1
       opener: 1.5.2
     transitivePeerDependencies:
       - debug
+
+  /@parcel/watcher-android-arm64/2.4.1:
+    resolution: {integrity: sha512-LOi/WTbbh3aTn2RYddrO8pnapixAziFl6SMxHM69r3tvdSm94JtCenaKgk1GRg5FJ5wpMCpHeW+7yqPlvZv7kg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@parcel/watcher-darwin-arm64/2.4.1:
+    resolution: {integrity: sha512-ln41eihm5YXIY043vBrrHfn94SIBlqOWmoROhsMVTSXGh0QahKGy77tfEywQ7v3NywyxBBkGIfrWRHm0hsKtzA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@parcel/watcher-darwin-x64/2.4.1:
+    resolution: {integrity: sha512-yrw81BRLjjtHyDu7J61oPuSoeYWR3lDElcPGJyOvIXmor6DEo7/G2u1o7I38cwlcoBHQFULqF6nesIX3tsEXMg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@parcel/watcher-freebsd-x64/2.4.1:
+    resolution: {integrity: sha512-TJa3Pex/gX3CWIx/Co8k+ykNdDCLx+TuZj3f3h7eOjgpdKM+Mnix37RYsYU4LHhiYJz3DK5nFCCra81p6g050w==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@parcel/watcher-linux-arm-glibc/2.4.1:
+    resolution: {integrity: sha512-4rVYDlsMEYfa537BRXxJ5UF4ddNwnr2/1O4MHM5PjI9cvV2qymvhwZSFgXqbS8YoTk5i/JR0L0JDs69BUn45YA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@parcel/watcher-linux-arm64-glibc/2.4.1:
+    resolution: {integrity: sha512-BJ7mH985OADVLpbrzCLgrJ3TOpiZggE9FMblfO65PlOCdG++xJpKUJ0Aol74ZUIYfb8WsRlUdgrZxKkz3zXWYA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@parcel/watcher-linux-arm64-musl/2.4.1:
+    resolution: {integrity: sha512-p4Xb7JGq3MLgAfYhslU2SjoV9G0kI0Xry0kuxeG/41UfpjHGOhv7UoUDAz/jb1u2elbhazy4rRBL8PegPJFBhA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@parcel/watcher-linux-x64-glibc/2.4.1:
+    resolution: {integrity: sha512-s9O3fByZ/2pyYDPoLM6zt92yu6P4E39a03zvO0qCHOTjxmt3GHRMLuRZEWhWLASTMSrrnVNWdVI/+pUElJBBBg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@parcel/watcher-linux-x64-musl/2.4.1:
+    resolution: {integrity: sha512-L2nZTYR1myLNST0O632g0Dx9LyMNHrn6TOt76sYxWLdff3cB22/GZX2UPtJnaqQPdCRoszoY5rcOj4oMTtp5fQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@parcel/watcher-win32-arm64/2.4.1:
+    resolution: {integrity: sha512-Uq2BPp5GWhrq/lcuItCHoqxjULU1QYEcyjSO5jqqOK8RNFDBQnenMMx4gAl3v8GiWa59E9+uDM7yZ6LxwUIfRg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@parcel/watcher-win32-ia32/2.4.1:
+    resolution: {integrity: sha512-maNRit5QQV2kgHFSYwftmPBxiuK5u4DXjbXx7q6eKjq5dsLXZ4FJiVvlcw35QXzk0KrUecJmuVFbj4uV9oYrcw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@parcel/watcher-win32-x64/2.4.1:
+    resolution: {integrity: sha512-+DvS92F9ezicfswqrvIRM2njcYJbd5mb9CUgtrHCHmvn7pPPa+nMDRu1o1bYYz/l5IB2NVGNJWiH7h1E58IF2A==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@parcel/watcher/2.4.1:
+    resolution: {integrity: sha512-HNjmfLQEVRZmHRET336f20H/8kOozUGwk7yajvsonjNxbj2wBTK1WsQuHkD5yYh9RxFGL2EyDHryOihOwUoKDA==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      detect-libc: 1.0.3
+      is-glob: 4.0.3
+      micromatch: 4.0.8
+      node-addon-api: 7.1.1
+    optionalDependencies:
+      '@parcel/watcher-android-arm64': 2.4.1
+      '@parcel/watcher-darwin-arm64': 2.4.1
+      '@parcel/watcher-darwin-x64': 2.4.1
+      '@parcel/watcher-freebsd-x64': 2.4.1
+      '@parcel/watcher-linux-arm-glibc': 2.4.1
+      '@parcel/watcher-linux-arm64-glibc': 2.4.1
+      '@parcel/watcher-linux-arm64-musl': 2.4.1
+      '@parcel/watcher-linux-x64-glibc': 2.4.1
+      '@parcel/watcher-linux-x64-musl': 2.4.1
+      '@parcel/watcher-win32-arm64': 2.4.1
+      '@parcel/watcher-win32-ia32': 2.4.1
+      '@parcel/watcher-win32-x64': 2.4.1
+    dev: true
 
   /@pkgjs/parseargs/0.11.0:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -4585,7 +4600,7 @@ packages:
     dev: true
     optional: true
 
-  /@pmmmwh/react-refresh-webpack-plugin/0.5.15_zciuhk7ajont242gc253fauh24:
+  /@pmmmwh/react-refresh-webpack-plugin/0.5.15_e3ej43g5iw5szlea4i3o2x6iq4:
     resolution: {integrity: sha512-LFWllMA55pzB9D34w/wXUCf8+c+IYKuJDgxiZ3qMhl64KRMBHYM1I3VdGaD2BV5FNPV2/S2596bppxHbv2ZydQ==}
     engines: {node: '>= 10.13'}
     peerDependencies:
@@ -4612,15 +4627,15 @@ packages:
         optional: true
     dependencies:
       ansi-html: 0.0.9
-      core-js-pure: 3.37.1
+      core-js-pure: 3.39.0
       error-stack-parser: 2.1.4
       html-entities: 2.5.2
       loader-utils: 2.0.4
       react-refresh: 0.11.0
       schema-utils: 4.2.0
       source-map: 0.7.4
-      webpack: 5.92.1
-      webpack-dev-server: 4.15.2_webpack@5.92.1
+      webpack: 5.95.0
+      webpack-dev-server: 4.15.2_webpack@5.95.0
     dev: true
 
   /@popperjs/core/2.11.8:
@@ -4629,25 +4644,25 @@ packages:
   /@probe.gl/env/3.6.0:
     resolution: {integrity: sha512-4tTZYUg/8BICC3Yyb9rOeoKeijKbZHRXBEKObrfPmX4sQmYB15ZOUpoVBhAyJkOYVAM8EkPci6Uw5dLCwx2BEQ==}
     dependencies:
-      '@babel/runtime': 7.24.7
+      '@babel/runtime': 7.26.0
 
   /@probe.gl/log/3.6.0:
     resolution: {integrity: sha512-hjpyenpEvOdowgZ1qMeCJxfRD4JkKdlXz0RC14m42Un62NtOT+GpWyKA4LssT0+xyLULCByRAtG2fzZorpIAcA==}
     dependencies:
-      '@babel/runtime': 7.24.7
+      '@babel/runtime': 7.26.0
       '@probe.gl/env': 3.6.0
 
   /@probe.gl/stats/3.6.0:
     resolution: {integrity: sha512-JdALQXB44OP4kUBN/UrQgzbJe4qokbVF4Y8lkIA8iVCFnjVowWIgkD/z/0QO65yELT54tTrtepw1jScjKB+rhQ==}
     dependencies:
-      '@babel/runtime': 7.24.7
+      '@babel/runtime': 7.26.0
 
-  /@remix-run/router/1.17.1:
-    resolution: {integrity: sha512-mCOMec4BKd6BRGBZeSnGiIgwsbLGp3yhVqAD8H+PxiRNEHgDpZb8J1TnrSDlg97t0ySKMQJTHCWBCmBpSmkF6Q==}
+  /@remix-run/router/1.20.0:
+    resolution: {integrity: sha512-mUnk8rPJBI9loFDZ+YzPGdeniYK+FTmRD1TMCz7ev2SNIozyKKpnGgsxO34u6Z4z/t0ITuu7voi/AshfsGsgFg==}
     engines: {node: '>=14.0.0'}
     dev: false
 
-  /@rollup/plugin-babel/5.3.1_je4nbmfg47mhbnn75kmajdcj7i:
+  /@rollup/plugin-babel/5.3.1_jv6xoz77vs757ecddpkzporema:
     resolution: {integrity: sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
@@ -4658,40 +4673,40 @@ packages:
       '@types/babel__core':
         optional: true
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-module-imports': 7.24.7
-      '@rollup/pluginutils': 3.1.0_rollup@2.79.1
-      rollup: 2.79.1
+      '@babel/core': 7.26.0
+      '@babel/helper-module-imports': 7.25.9
+      '@rollup/pluginutils': 3.1.0_rollup@2.79.2
+      rollup: 2.79.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@rollup/plugin-node-resolve/11.2.1_rollup@2.79.1:
+  /@rollup/plugin-node-resolve/11.2.1_rollup@2.79.2:
     resolution: {integrity: sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.79.1
+      '@rollup/pluginutils': 3.1.0_rollup@2.79.2
       '@types/resolve': 1.17.1
       builtin-modules: 3.3.0
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.8
-      rollup: 2.79.1
+      rollup: 2.79.2
     dev: true
 
-  /@rollup/plugin-replace/2.4.2_rollup@2.79.1:
+  /@rollup/plugin-replace/2.4.2_rollup@2.79.2:
     resolution: {integrity: sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==}
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.79.1
+      '@rollup/pluginutils': 3.1.0_rollup@2.79.2
       magic-string: 0.25.9
-      rollup: 2.79.1
+      rollup: 2.79.2
     dev: true
 
-  /@rollup/pluginutils/3.1.0_rollup@2.79.1:
+  /@rollup/pluginutils/3.1.0_rollup@2.79.2:
     resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
@@ -4700,82 +4715,90 @@ packages:
       '@types/estree': 0.0.39
       estree-walker: 1.0.1
       picomatch: 2.3.1
-      rollup: 2.79.1
+      rollup: 2.79.2
     dev: true
 
-  /@rushstack/eslint-patch/1.10.3:
-    resolution: {integrity: sha512-qC/xYId4NMebE6w/V33Fh9gWxLgURiNYgVNObbJl2LZv0GUUItCcCqC5axQSwRaAgaxl2mELq1rMzlswaQ0Zxg==}
+  /@rtsao/scc/1.1.0:
+    resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
     dev: true
 
-  /@rushstack/node-core-library/4.0.2:
-    resolution: {integrity: sha512-hyES82QVpkfQMeBMteQUnrhASL/KHPhd7iJ8euduwNJG4mu2GSOKybf0rOEjOm1Wz7CwJEUm9y0yD7jg2C1bfg==}
+  /@rushstack/eslint-patch/1.10.4:
+    resolution: {integrity: sha512-WJgX9nzTqknM393q1QJDJmoW28kUfEnybeTfVNcNAPnIx210RXm2DiXiHzfNPJNIUUb1tJnz/l4QGtJ30PgWmA==}
+    dev: true
+
+  /@rushstack/node-core-library/5.9.0:
+    resolution: {integrity: sha512-MMsshEWkTbXqxqFxD4gcIUWQOCeBChlGczdZbHfqmNZQFLHB3yWxDFSMHFUdu2/OB9NUk7Awn5qRL+rws4HQNg==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
     dependencies:
+      ajv: 8.13.0
+      ajv-draft-04: 1.0.0_ajv@8.13.0
+      ajv-formats: 3.0.1
       fs-extra: 7.0.1
       import-lazy: 4.0.0
       jju: 1.4.0
       resolve: 1.22.8
       semver: 7.5.4
-      z-schema: 5.0.5
     dev: true
 
-  /@rushstack/node-core-library/4.0.2_@types+node@18.19.39:
-    resolution: {integrity: sha512-hyES82QVpkfQMeBMteQUnrhASL/KHPhd7iJ8euduwNJG4mu2GSOKybf0rOEjOm1Wz7CwJEUm9y0yD7jg2C1bfg==}
+  /@rushstack/node-core-library/5.9.0_@types+node@18.19.62:
+    resolution: {integrity: sha512-MMsshEWkTbXqxqFxD4gcIUWQOCeBChlGczdZbHfqmNZQFLHB3yWxDFSMHFUdu2/OB9NUk7Awn5qRL+rws4HQNg==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
     dependencies:
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
+      ajv: 8.13.0
+      ajv-draft-04: 1.0.0_ajv@8.13.0
+      ajv-formats: 3.0.1
       fs-extra: 7.0.1
       import-lazy: 4.0.0
       jju: 1.4.0
       resolve: 1.22.8
       semver: 7.5.4
-      z-schema: 5.0.5
     dev: true
 
-  /@rushstack/rig-package/0.5.2:
-    resolution: {integrity: sha512-mUDecIJeH3yYGZs2a48k+pbhM6JYwWlgjs2Ca5f2n1G2/kgdgP9D/07oglEGf6mRyXEnazhEENeYTSNDRCwdqA==}
+  /@rushstack/rig-package/0.5.3:
+    resolution: {integrity: sha512-olzSSjYrvCNxUFZowevC3uz8gvKr3WTpHQ7BkpjtRpA3wK+T0ybep/SRUMfr195gBzJm5gaXw0ZMgjIyHqJUow==}
     dependencies:
       resolve: 1.22.8
       strip-json-comments: 3.1.1
     dev: true
 
-  /@rushstack/terminal/0.9.0:
-    resolution: {integrity: sha512-49RnIDooriXyqcd7mGyjh9CmjOjf/Vn8PkOQXHa1CS0/RrrynCJLFhRDkswf7gGXZW+6UhROOE8wTmbOrfUTSA==}
+  /@rushstack/terminal/0.14.2:
+    resolution: {integrity: sha512-2fC1wqu1VCExKC0/L+0noVcFQEXEnoBOtCIex1TOjBzEDWcw8KzJjjj7aTP6mLxepG0XIyn9OufeFb6SFsa+sg==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
     dependencies:
-      '@rushstack/node-core-library': 4.0.2
-      colors: 1.2.5
+      '@rushstack/node-core-library': 5.9.0
+      supports-color: 8.1.1
     dev: true
 
-  /@rushstack/terminal/0.9.0_@types+node@18.19.39:
-    resolution: {integrity: sha512-49RnIDooriXyqcd7mGyjh9CmjOjf/Vn8PkOQXHa1CS0/RrrynCJLFhRDkswf7gGXZW+6UhROOE8wTmbOrfUTSA==}
+  /@rushstack/terminal/0.14.2_@types+node@18.19.62:
+    resolution: {integrity: sha512-2fC1wqu1VCExKC0/L+0noVcFQEXEnoBOtCIex1TOjBzEDWcw8KzJjjj7aTP6mLxepG0XIyn9OufeFb6SFsa+sg==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
     dependencies:
-      '@rushstack/node-core-library': 4.0.2_@types+node@18.19.39
-      '@types/node': 18.19.39
-      colors: 1.2.5
+      '@rushstack/node-core-library': 5.9.0_@types+node@18.19.62
+      '@types/node': 18.19.62
+      supports-color: 8.1.1
     dev: true
 
-  /@rushstack/ts-command-line/4.17.3:
-    resolution: {integrity: sha512-/PtTYW38A8iUviuCmQSccHfmx3uBh4Jm5YRPU2aTgYEgwT2jtg60vAbwnkMYkyaT1AbWpjZM3xq5uHYPURvStw==}
+  /@rushstack/ts-command-line/4.23.0:
+    resolution: {integrity: sha512-jYREBtsxduPV6ptNq8jOKp9+yx0ld1Tb/Tkdnlj8gTjazl1sF3DwX2VbluyYrNd0meWIL0bNeer7WDf5tKFjaQ==}
     dependencies:
-      '@rushstack/terminal': 0.9.0
+      '@rushstack/terminal': 0.14.2
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -4783,19 +4806,16 @@ packages:
       - '@types/node'
     dev: true
 
-  /@rushstack/ts-command-line/4.17.3_@types+node@18.19.39:
-    resolution: {integrity: sha512-/PtTYW38A8iUviuCmQSccHfmx3uBh4Jm5YRPU2aTgYEgwT2jtg60vAbwnkMYkyaT1AbWpjZM3xq5uHYPURvStw==}
+  /@rushstack/ts-command-line/4.23.0_@types+node@18.19.62:
+    resolution: {integrity: sha512-jYREBtsxduPV6ptNq8jOKp9+yx0ld1Tb/Tkdnlj8gTjazl1sF3DwX2VbluyYrNd0meWIL0bNeer7WDf5tKFjaQ==}
     dependencies:
-      '@rushstack/terminal': 0.9.0_@types+node@18.19.39
+      '@rushstack/terminal': 0.14.2_@types+node@18.19.62
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
     transitivePeerDependencies:
       - '@types/node'
     dev: true
-
-  /@seznam/compose-react-refs/1.0.6:
-    resolution: {integrity: sha512-izzOXQfeQLonzrIQb8u6LQ8dk+ymz3WXTIXjvOlTXHq6sbzROg3NWU+9TTAOpEoK9Bth24/6F/XrfHJ5yR5n6Q==}
 
   /@sinclair/typebox/0.24.51:
     resolution: {integrity: sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==}
@@ -4833,29 +4853,29 @@ packages:
       '@sinonjs/commons': 1.8.6
     dev: true
 
-  /@stylelint/postcss-css-in-js/0.37.3_lrpgrolfvll3p4c7yzuvfga3qm:
+  /@stylelint/postcss-css-in-js/0.37.3_7ddkth4qkj3urzklvpilix4jii:
     resolution: {integrity: sha512-scLk3cSH1H9KggSniseb2KNAU5D9FWc3H7BxCSAIdtU9OWIyw0zkEZ9qEKHryRM+SExYXRKNb7tOOVNAsQ3iwg==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       postcss: '>=7.0.0'
       postcss-syntax: '>=0.36.2'
     dependencies:
-      '@babel/core': 7.24.7
-      postcss: 8.4.39
-      postcss-syntax: 0.36.2_postcss@8.4.39
+      '@babel/core': 7.26.0
+      postcss: 8.4.47
+      postcss-syntax: 0.36.2_postcss@8.4.47
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@stylelint/postcss-markdown/0.36.2_lrpgrolfvll3p4c7yzuvfga3qm:
+  /@stylelint/postcss-markdown/0.36.2_7ddkth4qkj3urzklvpilix4jii:
     resolution: {integrity: sha512-2kGbqUVJUGE8dM+bMzXG/PYUWKkjLIkRLWNh39OaADkiabDRdw8ATFCgbMz5xdIcvwspPAluSL7uY+ZiTWdWmQ==}
     deprecated: 'Use the original unforked package instead: postcss-markdown'
     peerDependencies:
       postcss: '>=7.0.0'
       postcss-syntax: '>=0.36.2'
     dependencies:
-      postcss: 8.4.39
-      postcss-syntax: 0.36.2_postcss@8.4.39
+      postcss: 8.4.47
+      postcss-syntax: 0.36.2_postcss@8.4.47
       remark: 13.0.0
       unist-util-find-all-after: 3.0.2
     transitivePeerDependencies:
@@ -4874,101 +4894,101 @@ packages:
   /@svgdotjs/svg.js/3.0.13:
     resolution: {integrity: sha512-Ix3dobG2DvdK5f2SHtZdiiLwi+G0RDuDfwA4tZ1eqTGoiopia8JIfeWGeA0h2frFHcLDXnYvNiVGtW4y6cSDig==}
 
-  /@svgr/babel-plugin-add-jsx-attribute/6.5.1_@babel+core@7.24.7:
+  /@svgr/babel-plugin-add-jsx-attribute/6.5.1_@babel+core@7.26.0:
     resolution: {integrity: sha512-9PYGcXrAxitycIjRmZB+Q0JaN07GZIWaTBIGQzfaZv+qr1n8X1XUEJ5rZ/vx6OVD9RRYlrNnXWExQXcmZeD/BQ==}
     engines: {node: '>=10'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
+      '@babel/core': 7.26.0
     dev: true
 
-  /@svgr/babel-plugin-remove-jsx-attribute/8.0.0_@babel+core@7.24.7:
+  /@svgr/babel-plugin-remove-jsx-attribute/8.0.0_@babel+core@7.26.0:
     resolution: {integrity: sha512-BcCkm/STipKvbCl6b7QFrMh/vx00vIP63k2eM66MfHJzPr6O2U0jYEViXkHJWqXqQYjdeA9cuCl5KWmlwjDvbA==}
     engines: {node: '>=14'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
+      '@babel/core': 7.26.0
     dev: true
 
-  /@svgr/babel-plugin-remove-jsx-empty-expression/8.0.0_@babel+core@7.24.7:
+  /@svgr/babel-plugin-remove-jsx-empty-expression/8.0.0_@babel+core@7.26.0:
     resolution: {integrity: sha512-5BcGCBfBxB5+XSDSWnhTThfI9jcO5f0Ai2V24gZpG+wXF14BzwxxdDb4g6trdOux0rhibGs385BeFMSmxtS3uA==}
     engines: {node: '>=14'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
+      '@babel/core': 7.26.0
     dev: true
 
-  /@svgr/babel-plugin-replace-jsx-attribute-value/6.5.1_@babel+core@7.24.7:
+  /@svgr/babel-plugin-replace-jsx-attribute-value/6.5.1_@babel+core@7.26.0:
     resolution: {integrity: sha512-8DPaVVE3fd5JKuIC29dqyMB54sA6mfgki2H2+swh+zNJoynC8pMPzOkidqHOSc6Wj032fhl8Z0TVn1GiPpAiJg==}
     engines: {node: '>=10'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
+      '@babel/core': 7.26.0
     dev: true
 
-  /@svgr/babel-plugin-svg-dynamic-title/6.5.1_@babel+core@7.24.7:
+  /@svgr/babel-plugin-svg-dynamic-title/6.5.1_@babel+core@7.26.0:
     resolution: {integrity: sha512-FwOEi0Il72iAzlkaHrlemVurgSQRDFbk0OC8dSvD5fSBPHltNh7JtLsxmZUhjYBZo2PpcU/RJvvi6Q0l7O7ogw==}
     engines: {node: '>=10'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
+      '@babel/core': 7.26.0
     dev: true
 
-  /@svgr/babel-plugin-svg-em-dimensions/6.5.1_@babel+core@7.24.7:
+  /@svgr/babel-plugin-svg-em-dimensions/6.5.1_@babel+core@7.26.0:
     resolution: {integrity: sha512-gWGsiwjb4tw+ITOJ86ndY/DZZ6cuXMNE/SjcDRg+HLuCmwpcjOktwRF9WgAiycTqJD/QXqL2f8IzE2Rzh7aVXA==}
     engines: {node: '>=10'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
+      '@babel/core': 7.26.0
     dev: true
 
-  /@svgr/babel-plugin-transform-react-native-svg/6.5.1_@babel+core@7.24.7:
+  /@svgr/babel-plugin-transform-react-native-svg/6.5.1_@babel+core@7.26.0:
     resolution: {integrity: sha512-2jT3nTayyYP7kI6aGutkyfJ7UMGtuguD72OjeGLwVNyfPRBD8zQthlvL+fAbAKk5n9ZNcvFkp/b1lZ7VsYqVJg==}
     engines: {node: '>=10'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
+      '@babel/core': 7.26.0
     dev: true
 
-  /@svgr/babel-plugin-transform-svg-component/6.5.1_@babel+core@7.24.7:
+  /@svgr/babel-plugin-transform-svg-component/6.5.1_@babel+core@7.26.0:
     resolution: {integrity: sha512-a1p6LF5Jt33O3rZoVRBqdxL350oge54iZWHNI6LJB5tQ7EelvD/Mb1mfBiZNAan0dt4i3VArkFRjA4iObuNykQ==}
     engines: {node: '>=12'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
+      '@babel/core': 7.26.0
     dev: true
 
-  /@svgr/babel-preset/6.5.1_@babel+core@7.24.7:
+  /@svgr/babel-preset/6.5.1_@babel+core@7.26.0:
     resolution: {integrity: sha512-6127fvO/FF2oi5EzSQOAjo1LE3OtNVh11R+/8FXa+mHx1ptAaS4cknIjnUA7e6j6fwGGJ17NzaTJFUwOV2zwCw==}
     engines: {node: '>=10'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7
-      '@svgr/babel-plugin-add-jsx-attribute': 6.5.1_@babel+core@7.24.7
-      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0_@babel+core@7.24.7
-      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0_@babel+core@7.24.7
-      '@svgr/babel-plugin-replace-jsx-attribute-value': 6.5.1_@babel+core@7.24.7
-      '@svgr/babel-plugin-svg-dynamic-title': 6.5.1_@babel+core@7.24.7
-      '@svgr/babel-plugin-svg-em-dimensions': 6.5.1_@babel+core@7.24.7
-      '@svgr/babel-plugin-transform-react-native-svg': 6.5.1_@babel+core@7.24.7
-      '@svgr/babel-plugin-transform-svg-component': 6.5.1_@babel+core@7.24.7
+      '@babel/core': 7.26.0
+      '@svgr/babel-plugin-add-jsx-attribute': 6.5.1_@babel+core@7.26.0
+      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0_@babel+core@7.26.0
+      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0_@babel+core@7.26.0
+      '@svgr/babel-plugin-replace-jsx-attribute-value': 6.5.1_@babel+core@7.26.0
+      '@svgr/babel-plugin-svg-dynamic-title': 6.5.1_@babel+core@7.26.0
+      '@svgr/babel-plugin-svg-em-dimensions': 6.5.1_@babel+core@7.26.0
+      '@svgr/babel-plugin-transform-react-native-svg': 6.5.1_@babel+core@7.26.0
+      '@svgr/babel-plugin-transform-svg-component': 6.5.1_@babel+core@7.26.0
     dev: true
 
   /@svgr/core/6.5.1:
     resolution: {integrity: sha512-/xdLSWxK5QkqG524ONSjvg3V/FkNyCv538OIBdQqPNaAta3AsXj/Bd2FbvR87yMbXO2hFSWiAe/Q6IkVPDw+mw==}
     engines: {node: '>=10'}
     dependencies:
-      '@babel/core': 7.24.7
-      '@svgr/babel-preset': 6.5.1_@babel+core@7.24.7
+      '@babel/core': 7.26.0
+      '@svgr/babel-preset': 6.5.1_@babel+core@7.26.0
       '@svgr/plugin-jsx': 6.5.1_@svgr+core@6.5.1
       camelcase: 6.3.0
       cosmiconfig: 7.1.0
@@ -4980,7 +5000,7 @@ packages:
     resolution: {integrity: sha512-1hnUxxjd83EAxbL4a0JDJoD3Dao3hmjvyvyEV8PzWmLK3B9m9NPlW7GKjFyoWE8nM7HnXzPcmmSyOW8yOddSXw==}
     engines: {node: '>=10'}
     dependencies:
-      '@babel/types': 7.24.7
+      '@babel/types': 7.26.0
       entities: 4.5.0
     dev: true
 
@@ -4990,8 +5010,8 @@ packages:
     peerDependencies:
       '@svgr/core': ^6.0.0
     dependencies:
-      '@babel/core': 7.24.7
-      '@svgr/babel-preset': 6.5.1_@babel+core@7.24.7
+      '@babel/core': 7.26.0
+      '@svgr/babel-preset': 6.5.1_@babel+core@7.26.0
       '@svgr/core': 6.5.1
       '@svgr/hast-util-to-babel-ast': 6.5.1
       svg-parser: 2.0.4
@@ -5015,11 +5035,11 @@ packages:
     resolution: {integrity: sha512-cQ/AsnBkXPkEK8cLbv4Dm7JGXq2XrumKnL1dRpJD9rIO2fTIlJI9a1uCciYG1F2aUsox/hJQyNGbt3soDxSRkA==}
     engines: {node: '>=10'}
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/plugin-transform-react-constant-elements': 7.24.7_@babel+core@7.24.7
-      '@babel/preset-env': 7.24.7_@babel+core@7.24.7
-      '@babel/preset-react': 7.24.7_@babel+core@7.24.7
-      '@babel/preset-typescript': 7.24.7_@babel+core@7.24.7
+      '@babel/core': 7.26.0
+      '@babel/plugin-transform-react-constant-elements': 7.25.9_@babel+core@7.26.0
+      '@babel/preset-env': 7.26.0_@babel+core@7.26.0
+      '@babel/preset-react': 7.25.9_@babel+core@7.26.0
+      '@babel/preset-typescript': 7.26.0_@babel+core@7.26.0
       '@svgr/core': 6.5.1
       '@svgr/plugin-jsx': 6.5.1_@svgr+core@6.5.1
       '@svgr/plugin-svgo': 6.5.1_@svgr+core@6.5.1
@@ -5027,10 +5047,10 @@ packages:
       - supports-color
     dev: true
 
-  /@swc/helpers/0.5.11:
-    resolution: {integrity: sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==}
+  /@swc/helpers/0.5.13:
+    resolution: {integrity: sha512-UoKGxQ3r5kYI9dALKJapMmuK+1zWM/H17Z1+iwnNmzcJRnfFuevZs375TA5rW31pu4BS4NoSy1fRsexDXfWn5w==}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.0
 
   /@szmarczak/http-timer/4.0.6:
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
@@ -5038,12 +5058,25 @@ packages:
     dependencies:
       defer-to-connect: 2.0.1
 
+  /@tanstack/react-virtual/3.10.8_nnrd3gsncyragczmpvfhocinkq:
+    resolution: {integrity: sha512-VbzbVGSsZlQktyLrP5nxE+vE1ZR+U0NFAWPbJLoG2+DKPwd2D7dVICTVIIaYlJqX1ZCEnYDbaOpmMwbsyhBoIA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@tanstack/virtual-core': 3.10.8
+      react: 18.3.1
+      react-dom: 18.3.1_react@18.3.1
+
+  /@tanstack/virtual-core/3.10.8:
+    resolution: {integrity: sha512-PBu00mtt95jbKFi6Llk9aik8bnR3tR/oQP1o3TSi+iG//+Q2RTIzCEgKkHG8BB86kxMNW6O8wku+Lmi+QFR6jA==}
+
   /@testing-library/dom/9.3.4:
     resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
     engines: {node: '>=14'}
     dependencies:
-      '@babel/code-frame': 7.24.7
-      '@babel/runtime': 7.24.7
+      '@babel/code-frame': 7.26.2
+      '@babel/runtime': 7.26.0
       '@types/aria-query': 5.0.4
       aria-query: 5.1.3
       chalk: 4.1.2
@@ -5056,7 +5089,7 @@ packages:
     resolution: {integrity: sha512-j31Bn0rQo12fhCWOUWy9fl7wtqkp7In/YP2p5ZFyRuiiB9Qs3g+hS4gAmDWONbAHcRmVooNJ5eOHQDCOmUFXHg==}
     engines: {node: '>=8', npm: '>=6'}
     dependencies:
-      '@babel/runtime': 7.24.7
+      '@babel/runtime': 7.26.0
       chalk: 2.4.2
       css: 2.2.4
       css.escape: 1.5.1
@@ -5074,9 +5107,9 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
     dependencies:
-      '@babel/runtime': 7.24.7
+      '@babel/runtime': 7.26.0
       '@testing-library/dom': 9.3.4
-      '@types/react-dom': 18.3.0
+      '@types/react-dom': 18.3.1
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
     dev: true
@@ -5123,8 +5156,8 @@ packages:
   /@types/babel__core/7.20.5:
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
     dependencies:
-      '@babel/parser': 7.24.7
-      '@babel/types': 7.24.7
+      '@babel/parser': 7.26.2
+      '@babel/types': 7.26.0
       '@types/babel__generator': 7.6.8
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.20.6
@@ -5133,20 +5166,20 @@ packages:
   /@types/babel__generator/7.6.8:
     resolution: {integrity: sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==}
     dependencies:
-      '@babel/types': 7.24.7
+      '@babel/types': 7.26.0
     dev: true
 
   /@types/babel__template/7.4.4:
     resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
     dependencies:
-      '@babel/parser': 7.24.7
-      '@babel/types': 7.24.7
+      '@babel/parser': 7.26.2
+      '@babel/types': 7.26.0
     dev: true
 
   /@types/babel__traverse/7.20.6:
     resolution: {integrity: sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==}
     dependencies:
-      '@babel/types': 7.24.7
+      '@babel/types': 7.26.0
     dev: true
 
   /@types/base64-js/1.3.2:
@@ -5156,13 +5189,13 @@ packages:
     resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
     dev: true
 
   /@types/bonjour/3.5.13:
     resolution: {integrity: sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==}
     dependencies:
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
     dev: true
 
   /@types/cacheable-request/6.0.3:
@@ -5170,37 +5203,30 @@ packages:
     dependencies:
       '@types/http-cache-semantics': 4.0.4
       '@types/keyv': 3.1.4
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       '@types/responselike': 1.0.3
 
   /@types/connect-history-api-fallback/1.5.4:
     resolution: {integrity: sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==}
     dependencies:
-      '@types/express-serve-static-core': 4.19.5
-      '@types/node': 18.19.39
+      '@types/express-serve-static-core': 5.0.1
+      '@types/node': 18.19.62
     dev: true
 
   /@types/connect/3.4.38:
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
     dependencies:
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
     dev: true
 
   /@types/electron-devtools-installer/2.2.5:
     resolution: {integrity: sha512-DhH8z0dadKuDolvH4TiW40Vp7H3VyZbOoZv98hhBaUfnxmvvcXTjkZjzw/54xvAmuG4KFzExOGAiVLg3jM2ojQ==}
     dev: true
 
-  /@types/eslint-scope/3.7.7:
-    resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
+  /@types/eslint/8.56.12:
+    resolution: {integrity: sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==}
     dependencies:
-      '@types/eslint': 8.56.10
-      '@types/estree': 1.0.5
-    dev: true
-
-  /@types/eslint/8.56.10:
-    resolution: {integrity: sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==}
-    dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       '@types/json-schema': 7.0.15
     dev: true
 
@@ -5208,15 +5234,24 @@ packages:
     resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
     dev: true
 
-  /@types/estree/1.0.5:
-    resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
+  /@types/estree/1.0.6:
+    resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
     dev: true
 
-  /@types/express-serve-static-core/4.19.5:
-    resolution: {integrity: sha512-y6W03tvrACO72aijJ5uF02FRq5cgDR9lUxddQ8vyF+GvmjJQqbzDcJngEjURc+ZsG31VI3hODNZJ2URj86pzmg==}
+  /@types/express-serve-static-core/4.19.6:
+    resolution: {integrity: sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==}
     dependencies:
-      '@types/node': 18.19.39
-      '@types/qs': 6.9.15
+      '@types/node': 18.19.62
+      '@types/qs': 6.9.16
+      '@types/range-parser': 1.2.7
+      '@types/send': 0.17.4
+    dev: true
+
+  /@types/express-serve-static-core/5.0.1:
+    resolution: {integrity: sha512-CRICJIl0N5cXDONAdlTv5ShATZ4HEwk6kDDIW2/w9qOWKg+NU/5F8wYRWCrONad0/UKkloNSmmyN/wX4rtpbVA==}
+    dependencies:
+      '@types/node': 18.19.62
+      '@types/qs': 6.9.16
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
     dev: true
@@ -5225,8 +5260,8 @@ packages:
     resolution: {integrity: sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==}
     dependencies:
       '@types/body-parser': 1.19.5
-      '@types/express-serve-static-core': 4.19.5
-      '@types/qs': 6.9.15
+      '@types/express-serve-static-core': 4.19.6
+      '@types/qs': 6.9.16
       '@types/serve-static': 1.15.7
     dev: true
 
@@ -5236,13 +5271,13 @@ packages:
   /@types/graceful-fs/4.1.9:
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
     dependencies:
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
     dev: true
 
   /@types/hoist-non-react-statics/3.3.5:
     resolution: {integrity: sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==}
     dependencies:
-      '@types/react': 18.3.3
+      '@types/react': 18.3.12
       hoist-non-react-statics: 3.3.2
 
   /@types/html-minifier-terser/6.1.0:
@@ -5256,10 +5291,10 @@ packages:
     resolution: {integrity: sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==}
     dev: true
 
-  /@types/http-proxy/1.17.14:
-    resolution: {integrity: sha512-SSrD0c1OQzlFX7pGu1eXxSEjemej64aaNPRhhVYUGqXh0BtldAAx37MG8btcumvpgKyZp1F5Gn3JkktdxiFv6w==}
+  /@types/http-proxy/1.17.15:
+    resolution: {integrity: sha512-25g5atgiVNTIv0LBDTg1H74Hvayx0ajtJPLLcYE3whFv75J0pWNtOBzaXJQgDTmrX1bx5U9YC2w/n65BN1HwRQ==}
     dependencies:
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
     dev: true
 
   /@types/istanbul-lib-coverage/2.0.6:
@@ -5292,17 +5327,17 @@ packages:
       pretty-format: 26.6.2
     dev: true
 
-  /@types/jquery/3.5.30:
-    resolution: {integrity: sha512-nbWKkkyb919DOUxjmRVk8vwtDb0/k8FKncmUKFi+NY+QXqWltooxTrswvz4LspQwxvLdvzBN1TImr6cw3aQx2A==}
+  /@types/jquery/3.5.32:
+    resolution: {integrity: sha512-b9Xbf4CkMqS02YH8zACqN1xzdxc3cO735Qe5AbSUFmyOiaWAbcpqh9Wna+Uk0vgACvoQHpWDg2rGdHkYPLmCiQ==}
     dependencies:
-      '@types/sizzle': 2.3.8
+      '@types/sizzle': 2.3.9
 
   /@types/jsdom/20.0.1:
     resolution: {integrity: sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==}
     dependencies:
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       '@types/tough-cookie': 4.0.5
-      parse5: 7.1.2
+      parse5: 7.2.1
     dev: true
 
   /@types/json-schema/7.0.15:
@@ -5316,22 +5351,22 @@ packages:
   /@types/keyv/3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
 
   /@types/lodash.isequal/4.5.8:
     resolution: {integrity: sha512-uput6pg4E/tj2LGxCZo9+y27JNyB2OZuuI/T5F+ylVDYuqICLG2/ktjxx0v6GvVntAf8TvEzeQLcV0ffRirXuA==}
     dependencies:
-      '@types/lodash': 4.17.6
+      '@types/lodash': 4.17.13
     dev: true
 
-  /@types/lodash/4.17.6:
-    resolution: {integrity: sha512-OpXEVoCKSS3lQqjx9GGGOapBeuW5eUboYHRlHP9urXPX25IKZ6AnP5ZRxtVf63iieUbsHxLn8NQ5Nlftc6yzAA==}
+  /@types/lodash/4.17.13:
+    resolution: {integrity: sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg==}
     dev: true
 
   /@types/mdast/3.0.15:
     resolution: {integrity: sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==}
     dependencies:
-      '@types/unist': 2.0.10
+      '@types/unist': 2.0.11
     dev: true
 
   /@types/mime/1.3.5:
@@ -5345,11 +5380,11 @@ packages:
   /@types/node-forge/1.3.11:
     resolution: {integrity: sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==}
     dependencies:
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
     dev: true
 
-  /@types/node/18.19.39:
-    resolution: {integrity: sha512-nPwTRDKUctxw3di5b4TfT3I0sWDiWoPQCZjXhvdkINntwr8lcoVCKsTgnXeRubKIlfnV+eN/HYk6Jb40tbcEAQ==}
+  /@types/node/18.19.62:
+    resolution: {integrity: sha512-UOGhw+yZV/icyM0qohQVh3ktpY40Sp7tdTW7HxG3pTd7AiMrlFlAJNUrGK9t5mdW0+ViQcFV74zCSIx9ZJpncA==}
     dependencies:
       undici-types: 5.26.5
 
@@ -5359,62 +5394,58 @@ packages:
 
   /@types/parse-json/4.0.2:
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
+    dev: true
 
   /@types/prettier/2.7.3:
     resolution: {integrity: sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==}
     dev: true
 
-  /@types/prop-types/15.7.12:
-    resolution: {integrity: sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==}
+  /@types/prop-types/15.7.13:
+    resolution: {integrity: sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==}
 
-  /@types/qs/6.9.15:
-    resolution: {integrity: sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==}
+  /@types/qs/6.9.16:
+    resolution: {integrity: sha512-7i+zxXdPD0T4cKDuxCUXJ4wHcsJLwENa6Z3dCu8cfCK743OGy5Nu1RmAGqDPsoTDINVEcdXKRvR/zre+P2Ku1A==}
     dev: true
 
   /@types/range-parser/1.2.7:
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
     dev: true
 
-  /@types/react-dom/18.3.0:
-    resolution: {integrity: sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==}
+  /@types/react-dom/18.3.1:
+    resolution: {integrity: sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==}
     dependencies:
-      '@types/react': 18.3.3
+      '@types/react': 18.3.12
     dev: true
 
-  /@types/react-redux/7.1.33:
-    resolution: {integrity: sha512-NF8m5AjWCkert+fosDsN3hAlHzpjSiXlVy9EgQEmLoBhaNXbmyeGs/aj5dQzKuF+/q+S7JQagorGDW8pJ28Hmg==}
+  /@types/react-redux/7.1.34:
+    resolution: {integrity: sha512-GdFaVjEbYv4Fthm2ZLvj1VSCedV7TqE5y1kNwnjSdBOTXuRSgowux6J8TAct15T3CKBr63UMk+2CO7ilRhyrAQ==}
     dependencies:
       '@types/hoist-non-react-statics': 3.3.5
-      '@types/react': 18.3.3
+      '@types/react': 18.3.12
       hoist-non-react-statics: 3.3.2
       redux: 4.2.1
 
   /@types/react-table/7.7.20:
     resolution: {integrity: sha512-ahMp4pmjVlnExxNwxyaDrFgmKxSbPwU23sGQw2gJK4EhCvnvmib2s/O/+y1dfV57dXOwpr2plfyBol+vEHbi2w==}
     dependencies:
-      '@types/react': 18.3.3
+      '@types/react': 18.3.12
 
-  /@types/react-transition-group/4.4.10:
-    resolution: {integrity: sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==}
+  /@types/react/18.3.12:
+    resolution: {integrity: sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==}
     dependencies:
-      '@types/react': 18.3.3
-
-  /@types/react/18.3.3:
-    resolution: {integrity: sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==}
-    dependencies:
-      '@types/prop-types': 15.7.12
+      '@types/prop-types': 15.7.13
       csstype: 3.1.3
 
   /@types/resolve/1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
     dependencies:
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
     dev: true
 
   /@types/responselike/1.0.3:
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
     dependencies:
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
 
   /@types/retry/0.12.0:
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
@@ -5428,7 +5459,7 @@ packages:
     resolution: {integrity: sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==}
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
     dev: true
 
   /@types/serve-index/1.9.4:
@@ -5441,17 +5472,17 @@ packages:
     resolution: {integrity: sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==}
     dependencies:
       '@types/http-errors': 2.0.4
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       '@types/send': 0.17.4
     dev: true
 
-  /@types/sizzle/2.3.8:
-    resolution: {integrity: sha512-0vWLNK2D5MT9dg0iOo8GlKguPAU02QjmZitPEsXRuJXU/OGIOt9vT9Fc26wtYuavLxtO45v9PGleoL9Z0k1LHg==}
+  /@types/sizzle/2.3.9:
+    resolution: {integrity: sha512-xzLEyKB50yqCUPUJkIsrVvoWNfFUbIZI+RspLWt8u+tIW/BetMBZtgV2LY/2o+tYH8dRvQ+eoPf3NdhQCcLE2w==}
 
   /@types/sockjs/0.3.36:
     resolution: {integrity: sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==}
     dependencies:
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
     dev: true
 
   /@types/stack-utils/2.0.3:
@@ -5466,14 +5497,14 @@ packages:
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
     dev: true
 
-  /@types/unist/2.0.10:
-    resolution: {integrity: sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==}
+  /@types/unist/2.0.11:
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
     dev: true
 
-  /@types/ws/8.5.10:
-    resolution: {integrity: sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==}
+  /@types/ws/8.5.12:
+    resolution: {integrity: sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==}
     dependencies:
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
     dev: true
 
   /@types/yargs-parser/21.0.3:
@@ -5498,8 +5529,8 @@ packages:
       '@types/yargs-parser': 21.0.3
     dev: true
 
-  /@types/yargs/17.0.32:
-    resolution: {integrity: sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==}
+  /@types/yargs/17.0.33:
+    resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
     dependencies:
       '@types/yargs-parser': 21.0.3
     dev: true
@@ -5508,7 +5539,7 @@ packages:
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
     requiresBuild: true
     dependencies:
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
     optional: true
 
   /@typescript-eslint/eslint-plugin/4.33.0_ffi3uiz42rv3jyhs6cr7p7qqry:
@@ -5525,18 +5556,18 @@ packages:
       '@typescript-eslint/experimental-utils': 4.33.0_eslint@7.32.0
       '@typescript-eslint/parser': 4.33.0_eslint@7.32.0
       '@typescript-eslint/scope-manager': 4.33.0
-      debug: 4.3.5
+      debug: 4.3.7
       eslint: 7.32.0
       functional-red-black-tree: 1.0.1
-      ignore: 5.3.1
+      ignore: 5.3.2
       regexpp: 3.2.0
-      semver: 7.6.2
+      semver: 7.6.3
       tsutils: 3.21.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.62.0_6642sdbk46myawr2npa4taenme:
+  /@typescript-eslint/eslint-plugin/5.62.0_imxewgebu4zsddg3peaq2zpmd4:
     resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5547,17 +5578,17 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@eslint-community/regexpp': 4.11.0
-      '@typescript-eslint/parser': 5.62.0_lhzdwpbtv2n477nxjcr5ny2fnm
+      '@eslint-community/regexpp': 4.12.1
+      '@typescript-eslint/parser': 5.62.0_iefaljtug4ytsd5a3rfvfodvxa
       '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0_lhzdwpbtv2n477nxjcr5ny2fnm
-      '@typescript-eslint/utils': 5.62.0_lhzdwpbtv2n477nxjcr5ny2fnm
-      debug: 4.3.5
-      eslint: 8.57.0
+      '@typescript-eslint/type-utils': 5.62.0_iefaljtug4ytsd5a3rfvfodvxa
+      '@typescript-eslint/utils': 5.62.0_iefaljtug4ytsd5a3rfvfodvxa
+      debug: 4.3.7
+      eslint: 8.57.1
       graphemer: 1.4.0
-      ignore: 5.3.1
+      ignore: 5.3.2
       natural-compare-lite: 1.4.0
-      semver: 7.6.2
+      semver: 7.6.3
       tsutils: 3.21.0_typescript@5.0.4
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -5599,14 +5630,14 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/experimental-utils/5.62.0_lhzdwpbtv2n477nxjcr5ny2fnm:
+  /@typescript-eslint/experimental-utils/5.62.0_iefaljtug4ytsd5a3rfvfodvxa:
     resolution: {integrity: sha512-RTXpeB3eMkpoclG3ZHft6vG/Z30azNHuqY6wKPBHlVMZFuEvrtlEDe8gMqDb+SO+9hjC/pLekeSCryf9vMZlCw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.62.0_lhzdwpbtv2n477nxjcr5ny2fnm
-      eslint: 8.57.0
+      '@typescript-eslint/utils': 5.62.0_iefaljtug4ytsd5a3rfvfodvxa
+      eslint: 8.57.1
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -5625,13 +5656,13 @@ packages:
       '@typescript-eslint/scope-manager': 4.33.0
       '@typescript-eslint/types': 4.33.0
       '@typescript-eslint/typescript-estree': 4.33.0
-      debug: 4.3.5
+      debug: 4.3.7
       eslint: 7.32.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.62.0_lhzdwpbtv2n477nxjcr5ny2fnm:
+  /@typescript-eslint/parser/5.62.0_iefaljtug4ytsd5a3rfvfodvxa:
     resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5644,8 +5675,8 @@ packages:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0_typescript@5.0.4
-      debug: 4.3.5
-      eslint: 8.57.0
+      debug: 4.3.7
+      eslint: 8.57.1
       typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
@@ -5667,7 +5698,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.62.0
     dev: true
 
-  /@typescript-eslint/type-utils/5.62.0_lhzdwpbtv2n477nxjcr5ny2fnm:
+  /@typescript-eslint/type-utils/5.62.0_iefaljtug4ytsd5a3rfvfodvxa:
     resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5678,9 +5709,9 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0_typescript@5.0.4
-      '@typescript-eslint/utils': 5.62.0_lhzdwpbtv2n477nxjcr5ny2fnm
-      debug: 4.3.5
-      eslint: 8.57.0
+      '@typescript-eslint/utils': 5.62.0_iefaljtug4ytsd5a3rfvfodvxa
+      debug: 4.3.7
+      eslint: 8.57.1
       tsutils: 3.21.0_typescript@5.0.4
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -5713,11 +5744,11 @@ packages:
     dependencies:
       '@typescript-eslint/types': 3.10.1
       '@typescript-eslint/visitor-keys': 3.10.1
-      debug: 4.3.5
+      debug: 4.3.7
       glob: 7.2.3
       is-glob: 4.0.3
       lodash: 4.17.21
-      semver: 7.6.2
+      semver: 7.6.3
       tsutils: 3.21.0
     transitivePeerDependencies:
       - supports-color
@@ -5734,10 +5765,10 @@ packages:
     dependencies:
       '@typescript-eslint/types': 4.33.0
       '@typescript-eslint/visitor-keys': 4.33.0
-      debug: 4.3.5
+      debug: 4.3.7
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.6.2
+      semver: 7.6.3
       tsutils: 3.21.0
     transitivePeerDependencies:
       - supports-color
@@ -5754,31 +5785,31 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.5
+      debug: 4.3.7
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.6.2
+      semver: 7.6.3
       tsutils: 3.21.0_typescript@5.0.4
       typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.62.0_lhzdwpbtv2n477nxjcr5ny2fnm:
+  /@typescript-eslint/utils/5.62.0_iefaljtug4ytsd5a3rfvfodvxa:
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0_eslint@8.57.0
+      '@eslint-community/eslint-utils': 4.4.1_eslint@8.57.1
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0_typescript@5.0.4
-      eslint: 8.57.0
+      eslint: 8.57.1
       eslint-scope: 5.1.1
-      semver: 7.6.2
+      semver: 7.6.3
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -5810,13 +5841,6 @@ packages:
   /@ungap/structured-clone/1.2.0:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
     dev: true
-
-  /@vtaits/use-lazy-ref/0.1.3_react@18.3.1:
-    resolution: {integrity: sha512-ZTLuFBHSivPcgWrwkXe5ExVt6R3/ybD+N0yFPy4ClzCztk/9bUD/1udKQ/jd7eCal+lapSrRWXbffqI9jkpDlg==}
-    peerDependencies:
-      react: ^16.14.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      react: 18.3.1
 
   /@webassemblyjs/ast/1.12.1:
     resolution: {integrity: sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==}
@@ -5958,16 +5982,16 @@ packages:
   /acorn-globals/7.0.1:
     resolution: {integrity: sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==}
     dependencies:
-      acorn: 8.12.1
-      acorn-walk: 8.3.3
+      acorn: 8.14.0
+      acorn-walk: 8.3.4
     dev: true
 
-  /acorn-import-attributes/1.9.5_acorn@8.12.1:
+  /acorn-import-attributes/1.9.5_acorn@8.14.0:
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
     peerDependencies:
       acorn: ^8
     dependencies:
-      acorn: 8.12.1
+      acorn: 8.14.0
     dev: true
 
   /acorn-jsx/5.3.2_acorn@7.4.1:
@@ -5978,12 +6002,12 @@ packages:
       acorn: 7.4.1
     dev: true
 
-  /acorn-jsx/5.3.2_acorn@8.12.1:
+  /acorn-jsx/5.3.2_acorn@8.14.0:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      acorn: 8.12.1
+      acorn: 8.14.0
     dev: true
 
   /acorn-walk/7.2.0:
@@ -5991,11 +6015,11 @@ packages:
     engines: {node: '>=0.4.0'}
     dev: true
 
-  /acorn-walk/8.3.3:
-    resolution: {integrity: sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==}
+  /acorn-walk/8.3.4:
+    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
     engines: {node: '>=0.4.0'}
     dependencies:
-      acorn: 8.12.1
+      acorn: 8.14.0
     dev: true
 
   /acorn/7.4.1:
@@ -6004,8 +6028,8 @@ packages:
     hasBin: true
     dev: true
 
-  /acorn/8.12.1:
-    resolution: {integrity: sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==}
+  /acorn/8.14.0:
+    resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: true
@@ -6027,7 +6051,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.5
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6036,7 +6060,7 @@ packages:
     resolution: {integrity: sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==}
     engines: {node: '>= 14'}
     dependencies:
-      debug: 4.3.5
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
@@ -6048,13 +6072,33 @@ packages:
       indent-string: 4.0.0
     dev: true
 
+  /ajv-draft-04/1.0.0_ajv@8.13.0:
+    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+    dependencies:
+      ajv: 8.13.0
+    dev: true
+
   /ajv-formats/2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependenciesMeta:
       ajv:
         optional: true
     dependencies:
-      ajv: 8.16.0
+      ajv: 8.17.1
+
+  /ajv-formats/3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+    dependencies:
+      ajv: 8.13.0
+    dev: true
 
   /ajv-keywords/3.5.2_ajv@6.12.6:
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
@@ -6064,12 +6108,12 @@ packages:
       ajv: 6.12.6
     dev: true
 
-  /ajv-keywords/5.1.0_ajv@8.16.0:
+  /ajv-keywords/5.1.0_ajv@8.17.1:
     resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
     peerDependencies:
       ajv: ^8.8.2
     dependencies:
-      ajv: 8.16.0
+      ajv: 8.17.1
       fast-deep-equal: 3.1.3
     dev: true
 
@@ -6091,16 +6135,22 @@ packages:
       uri-js: 4.4.1
     dev: true
 
-  /ajv/8.16.0:
-    resolution: {integrity: sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==}
+  /ajv/8.13.0:
+    resolution: {integrity: sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==}
     dependencies:
       fast-deep-equal: 3.1.3
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
       uri-js: 4.4.1
+    dev: true
 
-  /almost-equal/1.1.0:
-    resolution: {integrity: sha512-0V/PkoculFl5+0Lp47JoxUcO0xSxhIBvm+BxHdD/OgXNmdRpRHCFnKVuUoWyS9EzQP+otSGv0m9Lb4yVkQBn2A==}
+  /ajv/8.17.1:
+    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.0.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   /ansi-align/3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
@@ -6147,8 +6197,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /ansi-regex/6.0.1:
-    resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
+  /ansi-regex/6.1.0:
+    resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
     engines: {node: '>=12'}
     dev: true
 
@@ -6166,6 +6216,7 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       color-convert: 1.9.3
+    dev: true
 
   /ansi-styles/4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -6218,6 +6269,11 @@ packages:
     resolution: {integrity: sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==}
     dependencies:
       deep-equal: 2.2.3
+    dev: true
+
+  /aria-query/5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
     dev: true
 
   /arr-diff/4.0.0:
@@ -6312,15 +6368,6 @@ packages:
       es-shim-unscopables: 1.0.2
     dev: true
 
-  /array.prototype.toreversed/1.1.2:
-    resolution: {integrity: sha512-wwDCoT4Ck4Cz7sLtgUmzR5UV3YF5mFHUlbChCzZBQZ+0m2cl/DH3tKgvphv1nKgFsJ48oCSg6p91q2Vm0I/ZMA==}
-    dependencies:
-      call-bind: 1.0.7
-      define-properties: 1.2.1
-      es-abstract: 1.23.3
-      es-shim-unscopables: 1.0.2
-    dev: true
-
   /array.prototype.tosorted/1.1.4:
     resolution: {integrity: sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==}
     engines: {node: '>= 0.4'}
@@ -6375,8 +6422,8 @@ packages:
       lodash: 4.17.21
     dev: true
 
-  /async/3.2.5:
-    resolution: {integrity: sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==}
+  /async/3.2.6:
+    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
     dev: true
 
   /asynckit/0.4.0:
@@ -6397,19 +6444,19 @@ packages:
     resolution: {integrity: sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w==}
     engines: {node: '>=10.12.0'}
 
-  /autoprefixer/10.4.19_postcss@8.4.39:
-    resolution: {integrity: sha512-BaENR2+zBZ8xXhM4pUaKUxlVdxZ0EZhjvbopwnXmxRUfqDmwSpC2lAi/QXvx7NRdPCo1WKEcEF6mV64si1z4Ew==}
+  /autoprefixer/10.4.20_postcss@8.4.47:
+    resolution: {integrity: sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==}
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      browserslist: 4.23.2
-      caniuse-lite: 1.0.30001641
+      browserslist: 4.24.2
+      caniuse-lite: 1.0.30001676
       fraction.js: 4.3.7
       normalize-range: 0.1.2
-      picocolors: 1.0.1
-      postcss: 8.4.39
+      picocolors: 1.1.1
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
@@ -6417,12 +6464,12 @@ packages:
     resolution: {integrity: sha512-eM9d/swFopRt5gdJ7jrpCwgvEMIayITpojhkkSMRsFHYuH5bkSQ4p/9qTEHtmNudUZh22Tehu7I6CxAW0IXTKA==}
     hasBin: true
     dependencies:
-      browserslist: 4.23.2
-      caniuse-lite: 1.0.30001641
+      browserslist: 4.24.2
+      caniuse-lite: 1.0.30001676
       normalize-range: 0.1.2
       num2fraction: 1.2.2
       picocolors: 0.2.1
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
@@ -6433,38 +6480,37 @@ packages:
       possible-typed-array-names: 1.0.0
     dev: true
 
-  /axe-core/4.9.1:
-    resolution: {integrity: sha512-QbUdXJVTpvUTHU7871ppZkdOLBeGUKBQWHkHrvN2V9IQWGMt61zf3B45BtzjxEJzYuj0JBjBZP/hmYS/R9pmAw==}
+  /axe-core/4.10.2:
+    resolution: {integrity: sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==}
     engines: {node: '>=4'}
     dev: true
 
-  /axios/1.7.4:
-    resolution: {integrity: sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==}
+  /axios/1.7.7:
+    resolution: {integrity: sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==}
     dependencies:
-      follow-redirects: 1.15.6
-      form-data: 4.0.0
+      follow-redirects: 1.15.9
+      form-data: 4.0.1
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
 
-  /axobject-query/3.1.1:
-    resolution: {integrity: sha512-goKlv8DZrK9hUh975fnHzhNIO4jUnFCfv/dszV5VwUGDFjI6vQ2VwoyjYjYNEbBE8AH87TduWP5uyDR1D+Iteg==}
-    dependencies:
-      deep-equal: 2.2.3
+  /axobject-query/4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
     dev: true
 
-  /babel-jest/27.5.1_@babel+core@7.24.7:
+  /babel-jest/27.5.1_@babel+core@7.26.0:
     resolution: {integrity: sha512-cdQ5dXjGRd0IBRATiQ4mZGlGlRE8kJpjPOixdNRdT+m3UcNqmYWN6rK6nvtXYfY3D76cb8s/O1Ss8ea24PIwcg==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     peerDependencies:
       '@babel/core': ^7.8.0
     dependencies:
-      '@babel/core': 7.24.7
+      '@babel/core': 7.26.0
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
       '@types/babel__core': 7.20.5
       babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 27.5.1_@babel+core@7.24.7
+      babel-preset-jest: 27.5.1_@babel+core@7.26.0
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
@@ -6472,17 +6518,17 @@ packages:
       - supports-color
     dev: true
 
-  /babel-jest/29.7.0_@babel+core@7.24.7:
+  /babel-jest/29.7.0_@babel+core@7.26.0:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       '@babel/core': ^7.8.0
     dependencies:
-      '@babel/core': 7.24.7
+      '@babel/core': 7.26.0
       '@jest/transform': 29.7.0
       '@types/babel__core': 7.20.5
       babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 29.6.3_@babel+core@7.24.7
+      babel-preset-jest: 29.6.3_@babel+core@7.26.0
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
@@ -6490,19 +6536,19 @@ packages:
       - supports-color
     dev: true
 
-  /babel-loader/8.3.0_z5hqyrl7ys5omqq6tawbtvekhm:
-    resolution: {integrity: sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==}
+  /babel-loader/8.4.1_i3bi27r3gwde5aemtthvmmugoi:
+    resolution: {integrity: sha512-nXzRChX+Z1GoE6yWavBQg6jDslyFF3SDjl2paADuoQtQW10JqShJt62R6eJQ5m/pjJFDT8xgKIWSP85OY8eXeA==}
     engines: {node: '>= 8.9'}
     peerDependencies:
       '@babel/core': ^7.0.0
       webpack: '>=2'
     dependencies:
-      '@babel/core': 7.24.7
+      '@babel/core': 7.26.0
       find-cache-dir: 3.3.2
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.92.1
+      webpack: 5.95.0
     dev: true
 
   /babel-plugin-import-remove-resource-query/1.0.0:
@@ -6513,7 +6559,7 @@ packages:
     resolution: {integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-plugin-utils': 7.25.9
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-instrument: 5.2.1
@@ -6526,8 +6572,8 @@ packages:
     resolution: {integrity: sha512-50wCwD5EMNW4aRpOwtqzyZHIewTYNxLA4nhB+09d8BIssfNfzBRhkBIHiaPv1Si226TQSvp8gxAJm2iY2qs2hQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@babel/template': 7.24.7
-      '@babel/types': 7.24.7
+      '@babel/template': 7.25.9
+      '@babel/types': 7.26.0
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.6
     dev: true
@@ -6536,8 +6582,8 @@ packages:
     resolution: {integrity: sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@babel/template': 7.24.7
-      '@babel/types': 7.24.7
+      '@babel/template': 7.25.9
+      '@babel/types': 7.26.0
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.6
     dev: true
@@ -6546,50 +6592,51 @@ packages:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
     engines: {node: '>=10', npm: '>=6'}
     dependencies:
-      '@babel/runtime': 7.24.7
+      '@babel/runtime': 7.26.0
       cosmiconfig: 7.1.0
       resolve: 1.22.8
+    dev: true
 
-  /babel-plugin-named-asset-import/0.3.8_@babel+core@7.24.7:
+  /babel-plugin-named-asset-import/0.3.8_@babel+core@7.26.0:
     resolution: {integrity: sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q==}
     peerDependencies:
       '@babel/core': ^7.1.0
     dependencies:
-      '@babel/core': 7.24.7
+      '@babel/core': 7.26.0
     dev: true
 
-  /babel-plugin-polyfill-corejs2/0.4.11_@babel+core@7.24.7:
+  /babel-plugin-polyfill-corejs2/0.4.11_@babel+core@7.26.0:
     resolution: {integrity: sha512-sMEJ27L0gRHShOh5G54uAAPaiCOygY/5ratXuiyb2G46FmlSpc9eFCzYVyDiPxfNbwzA7mYahmjQc5q+CZQ09Q==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/compat-data': 7.24.7
-      '@babel/core': 7.24.7
-      '@babel/helper-define-polyfill-provider': 0.6.2_@babel+core@7.24.7
+      '@babel/compat-data': 7.26.2
+      '@babel/core': 7.26.0
+      '@babel/helper-define-polyfill-provider': 0.6.2_@babel+core@7.26.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /babel-plugin-polyfill-corejs3/0.10.4_@babel+core@7.24.7:
-    resolution: {integrity: sha512-25J6I8NGfa5YkCDogHRID3fVCadIR8/pGl1/spvCkzb6lVn6SR3ojpx9nOn9iEBcUsjY24AmdKm5khcfKdylcg==}
+  /babel-plugin-polyfill-corejs3/0.10.6_@babel+core@7.26.0:
+    resolution: {integrity: sha512-b37+KR2i/khY5sKmWNVQAnitvquQbNdWy6lJdsr0kmquCKEEUgMKK4SboVM3HtfnZilfjr4MMQ7vY58FVWDtIA==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-define-polyfill-provider': 0.6.2_@babel+core@7.24.7
-      core-js-compat: 3.37.1
+      '@babel/core': 7.26.0
+      '@babel/helper-define-polyfill-provider': 0.6.2_@babel+core@7.26.0
+      core-js-compat: 3.39.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /babel-plugin-polyfill-regenerator/0.6.2_@babel+core@7.24.7:
+  /babel-plugin-polyfill-regenerator/0.6.2_@babel+core@7.26.0:
     resolution: {integrity: sha512-2R25rQZWP63nGwaAswvDazbPXfrM3HwVoBXK6HcqeKrSrL/JqcC/rDcf95l4r7LXLyxDXc8uQDa064GubtCABg==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-define-polyfill-provider': 0.6.2_@babel+core@7.24.7
+      '@babel/core': 7.26.0
+      '@babel/helper-define-polyfill-provider': 0.6.2_@babel+core@7.26.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6598,65 +6645,68 @@ packages:
     resolution: {integrity: sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==}
     dev: true
 
-  /babel-preset-current-node-syntax/1.0.1_@babel+core@7.24.7:
-    resolution: {integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==}
+  /babel-preset-current-node-syntax/1.1.0_@babel+core@7.26.0:
+    resolution: {integrity: sha512-ldYss8SbBlWva1bs28q78Ju5Zq1F+8BrqBZZ0VFhLBvhh6lCpC2o3gDJi/5DRLs9FgYZCnmPYIVFU4lRXCkyUw==}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.24.7
-      '@babel/plugin-syntax-bigint': 7.8.3_@babel+core@7.24.7
-      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.24.7
-      '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.24.7
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.24.7
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.24.7
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.24.7
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.24.7
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.24.7
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.24.7
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.24.7
-      '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.24.7
+      '@babel/core': 7.26.0
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.26.0
+      '@babel/plugin-syntax-bigint': 7.8.3_@babel+core@7.26.0
+      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.26.0
+      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.26.0
+      '@babel/plugin-syntax-import-attributes': 7.26.0_@babel+core@7.26.0
+      '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.26.0
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.26.0
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.26.0
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.26.0
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.26.0
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.26.0
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.26.0
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.26.0
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.26.0
+      '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.26.0
     dev: true
 
-  /babel-preset-jest/27.5.1_@babel+core@7.24.7:
+  /babel-preset-jest/27.5.1_@babel+core@7.26.0:
     resolution: {integrity: sha512-Nptf2FzlPCWYuJg41HBqXVT8ym6bXOevuCTbhxlUpjwtysGaIWFvDEjp4y+G7fl13FgOdjs7P/DmErqH7da0Ag==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.24.7
+      '@babel/core': 7.26.0
       babel-plugin-jest-hoist: 27.5.1
-      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.24.7
+      babel-preset-current-node-syntax: 1.1.0_@babel+core@7.26.0
     dev: true
 
-  /babel-preset-jest/29.6.3_@babel+core@7.24.7:
+  /babel-preset-jest/29.6.3_@babel+core@7.26.0:
     resolution: {integrity: sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.24.7
+      '@babel/core': 7.26.0
       babel-plugin-jest-hoist: 29.6.3
-      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.24.7
+      babel-preset-current-node-syntax: 1.1.0_@babel+core@7.26.0
     dev: true
 
   /babel-preset-react-app/10.0.1:
     resolution: {integrity: sha512-b0D9IZ1WhhCWkrTXyFuIIgqGzSkRIH5D5AmB0bXbzYAB1OBAwHcUeyWW2LorutLWF5btNo/N7r/cIdmvvKJlYg==}
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.24.7
-      '@babel/plugin-proposal-decorators': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.24.7
-      '@babel/plugin-proposal-numeric-separator': 7.18.6_@babel+core@7.24.7
-      '@babel/plugin-proposal-optional-chaining': 7.21.0_@babel+core@7.24.7
-      '@babel/plugin-proposal-private-methods': 7.18.6_@babel+core@7.24.7
-      '@babel/plugin-transform-flow-strip-types': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-react-display-name': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-transform-runtime': 7.24.7_@babel+core@7.24.7
-      '@babel/preset-env': 7.24.7_@babel+core@7.24.7
-      '@babel/preset-react': 7.24.7_@babel+core@7.24.7
-      '@babel/preset-typescript': 7.24.7_@babel+core@7.24.7
-      '@babel/runtime': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.26.0
+      '@babel/plugin-proposal-decorators': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.26.0
+      '@babel/plugin-proposal-numeric-separator': 7.18.6_@babel+core@7.26.0
+      '@babel/plugin-proposal-optional-chaining': 7.21.0_@babel+core@7.26.0
+      '@babel/plugin-proposal-private-methods': 7.18.6_@babel+core@7.26.0
+      '@babel/plugin-transform-flow-strip-types': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-react-display-name': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-transform-runtime': 7.25.9_@babel+core@7.26.0
+      '@babel/preset-env': 7.26.0_@babel+core@7.26.0
+      '@babel/preset-react': 7.25.9_@babel+core@7.26.0
+      '@babel/preset-typescript': 7.26.0_@babel+core@7.26.0
+      '@babel/runtime': 7.26.0
       babel-plugin-macros: 3.1.0
       babel-plugin-transform-react-remove-prop-types: 0.4.24
     transitivePeerDependencies:
@@ -6687,6 +6737,10 @@ packages:
       mixin-deep: 1.3.2
       pascalcase: 0.1.1
     dev: true
+
+  /base64-js/0.0.8:
+    resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
+    engines: {node: '>= 0.4'}
 
   /base64-js/1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -6749,6 +6803,7 @@ packages:
 
   /boolean/3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     optional: true
 
   /boxen/7.0.0:
@@ -6793,15 +6848,15 @@ packages:
     resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
     dev: true
 
-  /browserslist/4.23.2:
-    resolution: {integrity: sha512-qkqSyistMYdxAcw+CzbZwlBy8AGmS/eEWs+sEV5TnLRGDOL+C5M2EnH6tlZyg0YoAxGJAFKh61En9BR941GnHA==}
+  /browserslist/4.24.2:
+    resolution: {integrity: sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001641
-      electron-to-chromium: 1.4.823
-      node-releases: 2.0.14
-      update-browserslist-db: 1.1.0_browserslist@4.23.2
+      caniuse-lite: 1.0.30001676
+      electron-to-chromium: 1.5.49
+      node-releases: 2.0.18
+      update-browserslist-db: 1.1.1_browserslist@4.24.2
     dev: true
 
   /bs-logger/0.2.6:
@@ -6882,12 +6937,13 @@ packages:
   /callsites/3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
+    dev: true
 
   /camel-case/4.1.2:
     resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
     dependencies:
       pascal-case: 3.1.2
-      tslib: 2.6.3
+      tslib: 2.8.0
     dev: true
 
   /camelcase-css/2.0.1:
@@ -6922,14 +6978,14 @@ packages:
   /caniuse-api/3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
     dependencies:
-      browserslist: 4.23.2
-      caniuse-lite: 1.0.30001641
+      browserslist: 4.24.2
+      caniuse-lite: 1.0.30001676
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
     dev: true
 
-  /caniuse-lite/1.0.30001641:
-    resolution: {integrity: sha512-Phv5thgl67bHYo1TtMY/MurjkHhV4EDaCosezRXgZ8jzA/Ub+wjxAvbGvjoFENStinwi5kCyOYV3mi5tOGykwA==}
+  /caniuse-lite/1.0.30001676:
+    resolution: {integrity: sha512-Qz6zwGCiPghQXGJvgQAem79esjitvJ+CxSbSQkW9H/UX5hg8XM88d4lp2W+MEQ81j+Hip58Il+jGVdazk1z9cw==}
     dev: true
 
   /case-sensitive-paths-webpack-plugin/2.4.0:
@@ -6962,6 +7018,7 @@ packages:
       ansi-styles: 3.2.1
       escape-string-regexp: 1.0.5
       supports-color: 5.5.0
+    dev: true
 
   /chalk/3.0.0:
     resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
@@ -7029,6 +7086,13 @@ packages:
       fsevents: 2.3.3
     dev: true
 
+  /chokidar/4.0.1:
+    resolution: {integrity: sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==}
+    engines: {node: '>= 14.16.0'}
+    dependencies:
+      readdirp: 4.0.2
+    dev: true
+
   /chrome-trace-event/1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
@@ -7039,8 +7103,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /cjs-module-lexer/1.3.1:
-    resolution: {integrity: sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q==}
+  /cjs-module-lexer/1.4.1:
+    resolution: {integrity: sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==}
     dev: true
 
   /class-utils/0.3.6:
@@ -7169,6 +7233,7 @@ packages:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
     dependencies:
       color-name: 1.1.3
+    dev: true
 
   /color-convert/2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -7179,6 +7244,7 @@ packages:
 
   /color-name/1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
+    dev: true
 
   /color-name/1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
@@ -7194,11 +7260,6 @@ packages:
 
   /colors/0.6.2:
     resolution: {integrity: sha512-OsSVtHK8Ir8r3+Fxw/b4jS1ZLPXkV6ZxDRJQzeD7qo0SqMXWrHDM71DgYzPMHY8SFJ0Ao+nNU2p1MmwdzKqPrw==}
-    engines: {node: '>=0.1.90'}
-    dev: true
-
-  /colors/1.2.5:
-    resolution: {integrity: sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==}
     engines: {node: '>=0.1.90'}
     dev: true
 
@@ -7237,13 +7298,6 @@ packages:
     engines: {node: '>= 12'}
     dev: true
 
-  /commander/9.5.0:
-    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
-    engines: {node: ^12.20.0 || >=14}
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /common-tags/1.8.2:
     resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
     engines: {node: '>=4.0.0'}
@@ -7261,7 +7315,7 @@ packages:
     resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
     engines: {node: '>= 0.6'}
     dependencies:
-      mime-db: 1.52.0
+      mime-db: 1.53.0
     dev: true
 
   /compression/1.7.4:
@@ -7291,7 +7345,7 @@ packages:
       lodash: 4.17.21
       read-pkg: 4.0.1
       rxjs: 6.6.7
-      spawn-command: 0.0.2-1
+      spawn-command: 0.0.2
       supports-color: 6.1.0
       tree-kill: 1.2.2
       yargs: 13.3.2
@@ -7301,7 +7355,7 @@ packages:
     resolution: {integrity: sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg==}
     engines: {node: '>=12'}
     dependencies:
-      ajv: 8.16.0
+      ajv: 8.17.1
       ajv-formats: 2.1.1
       atomically: 1.7.0
       debounce-fn: 4.0.0
@@ -7310,7 +7364,7 @@ packages:
       json-schema-typed: 7.0.3
       onetime: 5.1.2
       pkg-up: 3.1.0
-      semver: 7.6.2
+      semver: 7.6.3
 
   /confusing-browser-globals/1.0.11:
     resolution: {integrity: sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==}
@@ -7338,6 +7392,7 @@ packages:
 
   /convert-source-map/1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
+    dev: true
 
   /convert-source-map/2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -7346,8 +7401,8 @@ packages:
   /cookie-signature/1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
 
-  /cookie/0.6.0:
-    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
+  /cookie/0.7.1:
+    resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
     engines: {node: '>= 0.6'}
 
   /copy-descriptor/0.1.1:
@@ -7355,7 +7410,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /copy-webpack-plugin/10.2.4_webpack@5.92.1:
+  /copy-webpack-plugin/10.2.4_webpack@5.95.0:
     resolution: {integrity: sha512-xFVltahqlsRcyyJqQbDY6EYTtyQZF9rf+JPjwHObLdPFMEISqkFkr7mFoVOC6BfYS/dNThyoQKvziugm+OnwBg==}
     engines: {node: '>= 12.20.0'}
     peerDependencies:
@@ -7367,10 +7422,10 @@ packages:
       normalize-path: 3.0.0
       schema-utils: 4.2.0
       serialize-javascript: 6.0.2
-      webpack: 5.92.1
+      webpack: 5.95.0
     dev: true
 
-  /copy-webpack-plugin/11.0.0_webpack@5.92.1:
+  /copy-webpack-plugin/11.0.0_webpack@5.95.0:
     resolution: {integrity: sha512-fX2MWpamkW0hZxMEg0+mYnA40LTosOSa5TqZ9GYIBzyJa9C3QUaMPSE2xAi/buNr8u89SfD9wHSQVBzrRa/SOQ==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -7382,7 +7437,7 @@ packages:
       normalize-path: 3.0.0
       schema-utils: 4.2.0
       serialize-javascript: 6.0.2
-      webpack: 5.92.1
+      webpack: 5.95.0
     dev: true
 
   /copyfiles/2.4.1:
@@ -7398,19 +7453,19 @@ packages:
       yargs: 16.2.0
     dev: true
 
-  /core-js-compat/3.37.1:
-    resolution: {integrity: sha512-9TNiImhKvQqSUkOvk/mMRZzOANTiEVC7WaBNhHcKM7x+/5E1l5NvsysR19zuDQScE8k+kfQXWRN3AtS/eOSHpg==}
+  /core-js-compat/3.39.0:
+    resolution: {integrity: sha512-VgEUx3VwlExr5no0tXlBt+silBvhTryPwCXRI2Id1PN8WTKu7MreethvddqOubrYxkFdv/RnYrqlv1sFNAUelw==}
     dependencies:
-      browserslist: 4.23.2
+      browserslist: 4.24.2
     dev: true
 
-  /core-js-pure/3.37.1:
-    resolution: {integrity: sha512-J/r5JTHSmzTxbiYYrzXg9w1VpqrYt+gexenBE9pugeyhwPZTAEJddyiReJWsLO6uNQ8xJZFbod6XC7KKwatCiA==}
+  /core-js-pure/3.39.0:
+    resolution: {integrity: sha512-7fEcWwKI4rJinnK+wLTezeg2smbFFdSBP6E2kQZNbnzM2s1rpKQ6aaRteZSSg7FLU3P0HGGVo/gbpfanU36urg==}
     requiresBuild: true
     dev: true
 
-  /core-js/3.37.1:
-    resolution: {integrity: sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==}
+  /core-js/3.39.0:
+    resolution: {integrity: sha512-raM0ew0/jJUqkJ0E6e8UDtl+y/7ktFivgWvqw8dNSQeNWoSDLvQ1H/RN3aPXB9tBd4/FhyR4RDPGhsNIMsAn7g==}
     requiresBuild: true
     dev: true
 
@@ -7438,6 +7493,7 @@ packages:
       parse-json: 5.2.0
       path-type: 4.0.0
       yaml: 1.10.2
+    dev: true
 
   /cpx2/3.0.2:
     resolution: {integrity: sha512-xVmdulZJVGSV+c8KkZ9IQY+RgyL9sGeVqScI2e7NtsEY9SVKcQXM4v0/9OLU0W0YtL9nmmqrtWjs5rpvgHn9Hg==}
@@ -7446,7 +7502,7 @@ packages:
     dependencies:
       co: 4.6.0
       debounce: 1.2.1
-      debug: 4.3.5
+      debug: 4.3.7
       duplexer: 0.1.2
       fs-extra: 10.1.0
       glob: 7.2.3
@@ -7466,12 +7522,12 @@ packages:
     hasBin: true
     dependencies:
       debounce: 1.2.1
-      debug: 4.3.5
+      debug: 4.3.7
       duplexer: 0.1.2
       fs-extra: 10.1.0
-      glob-gitignore: 1.0.14
+      glob-gitignore: 1.0.15
       glob2base: 0.0.12
-      ignore: 5.3.1
+      ignore: 5.3.2
       minimatch: 3.1.2
       p-map: 4.0.0
       resolve: 1.22.8
@@ -7482,7 +7538,7 @@ packages:
       - supports-color
     dev: true
 
-  /create-jest/29.7.0_@types+node@18.19.39:
+  /create-jest/29.7.0_@types+node@18.19.62:
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -7491,7 +7547,7 @@ packages:
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0_@types+node@18.19.39
+      jest-config: 29.7.0_@types+node@18.19.62
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -7552,38 +7608,38 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /css-blank-pseudo/3.0.3_postcss@8.4.39:
+  /css-blank-pseudo/3.0.3_postcss@8.4.47:
     resolution: {integrity: sha512-VS90XWtsHGqoM0t4KpH053c4ehxZ2E6HtGI7x68YFV0pTo/QmkV/YFA+NnlvK8guxZVNWGQhVNJGC39Q8XF4OQ==}
     engines: {node: ^12 || ^14 || >=16}
     hasBin: true
     peerDependencies:
       postcss: ^8.4
     dependencies:
-      postcss: 8.4.39
-      postcss-selector-parser: 6.1.0
+      postcss: 8.4.47
+      postcss-selector-parser: 6.1.2
     dev: true
 
-  /css-declaration-sorter/6.4.1_postcss@8.4.39:
+  /css-declaration-sorter/6.4.1_postcss@8.4.47:
     resolution: {integrity: sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g==}
     engines: {node: ^10 || ^12 || >=14}
     peerDependencies:
       postcss: ^8.0.9
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
     dev: true
 
-  /css-has-pseudo/3.0.4_postcss@8.4.39:
+  /css-has-pseudo/3.0.4_postcss@8.4.47:
     resolution: {integrity: sha512-Vse0xpR1K9MNlp2j5w1pgWIJtm1a8qS0JwS9goFYcImjlHEmywP9VUF05aGBXzGpDJF86QXk4L0ypBmwPhGArw==}
     engines: {node: ^12 || ^14 || >=16}
     hasBin: true
     peerDependencies:
       postcss: ^8.4
     dependencies:
-      postcss: 8.4.39
-      postcss-selector-parser: 6.1.0
+      postcss: 8.4.47
+      postcss-selector-parser: 6.1.2
     dev: true
 
-  /css-loader/6.11.0_webpack@5.92.1:
+  /css-loader/6.11.0_webpack@5.95.0:
     resolution: {integrity: sha512-CTJ+AEQJjq5NzLga5pE39qdiSV56F8ywCIsqNIRF0r7BDgWsN25aazToqAFg7ZrtA/U016xudB3ffgweORxX7g==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -7595,18 +7651,18 @@ packages:
       webpack:
         optional: true
     dependencies:
-      icss-utils: 5.1.0_postcss@8.4.39
-      postcss: 8.4.39
-      postcss-modules-extract-imports: 3.1.0_postcss@8.4.39
-      postcss-modules-local-by-default: 4.0.5_postcss@8.4.39
-      postcss-modules-scope: 3.2.0_postcss@8.4.39
-      postcss-modules-values: 4.0.0_postcss@8.4.39
+      icss-utils: 5.1.0_postcss@8.4.47
+      postcss: 8.4.47
+      postcss-modules-extract-imports: 3.1.0_postcss@8.4.47
+      postcss-modules-local-by-default: 4.0.5_postcss@8.4.47
+      postcss-modules-scope: 3.2.0_postcss@8.4.47
+      postcss-modules-values: 4.0.0_postcss@8.4.47
       postcss-value-parser: 4.2.0
-      semver: 7.6.2
-      webpack: 5.92.1
+      semver: 7.6.3
+      webpack: 5.95.0
     dev: true
 
-  /css-minimizer-webpack-plugin/3.4.1_webpack@5.92.1:
+  /css-minimizer-webpack-plugin/3.4.1_webpack@5.95.0:
     resolution: {integrity: sha512-1u6D71zeIfgngN2XNRJefc/hY7Ybsxd74Jm4qngIXyUEk7fss3VUzuHxLAq/R8NAba4QU9OUSaMZlbpRc7bM4Q==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -7625,23 +7681,23 @@ packages:
       esbuild:
         optional: true
     dependencies:
-      cssnano: 5.1.15_postcss@8.4.39
+      cssnano: 5.1.15_postcss@8.4.47
       jest-worker: 27.5.1
-      postcss: 8.4.39
+      postcss: 8.4.47
       schema-utils: 4.2.0
       serialize-javascript: 6.0.2
       source-map: 0.6.1
-      webpack: 5.92.1
+      webpack: 5.95.0
     dev: true
 
-  /css-prefers-color-scheme/6.0.3_postcss@8.4.39:
+  /css-prefers-color-scheme/6.0.3_postcss@8.4.47:
     resolution: {integrity: sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA==}
     engines: {node: ^12 || ^14 || >=16}
     hasBin: true
     peerDependencies:
       postcss: ^8.4
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
     dev: true
 
   /css-select/4.3.0:
@@ -7690,62 +7746,62 @@ packages:
     hasBin: true
     dev: true
 
-  /cssnano-preset-default/5.2.14_postcss@8.4.39:
+  /cssnano-preset-default/5.2.14_postcss@8.4.47:
     resolution: {integrity: sha512-t0SFesj/ZV2OTylqQVOrFgEh5uanxbO6ZAdeCrNsUQ6fVuXwYTxJPNAGvGTxHbD68ldIJNec7PyYZDBrfDQ+6A==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      css-declaration-sorter: 6.4.1_postcss@8.4.39
-      cssnano-utils: 3.1.0_postcss@8.4.39
-      postcss: 8.4.39
-      postcss-calc: 8.2.4_postcss@8.4.39
-      postcss-colormin: 5.3.1_postcss@8.4.39
-      postcss-convert-values: 5.1.3_postcss@8.4.39
-      postcss-discard-comments: 5.1.2_postcss@8.4.39
-      postcss-discard-duplicates: 5.1.0_postcss@8.4.39
-      postcss-discard-empty: 5.1.1_postcss@8.4.39
-      postcss-discard-overridden: 5.1.0_postcss@8.4.39
-      postcss-merge-longhand: 5.1.7_postcss@8.4.39
-      postcss-merge-rules: 5.1.4_postcss@8.4.39
-      postcss-minify-font-values: 5.1.0_postcss@8.4.39
-      postcss-minify-gradients: 5.1.1_postcss@8.4.39
-      postcss-minify-params: 5.1.4_postcss@8.4.39
-      postcss-minify-selectors: 5.2.1_postcss@8.4.39
-      postcss-normalize-charset: 5.1.0_postcss@8.4.39
-      postcss-normalize-display-values: 5.1.0_postcss@8.4.39
-      postcss-normalize-positions: 5.1.1_postcss@8.4.39
-      postcss-normalize-repeat-style: 5.1.1_postcss@8.4.39
-      postcss-normalize-string: 5.1.0_postcss@8.4.39
-      postcss-normalize-timing-functions: 5.1.0_postcss@8.4.39
-      postcss-normalize-unicode: 5.1.1_postcss@8.4.39
-      postcss-normalize-url: 5.1.0_postcss@8.4.39
-      postcss-normalize-whitespace: 5.1.1_postcss@8.4.39
-      postcss-ordered-values: 5.1.3_postcss@8.4.39
-      postcss-reduce-initial: 5.1.2_postcss@8.4.39
-      postcss-reduce-transforms: 5.1.0_postcss@8.4.39
-      postcss-svgo: 5.1.0_postcss@8.4.39
-      postcss-unique-selectors: 5.1.1_postcss@8.4.39
+      css-declaration-sorter: 6.4.1_postcss@8.4.47
+      cssnano-utils: 3.1.0_postcss@8.4.47
+      postcss: 8.4.47
+      postcss-calc: 8.2.4_postcss@8.4.47
+      postcss-colormin: 5.3.1_postcss@8.4.47
+      postcss-convert-values: 5.1.3_postcss@8.4.47
+      postcss-discard-comments: 5.1.2_postcss@8.4.47
+      postcss-discard-duplicates: 5.1.0_postcss@8.4.47
+      postcss-discard-empty: 5.1.1_postcss@8.4.47
+      postcss-discard-overridden: 5.1.0_postcss@8.4.47
+      postcss-merge-longhand: 5.1.7_postcss@8.4.47
+      postcss-merge-rules: 5.1.4_postcss@8.4.47
+      postcss-minify-font-values: 5.1.0_postcss@8.4.47
+      postcss-minify-gradients: 5.1.1_postcss@8.4.47
+      postcss-minify-params: 5.1.4_postcss@8.4.47
+      postcss-minify-selectors: 5.2.1_postcss@8.4.47
+      postcss-normalize-charset: 5.1.0_postcss@8.4.47
+      postcss-normalize-display-values: 5.1.0_postcss@8.4.47
+      postcss-normalize-positions: 5.1.1_postcss@8.4.47
+      postcss-normalize-repeat-style: 5.1.1_postcss@8.4.47
+      postcss-normalize-string: 5.1.0_postcss@8.4.47
+      postcss-normalize-timing-functions: 5.1.0_postcss@8.4.47
+      postcss-normalize-unicode: 5.1.1_postcss@8.4.47
+      postcss-normalize-url: 5.1.0_postcss@8.4.47
+      postcss-normalize-whitespace: 5.1.1_postcss@8.4.47
+      postcss-ordered-values: 5.1.3_postcss@8.4.47
+      postcss-reduce-initial: 5.1.2_postcss@8.4.47
+      postcss-reduce-transforms: 5.1.0_postcss@8.4.47
+      postcss-svgo: 5.1.0_postcss@8.4.47
+      postcss-unique-selectors: 5.1.1_postcss@8.4.47
     dev: true
 
-  /cssnano-utils/3.1.0_postcss@8.4.39:
+  /cssnano-utils/3.1.0_postcss@8.4.47:
     resolution: {integrity: sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
     dev: true
 
-  /cssnano/5.1.15_postcss@8.4.39:
+  /cssnano/5.1.15_postcss@8.4.47:
     resolution: {integrity: sha512-j+BKgDcLDQA+eDifLx0EO4XSA56b7uut3BQFH+wbSaSTuGLuiyTa/wbRYthUXX8LC9mLg+WWKe8h+qJuwTAbHw==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      cssnano-preset-default: 5.2.14_postcss@8.4.39
+      cssnano-preset-default: 5.2.14_postcss@8.4.47
       lilconfig: 2.1.0
-      postcss: 8.4.39
+      postcss: 8.4.47
       yaml: 1.10.2
     dev: true
 
@@ -7831,7 +7887,7 @@ packages:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
     engines: {node: '>=0.11'}
     dependencies:
-      '@babel/runtime': 7.24.7
+      '@babel/runtime': 7.26.0
     dev: true
 
   /debounce-fn/4.0.0:
@@ -7855,8 +7911,8 @@ packages:
       ms: 2.1.3
     dev: true
 
-  /debug/4.3.5:
-    resolution: {integrity: sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==}
+  /debug/4.3.7:
+    resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -7864,10 +7920,10 @@ packages:
       supports-color:
         optional: true
     dependencies:
-      ms: 2.1.2
+      ms: 2.1.3
 
-  /debug/4.3.5_supports-color@8.1.1:
-    resolution: {integrity: sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==}
+  /debug/4.3.7_supports-color@8.1.1:
+    resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -7875,7 +7931,7 @@ packages:
       supports-color:
         optional: true
     dependencies:
-      ms: 2.1.2
+      ms: 2.1.3
       supports-color: 8.1.1
     dev: true
 
@@ -7942,7 +7998,7 @@ packages:
       object-is: 1.1.6
       object-keys: 1.1.1
       object.assign: 4.1.5
-      regexp.prototype.flags: 1.5.2
+      regexp.prototype.flags: 1.5.3
       side-channel: 1.0.6
       which-boxed-primitive: 1.0.2
       which-collection: 1.0.2
@@ -8038,6 +8094,12 @@ packages:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
+  /detect-libc/1.0.3:
+    resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
+    engines: {node: '>=0.10'}
+    hasBin: true
+    dev: true
+
   /detect-newline/3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
@@ -8129,7 +8191,7 @@ packages:
   /dom-helpers/5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
     dependencies:
-      '@babel/runtime': 7.24.7
+      '@babel/runtime': 7.26.0
       csstype: 3.1.3
 
   /dom-serializer/0.2.2:
@@ -8184,8 +8246,8 @@ packages:
       domelementtype: 2.3.0
     dev: true
 
-  /dompurify/2.5.6:
-    resolution: {integrity: sha512-zUTaUBO8pY4+iJMPE1B9XlO2tXVYIcEA4SNGtvDELzTSCQO7RzH+j7S180BmhmJId78lqGU2z19vgVx2Sxs/PQ==}
+  /dompurify/2.5.7:
+    resolution: {integrity: sha512-2q4bEI+coQM8f5ez7kt2xclg1XsecaV9ASJk/54vwlfRRNQfDqJz2pzQ8t0Ix/ToBpXlVjrRIx7pFC/o8itG2Q==}
 
   /domready/1.0.8:
     resolution: {integrity: sha512-uIzsOJUNk+AdGE9a6VDeessoMCzF8RrZvJCX/W8QtyfgdR6Uofn/MvRonih3OtCO79b2VDzDOymuiABrQ4z3XA==}
@@ -8210,7 +8272,7 @@ packages:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.6.3
+      tslib: 2.8.0
     dev: true
 
   /dot-prop/6.0.1:
@@ -8259,7 +8321,7 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
     dependencies:
-      jake: 10.9.1
+      jake: 10.9.2
     dev: true
 
   /electron-devtools-installer/2.2.4:
@@ -8277,8 +8339,8 @@ packages:
       conf: 10.2.0
       type-fest: 2.19.0
 
-  /electron-to-chromium/1.4.823:
-    resolution: {integrity: sha512-4h+oPeAiGQOHFyUJOqpoEcPj/xxlicxBzOErVeYVMMmAiXUXsGpsFd0QXBMaUUbnD8hhSfLf9uw+MlsoIA7j5w==}
+  /electron-to-chromium/1.5.49:
+    resolution: {integrity: sha512-ZXfs1Of8fDb6z7WEYZjXpgIRF6MEu8JdeGA0A40aZq6OQbS+eJpnnV49epZRna2DU/YsEjSQuGtQPPtvt6J65A==}
     dev: true
 
   /electron/24.8.8:
@@ -8288,7 +8350,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@electron/get': 2.0.3
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -8329,13 +8391,17 @@ packages:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
     engines: {node: '>= 0.8'}
 
+  /encodeurl/2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
   /end-of-stream/1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
     dependencies:
       once: 1.4.0
 
-  /enhanced-resolve/5.17.0:
-    resolution: {integrity: sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA==}
+  /enhanced-resolve/5.17.1:
+    resolution: {integrity: sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==}
     engines: {node: '>=10.13.0'}
     dependencies:
       graceful-fs: 4.2.11
@@ -8371,6 +8437,7 @@ packages:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
     dependencies:
       is-arrayish: 0.2.1
+    dev: true
 
   /error-stack-parser/2.1.4:
     resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
@@ -8416,7 +8483,7 @@ packages:
       object-inspect: 1.13.2
       object-keys: 1.1.1
       object.assign: 4.1.5
-      regexp.prototype.flags: 1.5.2
+      regexp.prototype.flags: 1.5.3
       safe-array-concat: 1.1.2
       safe-regex-test: 1.0.3
       string.prototype.trim: 1.2.9
@@ -8454,8 +8521,8 @@ packages:
       stop-iteration-iterator: 1.0.0
     dev: true
 
-  /es-iterator-helpers/1.0.19:
-    resolution: {integrity: sha512-zoMwbCcH5hwUkKJkT8kDIBZSz9I6mVG//+lDCinLCGov4+r7NIy0ld8o03M0cJxl2spVf6ESYVS6/gpIfq1FFw==}
+  /es-iterator-helpers/1.1.0:
+    resolution: {integrity: sha512-/SurEfycdyssORP/E+bj4sEu1CWw4EmLDsHynHwSXQ7utgbrMRWW195pTrCjFgFCddf/UkYm3oqKPRq5i8bJbw==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.7
@@ -8470,7 +8537,7 @@ packages:
       has-proto: 1.0.3
       has-symbols: 1.0.3
       internal-slot: 1.0.7
-      iterator.prototype: 1.1.2
+      iterator.prototype: 1.1.3
       safe-array-concat: 1.1.2
     dev: true
 
@@ -8676,8 +8743,8 @@ packages:
       esbuild-windows-arm64: 0.13.15
     dev: true
 
-  /escalade/3.1.2:
-    resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
+  /escalade/3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
     dev: true
 
@@ -8687,6 +8754,7 @@ packages:
   /escape-string-regexp/1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
+    dev: true
 
   /escape-string-regexp/2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
@@ -8722,7 +8790,7 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /eslint-config-airbnb-base/14.2.1_ryxylqcqjrgqrcq5e2gwnwvmem:
+  /eslint-config-airbnb-base/14.2.1_lixxg4lvkdf443isck4h3kyyta:
     resolution: {integrity: sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==}
     engines: {node: '>= 6'}
     peerDependencies:
@@ -8731,12 +8799,12 @@ packages:
     dependencies:
       confusing-browser-globals: 1.0.11
       eslint: 7.32.0
-      eslint-plugin-import: 2.29.1_eslint@7.32.0
+      eslint-plugin-import: 2.31.0_eslint@7.32.0
       object.assign: 4.1.5
       object.entries: 1.1.8
     dev: true
 
-  /eslint-config-airbnb/18.2.1_cb6pno7fzmlsn2yskxvbihgdme:
+  /eslint-config-airbnb/18.2.1_j47woh5gdjkhehtho5cd7z7hme:
     resolution: {integrity: sha512-glZNDEZ36VdlZWoxn/bUR1r/sdFKPd1mHPbqUtkctgNG4yT2DLLtJ3D+yCV+jzZCc2V1nBVkmdknOJBZ5Hc0fg==}
     engines: {node: '>= 6'}
     peerDependencies:
@@ -8747,10 +8815,10 @@ packages:
       eslint-plugin-react-hooks: ^4 || ^3 || ^2.3.0 || ^1.7.0
     dependencies:
       eslint: 7.32.0
-      eslint-config-airbnb-base: 14.2.1_ryxylqcqjrgqrcq5e2gwnwvmem
-      eslint-plugin-import: 2.29.1_eslint@7.32.0
-      eslint-plugin-jsx-a11y: 6.9.0_eslint@7.32.0
-      eslint-plugin-react: 7.34.3_eslint@7.32.0
+      eslint-config-airbnb-base: 14.2.1_lixxg4lvkdf443isck4h3kyyta
+      eslint-plugin-import: 2.31.0_eslint@7.32.0
+      eslint-plugin-jsx-a11y: 6.10.2_eslint@7.32.0
+      eslint-plugin-react: 7.37.2_eslint@7.32.0
       eslint-plugin-react-hooks: 4.6.2_eslint@7.32.0
       object.assign: 4.1.5
       object.entries: 1.1.8
@@ -8766,7 +8834,7 @@ packages:
       get-stdin: 6.0.0
     dev: true
 
-  /eslint-config-react-app/6.0.0_ssuykkwe44xqfk7ygtu5dsspum:
+  /eslint-config-react-app/6.0.0_vblgvs7dq6s2rjad5szwfif2ae:
     resolution: {integrity: sha512-bpoAAC+YRfzq0dsTk+6v9aHm/uqnDwayNAXleMypGl6CpxI9oXXscVHo4fk3eJPIn+rsbtNetB4r/ZIidFIE8A==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -8792,33 +8860,33 @@ packages:
       confusing-browser-globals: 1.0.11
       eslint: 7.32.0
       eslint-plugin-flowtype: 5.10.0_eslint@7.32.0
-      eslint-plugin-import: 2.29.1_eslint@7.32.0
-      eslint-plugin-jsx-a11y: 6.9.0_eslint@7.32.0
-      eslint-plugin-react: 7.34.3_eslint@7.32.0
+      eslint-plugin-import: 2.31.0_eslint@7.32.0
+      eslint-plugin-jsx-a11y: 6.10.2_eslint@7.32.0
+      eslint-plugin-react: 7.37.2_eslint@7.32.0
       eslint-plugin-react-hooks: 4.6.2_eslint@7.32.0
     dev: true
 
-  /eslint-config-react-app/7.0.1_rxydg5byhhw2ikqe4ecaedklea:
+  /eslint-config-react-app/7.0.1_l6sf7e4olydjhtf3qe76zuqhfi:
     resolution: {integrity: sha512-K6rNzvkIeHaTd8m/QEh1Zko0KI7BACWkkneSs6s9cKZC/J27X3eZR6Upt1jkmZ/4FK+XUOPPxMEN7+lbUXfSlA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       eslint: ^8.0.0
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/eslint-parser': 7.24.7_ivopgdbs46443pcald3k67gmwm
-      '@rushstack/eslint-patch': 1.10.3
-      '@typescript-eslint/eslint-plugin': 5.62.0_6642sdbk46myawr2npa4taenme
-      '@typescript-eslint/parser': 5.62.0_lhzdwpbtv2n477nxjcr5ny2fnm
+      '@babel/core': 7.26.0
+      '@babel/eslint-parser': 7.25.9_ug2igzfsn2htp6pvbk547j4y6y
+      '@rushstack/eslint-patch': 1.10.4
+      '@typescript-eslint/eslint-plugin': 5.62.0_imxewgebu4zsddg3peaq2zpmd4
+      '@typescript-eslint/parser': 5.62.0_iefaljtug4ytsd5a3rfvfodvxa
       babel-preset-react-app: 10.0.1
       confusing-browser-globals: 1.0.11
-      eslint: 8.57.0
-      eslint-plugin-flowtype: 8.0.3_eslint@8.57.0
-      eslint-plugin-import: 2.29.1_eslint@8.57.0
-      eslint-plugin-jest: 25.7.0_6g2l2tswdavbxveddlniuczqoi
-      eslint-plugin-jsx-a11y: 6.9.0_eslint@8.57.0
-      eslint-plugin-react: 7.34.3_eslint@8.57.0
-      eslint-plugin-react-hooks: 4.6.2_eslint@8.57.0
-      eslint-plugin-testing-library: 5.11.1_lhzdwpbtv2n477nxjcr5ny2fnm
+      eslint: 8.57.1
+      eslint-plugin-flowtype: 8.0.3_eslint@8.57.1
+      eslint-plugin-import: 2.31.0_eslint@8.57.1
+      eslint-plugin-jest: 25.7.0_vsn4rgfo3vkx5dadyu7tqmjoza
+      eslint-plugin-jsx-a11y: 6.10.2_eslint@8.57.1
+      eslint-plugin-react: 7.37.2_eslint@8.57.1
+      eslint-plugin-react-hooks: 4.6.2_eslint@8.57.1
+      eslint-plugin-testing-library: 5.11.1_iefaljtug4ytsd5a3rfvfodvxa
     transitivePeerDependencies:
       - '@babel/plugin-syntax-flow'
       - '@babel/plugin-transform-react-jsx'
@@ -8831,12 +8899,12 @@ packages:
     resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
     dependencies:
       debug: 3.2.7
-      is-core-module: 2.14.0
+      is-core-module: 2.15.1
       resolve: 1.22.8
     dev: true
 
-  /eslint-module-utils/2.8.1_eslint@7.32.0:
-    resolution: {integrity: sha512-rXDXR3h7cs7dy9RNpUlQf80nX31XWJEyGq1tRMo+6GsO5VmTe4UTwtmonAD4ZkAsrfMVDA2wlGJ3790Ys+D49Q==}
+  /eslint-module-utils/2.12.0_eslint@7.32.0:
+    resolution: {integrity: sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==}
     engines: {node: '>=4'}
     peerDependencies:
       eslint: '*'
@@ -8848,8 +8916,8 @@ packages:
       eslint: 7.32.0
     dev: true
 
-  /eslint-module-utils/2.8.1_eslint@8.57.0:
-    resolution: {integrity: sha512-rXDXR3h7cs7dy9RNpUlQf80nX31XWJEyGq1tRMo+6GsO5VmTe4UTwtmonAD4ZkAsrfMVDA2wlGJ3790Ys+D49Q==}
+  /eslint-module-utils/2.12.0_eslint@8.57.1:
+    resolution: {integrity: sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==}
     engines: {node: '>=4'}
     peerDependencies:
       eslint: '*'
@@ -8858,7 +8926,7 @@ packages:
         optional: true
     dependencies:
       debug: 3.2.7
-      eslint: 8.57.0
+      eslint: 8.57.1
     dev: true
 
   /eslint-plugin-deprecation/1.2.1_eslint@7.32.0:
@@ -8886,7 +8954,7 @@ packages:
       string-natural-compare: 3.0.1
     dev: true
 
-  /eslint-plugin-flowtype/8.0.3_eslint@8.57.0:
+  /eslint-plugin-flowtype/8.0.3_eslint@8.57.1:
     resolution: {integrity: sha512-dX8l6qUL6O+fYPtpNRideCFSpmWOUVx5QcaGLVqe/vlDiBSe4vYljDWDETwnyFzpl7By/WVIu6rcrniCgH9BqQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -8894,17 +8962,18 @@ packages:
       '@babel/plugin-transform-react-jsx': ^7.14.9
       eslint: ^8.1.0
     dependencies:
-      eslint: 8.57.0
+      eslint: 8.57.1
       lodash: 4.17.21
       string-natural-compare: 3.0.1
     dev: true
 
-  /eslint-plugin-import/2.29.1_eslint@7.32.0:
-    resolution: {integrity: sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==}
+  /eslint-plugin-import/2.31.0_eslint@7.32.0:
+    resolution: {integrity: sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==}
     engines: {node: '>=4'}
     peerDependencies:
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9
     dependencies:
+      '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
       array.prototype.flat: 1.3.2
@@ -8913,45 +8982,48 @@ packages:
       doctrine: 2.1.0
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1_eslint@7.32.0
+      eslint-module-utils: 2.12.0_eslint@7.32.0
       hasown: 2.0.2
-      is-core-module: 2.14.0
+      is-core-module: 2.15.1
       is-glob: 4.0.3
       minimatch: 3.1.2
       object.fromentries: 2.0.8
       object.groupby: 1.0.3
       object.values: 1.2.0
       semver: 6.3.1
+      string.prototype.trimend: 1.0.8
       tsconfig-paths: 3.15.0
     dev: true
 
-  /eslint-plugin-import/2.29.1_eslint@8.57.0:
-    resolution: {integrity: sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==}
+  /eslint-plugin-import/2.31.0_eslint@8.57.1:
+    resolution: {integrity: sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==}
     engines: {node: '>=4'}
     peerDependencies:
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9
     dependencies:
+      '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
       array.prototype.flat: 1.3.2
       array.prototype.flatmap: 1.3.2
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 8.57.0
+      eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1_eslint@8.57.0
+      eslint-module-utils: 2.12.0_eslint@8.57.1
       hasown: 2.0.2
-      is-core-module: 2.14.0
+      is-core-module: 2.15.1
       is-glob: 4.0.3
       minimatch: 3.1.2
       object.fromentries: 2.0.8
       object.groupby: 1.0.3
       object.values: 1.2.0
       semver: 6.3.1
+      string.prototype.trimend: 1.0.8
       tsconfig-paths: 3.15.0
     dev: true
 
-  /eslint-plugin-jest/25.7.0_6g2l2tswdavbxveddlniuczqoi:
+  /eslint-plugin-jest/25.7.0_vsn4rgfo3vkx5dadyu7tqmjoza:
     resolution: {integrity: sha512-PWLUEXeeF7C9QGKqvdSbzLOiLTx+bno7/HC9eefePfEb257QFHg7ye3dh80AZVkaa/RQsBB1Q/ORQvg2X7F0NQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     peerDependencies:
@@ -8964,30 +9036,29 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0_6642sdbk46myawr2npa4taenme
-      '@typescript-eslint/experimental-utils': 5.62.0_lhzdwpbtv2n477nxjcr5ny2fnm
-      eslint: 8.57.0
+      '@typescript-eslint/eslint-plugin': 5.62.0_imxewgebu4zsddg3peaq2zpmd4
+      '@typescript-eslint/experimental-utils': 5.62.0_iefaljtug4ytsd5a3rfvfodvxa
+      eslint: 8.57.1
       jest: 27.5.1
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /eslint-plugin-jsx-a11y/6.9.0_eslint@7.32.0:
-    resolution: {integrity: sha512-nOFOCaJG2pYqORjK19lqPqxMO/JpvdCZdPtNdxY3kvom3jTvkAbOvQvD8wuD0G8BYR0IGAGYDlzqWJOh/ybn2g==}
+  /eslint-plugin-jsx-a11y/6.10.2_eslint@7.32.0:
+    resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
     engines: {node: '>=4.0'}
     peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
     dependencies:
-      aria-query: 5.1.3
+      aria-query: 5.3.2
       array-includes: 3.1.8
       array.prototype.flatmap: 1.3.2
       ast-types-flow: 0.0.8
-      axe-core: 4.9.1
-      axobject-query: 3.1.1
+      axe-core: 4.10.2
+      axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      es-iterator-helpers: 1.0.19
       eslint: 7.32.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
@@ -8995,32 +9066,31 @@ packages:
       minimatch: 3.1.2
       object.fromentries: 2.0.8
       safe-regex-test: 1.0.3
-      string.prototype.includes: 2.0.0
+      string.prototype.includes: 2.0.1
     dev: true
 
-  /eslint-plugin-jsx-a11y/6.9.0_eslint@8.57.0:
-    resolution: {integrity: sha512-nOFOCaJG2pYqORjK19lqPqxMO/JpvdCZdPtNdxY3kvom3jTvkAbOvQvD8wuD0G8BYR0IGAGYDlzqWJOh/ybn2g==}
+  /eslint-plugin-jsx-a11y/6.10.2_eslint@8.57.1:
+    resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
     engines: {node: '>=4.0'}
     peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
     dependencies:
-      aria-query: 5.1.3
+      aria-query: 5.3.2
       array-includes: 3.1.8
       array.prototype.flatmap: 1.3.2
       ast-types-flow: 0.0.8
-      axe-core: 4.9.1
-      axobject-query: 3.1.1
+      axe-core: 4.10.2
+      axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      es-iterator-helpers: 1.0.19
-      eslint: 8.57.0
+      eslint: 8.57.1
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
       minimatch: 3.1.2
       object.fromentries: 2.0.8
       safe-regex-test: 1.0.3
-      string.prototype.includes: 2.0.0
+      string.prototype.includes: 2.0.1
     dev: true
 
   /eslint-plugin-prefer-arrow/1.2.3_eslint@7.32.0:
@@ -9057,67 +9127,67 @@ packages:
       eslint: 7.32.0
     dev: true
 
-  /eslint-plugin-react-hooks/4.6.2_eslint@8.57.0:
+  /eslint-plugin-react-hooks/4.6.2_eslint@8.57.1:
     resolution: {integrity: sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==}
     engines: {node: '>=10'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
     dependencies:
-      eslint: 8.57.0
+      eslint: 8.57.1
     dev: true
 
-  /eslint-plugin-react/7.34.3_eslint@7.32.0:
-    resolution: {integrity: sha512-aoW4MV891jkUulwDApQbPYTVZmeuSyFrudpbTAQuj5Fv8VL+o6df2xIGpw8B0hPjAaih1/Fb0om9grCdyFYemA==}
+  /eslint-plugin-react/7.37.2_eslint@7.32.0:
+    resolution: {integrity: sha512-EsTAnj9fLVr/GZleBLFbj/sSuXeWmp1eXIN60ceYnZveqEaUCyW4X+Vh4WTdUhCkW4xutXYqTXCUSyqD4rB75w==}
     engines: {node: '>=4'}
     peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlast: 1.2.5
       array.prototype.flatmap: 1.3.2
-      array.prototype.toreversed: 1.1.2
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
-      es-iterator-helpers: 1.0.19
+      es-iterator-helpers: 1.1.0
       eslint: 7.32.0
       estraverse: 5.3.0
+      hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       minimatch: 3.1.2
       object.entries: 1.1.8
       object.fromentries: 2.0.8
-      object.hasown: 1.1.4
       object.values: 1.2.0
       prop-types: 15.8.1
       resolve: 2.0.0-next.5
       semver: 6.3.1
       string.prototype.matchall: 4.0.11
+      string.prototype.repeat: 1.0.0
     dev: true
 
-  /eslint-plugin-react/7.34.3_eslint@8.57.0:
-    resolution: {integrity: sha512-aoW4MV891jkUulwDApQbPYTVZmeuSyFrudpbTAQuj5Fv8VL+o6df2xIGpw8B0hPjAaih1/Fb0om9grCdyFYemA==}
+  /eslint-plugin-react/7.37.2_eslint@8.57.1:
+    resolution: {integrity: sha512-EsTAnj9fLVr/GZleBLFbj/sSuXeWmp1eXIN60ceYnZveqEaUCyW4X+Vh4WTdUhCkW4xutXYqTXCUSyqD4rB75w==}
     engines: {node: '>=4'}
     peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlast: 1.2.5
       array.prototype.flatmap: 1.3.2
-      array.prototype.toreversed: 1.1.2
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
-      es-iterator-helpers: 1.0.19
-      eslint: 8.57.0
+      es-iterator-helpers: 1.1.0
+      eslint: 8.57.1
       estraverse: 5.3.0
+      hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       minimatch: 3.1.2
       object.entries: 1.1.8
       object.fromentries: 2.0.8
-      object.hasown: 1.1.4
       object.values: 1.2.0
       prop-types: 15.8.1
       resolve: 2.0.0-next.5
       semver: 6.3.1
       string.prototype.matchall: 4.0.11
+      string.prototype.repeat: 1.0.0
     dev: true
 
   /eslint-plugin-simple-import-sort/5.0.3_eslint@7.32.0:
@@ -9128,14 +9198,14 @@ packages:
       eslint: 7.32.0
     dev: true
 
-  /eslint-plugin-testing-library/5.11.1_lhzdwpbtv2n477nxjcr5ny2fnm:
+  /eslint-plugin-testing-library/5.11.1_iefaljtug4ytsd5a3rfvfodvxa:
     resolution: {integrity: sha512-5eX9e1Kc2PqVRed3taaLnAAqPZGEX75C+M/rXzUAI3wIg/ZxzUm1OVAwfe/O+vE+6YXOLetSe9g5GKD2ecXipw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0, npm: '>=6'}
     peerDependencies:
       eslint: ^7.5.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.62.0_lhzdwpbtv2n477nxjcr5ny2fnm
-      eslint: 8.57.0
+      '@typescript-eslint/utils': 5.62.0_iefaljtug4ytsd5a3rfvfodvxa
+      eslint: 8.57.1
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -9189,25 +9259,26 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /eslint-webpack-plugin/3.2.0_2razpbuuqgklq63beclqevrxh4:
+  /eslint-webpack-plugin/3.2.0_23g3mlqifdeyf7a5itkkqemkee:
     resolution: {integrity: sha512-avrKcGncpPbPSUHX6B3stNGzkKFto3eL+DKM4+VyMrVnhPc3vRczVlCq3uhuFOdRvDHTVXuzwk1ZKUrqDQHQ9w==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
       webpack: ^5.0.0
     dependencies:
-      '@types/eslint': 8.56.10
-      eslint: 8.57.0
+      '@types/eslint': 8.56.12
+      eslint: 8.57.1
       jest-worker: 28.1.3
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       normalize-path: 3.0.0
       schema-utils: 4.2.0
-      webpack: 5.92.1
+      webpack: 5.95.0
     dev: true
 
   /eslint/7.32.0:
     resolution: {integrity: sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==}
     engines: {node: ^10.12.0 || >=12.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     dependencies:
       '@babel/code-frame': 7.12.11
@@ -9216,7 +9287,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.5
+      debug: 4.3.7
       doctrine: 3.0.0
       enquirer: 2.4.1
       escape-string-regexp: 4.0.0
@@ -9244,7 +9315,7 @@ packages:
       optionator: 0.9.4
       progress: 2.0.3
       regexpp: 3.2.0
-      semver: 7.6.2
+      semver: 7.6.3
       strip-ansi: 6.0.1
       strip-json-comments: 3.1.1
       table: 6.8.2
@@ -9254,23 +9325,24 @@ packages:
       - supports-color
     dev: true
 
-  /eslint/8.57.0:
-    resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
+  /eslint/8.57.1:
+    resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0_eslint@8.57.0
-      '@eslint-community/regexpp': 4.11.0
+      '@eslint-community/eslint-utils': 4.4.1_eslint@8.57.1
+      '@eslint-community/regexpp': 4.12.1
       '@eslint/eslintrc': 2.1.4
-      '@eslint/js': 8.57.0
-      '@humanwhocodes/config-array': 0.11.14
+      '@eslint/js': 8.57.1
+      '@humanwhocodes/config-array': 0.13.0
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       '@ungap/structured-clone': 1.2.0
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.5
+      debug: 4.3.7
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -9284,7 +9356,7 @@ packages:
       glob-parent: 6.0.2
       globals: 13.24.0
       graphemer: 1.4.0
-      ignore: 5.3.1
+      ignore: 5.3.2
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
@@ -9314,8 +9386,8 @@ packages:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 8.12.1
-      acorn-jsx: 5.3.2_acorn@8.12.1
+      acorn: 8.14.0
+      acorn-jsx: 5.3.2_acorn@8.14.0
       eslint-visitor-keys: 3.4.3
     dev: true
 
@@ -9468,21 +9540,21 @@ packages:
       jest-util: 29.7.0
     dev: true
 
-  /express-ws/5.0.2_express@4.19.2:
+  /express-ws/5.0.2_express@4.21.1:
     resolution: {integrity: sha512-0uvmuk61O9HXgLhGl3QhNSEtRsQevtmbL94/eILaliEADZBHZOQUAiHFrGPrgsjikohyrmSG5g+sCfASTt0lkQ==}
     engines: {node: '>=4.5.0'}
     peerDependencies:
       express: ^4.0.0 || ^5.0.0-alpha.1
     dependencies:
-      express: 4.19.2
+      express: 4.21.1
       ws: 7.5.10
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
     dev: false
 
-  /express/4.19.2:
-    resolution: {integrity: sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==}
+  /express/4.21.1:
+    resolution: {integrity: sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==}
     engines: {node: '>= 0.10.0'}
     dependencies:
       accepts: 1.3.8
@@ -9490,27 +9562,27 @@ packages:
       body-parser: 1.20.3
       content-disposition: 0.5.4
       content-type: 1.0.5
-      cookie: 0.6.0
+      cookie: 0.7.1
       cookie-signature: 1.0.6
       debug: 2.6.9
       depd: 2.0.0
-      encodeurl: 1.0.2
+      encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 1.2.0
+      finalhandler: 1.3.1
       fresh: 0.5.2
       http-errors: 2.0.0
-      merge-descriptors: 1.0.1
+      merge-descriptors: 1.0.3
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
       path-to-regexp: 0.1.10
       proxy-addr: 2.0.7
-      qs: 6.11.0
+      qs: 6.13.0
       range-parser: 1.2.1
       safe-buffer: 5.2.1
-      send: 0.18.0
-      serve-static: 1.15.0
+      send: 0.19.0
+      serve-static: 1.16.2
       setprototypeof: 1.2.0
       statuses: 2.0.1
       type-is: 1.6.18
@@ -9555,7 +9627,7 @@ packages:
     engines: {node: '>= 10.17.0'}
     hasBin: true
     dependencies:
-      debug: 4.3.5
+      debug: 4.3.7
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -9578,7 +9650,7 @@ packages:
       '@nodelib/fs.walk': 1.2.8
       glob-parent: 5.1.2
       merge2: 1.4.1
-      micromatch: 4.0.7
+      micromatch: 4.0.8
     dev: true
 
   /fast-json-stable-stringify/2.1.0:
@@ -9589,7 +9661,7 @@ packages:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: true
 
-  /fast-sass-loader/2.0.1_sass@1.77.7+webpack@5.92.1:
+  /fast-sass-loader/2.0.1_sass@1.80.5+webpack@5.95.0:
     resolution: {integrity: sha512-RGQNKA9d7OiF9dIa65QOabz4guGRZGg4CS2uXvLyWdmy5A6VLK8ZZEQKKlJ54ILmOpdFyaAq8u3Fj3oNkSmdug==}
     peerDependencies:
       sass: 1.x
@@ -9600,21 +9672,18 @@ packages:
       co: 4.6.0
       fs-extra: 3.0.1
       loader-utils: 1.4.2
-      sass: 1.77.7
-      webpack: 5.92.1
+      sass: 1.80.5
+      webpack: 5.95.0
     dev: true
 
-  /fast-sort/3.4.0:
-    resolution: {integrity: sha512-c/cMBGA5mH3OYjaXedtLIM3hQjv+KuZuiD2QEH5GofNOZeQVDIYIN7Okc2AW1KPhk44g5PTZnXp8t2lOMl8qhQ==}
+  /fast-sort/3.4.1:
+    resolution: {integrity: sha512-76uvGPsF6So53sZAqenP9UVT3p5l7cyTHkLWVCMinh41Y8NDrK1IYXJgaBMfc1gk7nJiSRZp676kddFG2Aa5+A==}
 
-  /fast-url-parser/1.1.3:
-    resolution: {integrity: sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==}
-    dependencies:
-      punycode: 1.4.1
-    dev: true
+  /fast-uri/3.0.3:
+    resolution: {integrity: sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==}
 
-  /fast-xml-parser/4.4.1:
-    resolution: {integrity: sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==}
+  /fast-xml-parser/4.5.0:
+    resolution: {integrity: sha512-/PlTQCI96+fZMAOLMZK4CWG1ItCbfZ/0jx7UIJFChPNrx7tcEgerUgWbeieCM9MfHInUDyK8DWYZ+YrywDJuTg==}
     hasBin: true
     dependencies:
       strnum: 1.0.5
@@ -9655,7 +9724,7 @@ packages:
       flat-cache: 3.2.0
     dev: true
 
-  /file-loader/6.2.0_webpack@5.92.1:
+  /file-loader/6.2.0_webpack@5.95.0:
     resolution: {integrity: sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -9663,7 +9732,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.92.1
+      webpack: 5.95.0
     dev: true
 
   /file-saver/2.0.5:
@@ -9688,12 +9757,12 @@ packages:
       to-regex-range: 5.0.1
     dev: true
 
-  /finalhandler/1.2.0:
-    resolution: {integrity: sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==}
+  /finalhandler/1.3.1:
+    resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
     engines: {node: '>= 0.8'}
     dependencies:
       debug: 2.6.9
-      encodeurl: 1.0.2
+      encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
       parseurl: 1.3.3
@@ -9712,9 +9781,6 @@ packages:
   /find-index/0.1.1:
     resolution: {integrity: sha512-uJ5vWrfBKMcE6y2Z8834dwEZj9mNGxYa3t3I53OwFeuZ8D9oc2E5zcsrkuhX6h4iYrjhiv0T3szQmxlAV9uxDg==}
     dev: true
-
-  /find-root/1.1.0:
-    resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
 
   /find-up/3.0.0:
     resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==}
@@ -9768,8 +9834,8 @@ packages:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
     dev: true
 
-  /follow-redirects/1.15.6:
-    resolution: {integrity: sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==}
+  /follow-redirects/1.15.9:
+    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -9788,15 +9854,15 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /foreground-child/3.2.1:
-    resolution: {integrity: sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==}
+  /foreground-child/3.3.0:
+    resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
     engines: {node: '>=14'}
     dependencies:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
     dev: true
 
-  /fork-ts-checker-webpack-plugin/6.5.3_vmohbas7cixbs7dvjlkwhs5g3i:
+  /fork-ts-checker-webpack-plugin/6.5.3_z6tosmbba6a4h5dofl3zomc5vu:
     resolution: {integrity: sha512-SbH/l9ikmMWycd5puHJKTkZJKddF4iRLyW3DeZ08HTI7NGyLS38MXd/KGgeWumQO7YNQbW2u/NtPT2YowbPaGQ==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -9810,34 +9876,35 @@ packages:
       vue-template-compiler:
         optional: true
     dependencies:
-      '@babel/code-frame': 7.24.7
+      '@babel/code-frame': 7.26.2
       '@types/json-schema': 7.0.15
       chalk: 4.1.2
       chokidar: 3.6.0
       cosmiconfig: 6.0.0
       deepmerge: 4.3.1
-      eslint: 8.57.0
+      eslint: 8.57.1
       fs-extra: 9.1.0
       glob: 7.2.3
       memfs: 3.5.3
       minimatch: 3.1.2
       schema-utils: 2.7.0
-      semver: 7.6.2
+      semver: 7.6.3
       tapable: 1.1.3
       typescript: 5.0.4
-      webpack: 5.92.1
+      webpack: 5.95.0
     dev: true
 
-  /form-data/2.5.1:
-    resolution: {integrity: sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==}
+  /form-data/2.5.2:
+    resolution: {integrity: sha512-GgwY0PS7DbXqajuGf4OYlsrIu3zgxD6Vvql43IBhm6MahqA5SK/7mwhtNj2AdH2z35YR34ujJ7BN+3fFC3jP5Q==}
     engines: {node: '>= 0.12'}
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
+      safe-buffer: 5.2.1
 
-  /form-data/3.0.1:
-    resolution: {integrity: sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==}
+  /form-data/3.0.2:
+    resolution: {integrity: sha512-sJe+TQb2vIaIyO783qN6BlMYWMw3WBOHA1Ay2qxsnjuafEOQFJ2JakedOQirT6D5XPRxDvS7AHYyem9fTpb4LQ==}
     engines: {node: '>= 6'}
     dependencies:
       asynckit: 0.4.0
@@ -9845,8 +9912,8 @@ packages:
       mime-types: 2.1.35
     dev: true
 
-  /form-data/4.0.0:
-    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
+  /form-data/4.0.1:
+    resolution: {integrity: sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==}
     engines: {node: '>= 6'}
     dependencies:
       asynckit: 0.4.0
@@ -10000,13 +10067,13 @@ packages:
     resolution: {integrity: sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==}
     engines: {node: '>=6'}
     dependencies:
-      pump: 3.0.0
+      pump: 3.0.2
 
   /get-stream/5.2.0:
     resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
     engines: {node: '>=8'}
     dependencies:
-      pump: 3.0.0
+      pump: 3.0.2
 
   /get-stream/6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
@@ -10027,14 +10094,13 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /glob-gitignore/1.0.14:
-    resolution: {integrity: sha512-YuAEPqL58bOQDqDF2kMv009rIjSAtPs+WPzyGbwRWK+wD0UWQVRoP34Pz6yJ6ivco65C9tZnaIt0I3JCuQ8NZQ==}
+  /glob-gitignore/1.0.15:
+    resolution: {integrity: sha512-22pvDWt2hMPfL3UF6lWcZpP+VIwBekJyj6xyb1DpeSALJm+n/0gI9lWD30kvA/h3bgPqYeAX7xGONzmyHrSfqQ==}
     engines: {node: '>= 6'}
     dependencies:
       glob: 7.2.3
-      ignore: 5.3.1
-      lodash.difference: 4.5.0
-      lodash.union: 4.6.0
+      ignore: 5.3.2
+      lodash: 4.17.21
       make-array: 1.0.5
       util.inherits: 1.0.3
     dev: true
@@ -10061,11 +10127,11 @@ packages:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     hasBin: true
     dependencies:
-      foreground-child: 3.2.1
-      jackspeak: 3.4.2
+      foreground-child: 3.3.0
+      jackspeak: 3.4.3
       minimatch: 9.0.5
       minipass: 7.1.2
-      package-json-from-dist: 1.0.0
+      package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
     dev: true
 
@@ -10109,7 +10175,7 @@ packages:
       es6-error: 4.1.1
       matcher: 3.0.0
       roarr: 2.15.4
-      semver: 7.6.2
+      semver: 7.6.3
       serialize-error: 7.0.1
     optional: true
 
@@ -10132,6 +10198,7 @@ packages:
   /globals/11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
+    dev: true
 
   /globals/13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
@@ -10154,7 +10221,7 @@ packages:
       array-union: 2.1.0
       dir-glob: 3.0.1
       fast-glob: 3.3.2
-      ignore: 5.3.1
+      ignore: 5.3.2
       merge2: 1.4.1
       slash: 3.0.0
     dev: true
@@ -10166,7 +10233,7 @@ packages:
       array-union: 3.0.1
       dir-glob: 3.0.1
       fast-glob: 3.3.2
-      ignore: 5.3.1
+      ignore: 5.3.2
       merge2: 1.4.1
       slash: 4.0.0
     dev: true
@@ -10177,7 +10244,7 @@ packages:
     dependencies:
       dir-glob: 3.0.1
       fast-glob: 3.3.2
-      ignore: 5.3.1
+      ignore: 5.3.2
       merge2: 1.4.1
       slash: 4.0.0
     dev: true
@@ -10256,6 +10323,7 @@ packages:
   /has-flag/3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
     engines: {node: '>=4'}
+    dev: true
 
   /has-flag/4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -10324,13 +10392,10 @@ packages:
     hasBin: true
     dev: true
 
-  /highlight-words-core/1.2.2:
-    resolution: {integrity: sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg==}
-
   /history/5.3.0:
     resolution: {integrity: sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==}
     dependencies:
-      '@babel/runtime': 7.24.7
+      '@babel/runtime': 7.26.0
     dev: false
 
   /hoist-non-react-statics/3.3.2:
@@ -10396,7 +10461,7 @@ packages:
       he: 1.2.0
       param-case: 3.0.4
       relateurl: 0.2.7
-      terser: 5.31.1
+      terser: 5.36.0
     dev: true
 
   /html-tags/3.3.1:
@@ -10404,8 +10469,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /html-webpack-plugin/5.6.0_webpack@5.92.1:
-    resolution: {integrity: sha512-iwaY4wzbe48AfKLZ/Cc8k0L+FKG6oSNRaZ8x5A/T/IVDGyXcbHncM9TdDa93wn0FsSm82FhTKW7f3vS61thXAw==}
+  /html-webpack-plugin/5.6.3_webpack@5.95.0:
+    resolution: {integrity: sha512-QSf1yjtSAsmf7rYBV7XX86uua4W/vkhIt0xNXKbsi2foEeW7vjJQz4bhnpL3xH+l1ryl1680uNv968Z+X6jSYg==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
       '@rspack/core': 0.x || 1.x
@@ -10421,7 +10486,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.92.1
+      webpack: 5.95.0
     dev: true
 
   /htmlparser2/3.10.1:
@@ -10491,7 +10556,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.5
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10502,7 +10567,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.5
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10512,12 +10577,12 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.5
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
-  /http-proxy-middleware/2.0.6_@types+express@4.17.21:
-    resolution: {integrity: sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==}
+  /http-proxy-middleware/2.0.7_@types+express@4.17.21:
+    resolution: {integrity: sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@types/express': ^4.17.13
@@ -10526,11 +10591,11 @@ packages:
         optional: true
     dependencies:
       '@types/express': 4.17.21
-      '@types/http-proxy': 1.17.14
+      '@types/http-proxy': 1.17.15
       http-proxy: 1.18.1
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
-      micromatch: 4.0.7
+      micromatch: 4.0.8
     transitivePeerDependencies:
       - debug
     dev: true
@@ -10540,7 +10605,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.6
+      follow-redirects: 1.15.9
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -10558,7 +10623,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.5
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10568,7 +10633,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.5
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
@@ -10585,7 +10650,7 @@ packages:
   /i18next-browser-languagedetector/6.1.8:
     resolution: {integrity: sha512-Svm+MduCElO0Meqpj1kJAriTC6OhI41VhlT/A0UPjGoPZBhAHIaGE5EfsHlTpgdH09UVX7rcc72pSDDBeKSQQA==}
     dependencies:
-      '@babel/runtime': 7.24.7
+      '@babel/runtime': 7.26.0
 
   /i18next-http-backend/1.4.5:
     resolution: {integrity: sha512-tLuHWuLWl6CmS07o+UB6EcQCaUjrZ1yhdseIN7sfq0u7phsMePJ8pqlGhIAdRDPF/q7ooyo5MID5DRFBCH+x5w==}
@@ -10601,7 +10666,7 @@ packages:
   /i18next/21.10.0:
     resolution: {integrity: sha512-YeuIBmFsGjUfO3qBmMOc0rQaun4mIpGKET5WDwvu8lU7gvwpcariZLNtL0Fzj+zazcHUrlXHiptcFhBMFaxzfg==}
     dependencies:
-      '@babel/runtime': 7.24.7
+      '@babel/runtime': 7.26.0
 
   /iconv-lite/0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -10616,13 +10681,13 @@ packages:
       safer-buffer: 2.1.2
     dev: true
 
-  /icss-utils/5.1.0_postcss@8.4.39:
+  /icss-utils/5.1.0_postcss@8.4.47:
     resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
     dev: true
 
   /idb/7.1.1:
@@ -10641,8 +10706,8 @@ packages:
     engines: {node: '>= 4'}
     dev: true
 
-  /ignore/5.3.1:
-    resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
+  /ignore/5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
     dev: true
 
@@ -10659,8 +10724,8 @@ packages:
   /immer/9.0.6:
     resolution: {integrity: sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==}
 
-  /immutable/4.3.6:
-    resolution: {integrity: sha512-Ju0+lEMyzMVZarkTn/gqRpdqd5dOPaz1mCZ0SH3JV6iFw81PldE/PEB1hWVEA288HPt4WXW8O7AWxB10M+03QQ==}
+  /immutable/4.3.7:
+    resolution: {integrity: sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==}
     dev: true
 
   /import-fresh/3.3.0:
@@ -10669,14 +10734,15 @@ packages:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
+    dev: true
 
   /import-lazy/4.0.0:
     resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
     engines: {node: '>=8'}
     dev: true
 
-  /import-local/3.1.0:
-    resolution: {integrity: sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==}
+  /import-local/3.2.0:
+    resolution: {integrity: sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==}
     engines: {node: '>=8'}
     hasBin: true
     dependencies:
@@ -10722,8 +10788,8 @@ packages:
       side-channel: 1.0.6
     dev: true
 
-  /inversify/6.0.2:
-    resolution: {integrity: sha512-i9m8j/7YIv4mDuYXUAcrpKPSaju/CIly9AHK5jvCBeoiM/2KEsuCQTTP+rzSWWpLYWRukdXFSl6ZTk2/uumbiA==}
+  /inversify/6.0.3:
+    resolution: {integrity: sha512-s/svzcRQ/scaGUUyaVtFSL1dvOaRgyvE7VvpGcJwXmFz7CCzfSfxC/Uyl7iSHDEmBabJ2gbDES72DaygtMmwvg==}
 
   /ipaddr.js/1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -10770,6 +10836,7 @@ packages:
 
   /is-arrayish/0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+    dev: true
 
   /is-async-function/2.0.0:
     resolution: {integrity: sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==}
@@ -10813,11 +10880,12 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /is-core-module/2.14.0:
-    resolution: {integrity: sha512-a5dFJih5ZLYlRtDc0dZWP7RiKr6xIKzmn/oAYCDvdLThadVgyJwlaoQPmRtMSpz+rk0OGAgIu+TcM9HUF0fk1A==}
+  /is-core-module/2.15.1:
+    resolution: {integrity: sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       hasown: 2.0.2
+    dev: true
 
   /is-data-descriptor/1.0.1:
     resolution: {integrity: sha512-bc4NlCDiCr28U4aEsQ3Qs2491gVq4V8G7MQyws968ImqjKuYtTJXrl7Vq7jsN7Ly/C3xj5KWFrY7sHNeDkAzXw==}
@@ -11139,8 +11207,8 @@ packages:
     resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/parser': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/parser': 7.26.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -11152,11 +11220,11 @@ packages:
     resolution: {integrity: sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==}
     engines: {node: '>=10'}
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/parser': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/parser': 7.26.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.6.2
+      semver: 7.6.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11174,7 +11242,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.5
+      debug: 4.3.7
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -11189,8 +11257,9 @@ packages:
       istanbul-lib-report: 3.0.1
     dev: true
 
-  /iterator.prototype/1.1.2:
-    resolution: {integrity: sha512-DR33HMMr8EzwuRL8Y9D3u2BMj8+RqSE850jfGu59kS7tbmPLzGkZmVSfyCFSDxuZiEY6Rzt3T2NA/qU+NwVj1w==}
+  /iterator.prototype/1.1.3:
+    resolution: {integrity: sha512-FW5iMbeQ6rBGm/oKgzq2aW4KvAGpxPzYES8N4g4xNXUKpL1mclMvOe+76AcLDTvD+Ze+sOpVhgdAQEKF4L9iGQ==}
+    engines: {node: '>= 0.4'}
     dependencies:
       define-properties: 1.2.1
       get-intrinsic: 1.2.4
@@ -11199,21 +11268,20 @@ packages:
       set-function-name: 2.0.2
     dev: true
 
-  /jackspeak/3.4.2:
-    resolution: {integrity: sha512-qH3nOSj8q/8+Eg8LUPOq3C+6HWkpUioIjDsq1+D4zY91oZvpPttw8GwtF1nReRYKXl+1AORyFqtm2f5Q1SB6/Q==}
-    engines: {node: 14 >=14.21 || 16 >=16.20 || >=18}
+  /jackspeak/3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
     dependencies:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
     dev: true
 
-  /jake/10.9.1:
-    resolution: {integrity: sha512-61btcOHNnLnsOdtLgA5efqQWjnSi/vow5HbI7HMdKKWqvrKR1bLK3BPlJn9gcSaP2ewuamUSMB5XEy76KUIS2w==}
+  /jake/10.9.2:
+    resolution: {integrity: sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      async: 3.2.5
+      async: 3.2.6
       chalk: 4.1.2
       filelist: 1.0.4
       minimatch: 3.1.2
@@ -11244,7 +11312,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -11272,7 +11340,7 @@ packages:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.3
@@ -11309,7 +11377,7 @@ packages:
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      import-local: 3.1.0
+      import-local: 3.2.0
       jest-config: 27.5.1
       jest-util: 27.5.1
       jest-validate: 27.5.1
@@ -11323,7 +11391,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /jest-cli/29.7.0_@types+node@18.19.39:
+  /jest-cli/29.7.0_@types+node@18.19.62:
     resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -11337,10 +11405,10 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0_@types+node@18.19.39
+      create-jest: 29.7.0_@types+node@18.19.62
       exit: 0.1.2
-      import-local: 3.1.0
-      jest-config: 29.7.0_@types+node@18.19.39
+      import-local: 3.2.0
+      jest-config: 29.7.0_@types+node@18.19.62
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -11360,10 +11428,10 @@ packages:
       ts-node:
         optional: true
     dependencies:
-      '@babel/core': 7.24.7
+      '@babel/core': 7.26.0
       '@jest/test-sequencer': 27.5.1
       '@jest/types': 27.5.1
-      babel-jest: 27.5.1_@babel+core@7.24.7
+      babel-jest: 27.5.1_@babel+core@7.26.0
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
@@ -11379,7 +11447,7 @@ packages:
       jest-runner: 27.5.1
       jest-util: 27.5.1
       jest-validate: 27.5.1
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       parse-json: 5.2.0
       pretty-format: 27.5.1
       slash: 3.0.0
@@ -11391,7 +11459,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /jest-config/29.7.0_@types+node@18.19.39:
+  /jest-config/29.7.0_@types+node@18.19.62:
     resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -11403,11 +11471,11 @@ packages:
       ts-node:
         optional: true
     dependencies:
-      '@babel/core': 7.24.7
+      '@babel/core': 7.26.0
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.39
-      babel-jest: 29.7.0_@babel+core@7.24.7
+      '@types/node': 18.19.62
+      babel-jest: 29.7.0_@babel+core@7.26.0
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
@@ -11421,7 +11489,7 @@ packages:
       jest-runner: 29.7.0
       jest-util: 29.7.0
       jest-validate: 29.7.0
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       parse-json: 5.2.0
       pretty-format: 29.7.0
       slash: 3.0.0
@@ -11514,7 +11582,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       jest-mock: 27.5.1
       jest-util: 27.5.1
       jsdom: 16.7.0
@@ -11538,7 +11606,7 @@ packages:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/jsdom': 20.0.1
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       jest-mock: 29.7.0
       jest-util: 29.7.0
       jsdom: 20.0.3
@@ -11555,7 +11623,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       jest-mock: 27.5.1
       jest-util: 27.5.1
     dev: true
@@ -11567,7 +11635,7 @@ packages:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       jest-mock: 29.7.0
       jest-util: 29.7.0
     dev: true
@@ -11598,7 +11666,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@types/graceful-fs': 4.1.9
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -11606,7 +11674,7 @@ packages:
       jest-serializer: 27.5.1
       jest-util: 27.5.1
       jest-worker: 27.5.1
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.3
@@ -11618,14 +11686,14 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
       jest-regex-util: 29.6.3
       jest-util: 29.7.0
       jest-worker: 29.7.0
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.3
@@ -11639,7 +11707,7 @@ packages:
       '@jest/source-map': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       chalk: 4.1.2
       co: 4.6.0
       expect: 27.5.1
@@ -11706,12 +11774,12 @@ packages:
     resolution: {integrity: sha512-rMyFe1+jnyAAf+NHwTclDz0eAaLkVDdKVHHBFWsBWHnnh5YeJMNWWsv7AbFYXfK3oTqvL7VTWkhNLu1jX24D+g==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@babel/code-frame': 7.24.7
+      '@babel/code-frame': 7.26.2
       '@jest/types': 27.5.1
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
       graceful-fs: 4.2.11
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       pretty-format: 27.5.1
       slash: 3.0.0
       stack-utils: 2.0.6
@@ -11721,12 +11789,12 @@ packages:
     resolution: {integrity: sha512-PFdn9Iewbt575zKPf1286Ht9EPoJmYT7P0kY+RibeYZ2XtOr53pDLEFoTWXbd1h4JiGiWpTBC84fc8xMXQMb7g==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
-      '@babel/code-frame': 7.24.7
+      '@babel/code-frame': 7.26.2
       '@jest/types': 28.1.3
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
       graceful-fs: 4.2.11
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       pretty-format: 28.1.3
       slash: 3.0.0
       stack-utils: 2.0.6
@@ -11736,12 +11804,12 @@ packages:
     resolution: {integrity: sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@babel/code-frame': 7.24.7
+      '@babel/code-frame': 7.26.2
       '@jest/types': 29.6.3
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
       graceful-fs: 4.2.11
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       pretty-format: 29.7.0
       slash: 3.0.0
       stack-utils: 2.0.6
@@ -11752,7 +11820,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
     dev: true
 
   /jest-mock/29.7.0:
@@ -11760,7 +11828,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       jest-util: 29.7.0
     dev: true
 
@@ -11864,7 +11932,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       chalk: 4.1.2
       emittery: 0.8.1
       graceful-fs: 4.2.11
@@ -11896,7 +11964,7 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -11928,7 +11996,7 @@ packages:
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
       chalk: 4.1.2
-      cjs-module-lexer: 1.3.1
+      cjs-module-lexer: 1.4.1
       collect-v8-coverage: 1.0.2
       execa: 5.1.1
       glob: 7.2.3
@@ -11957,9 +12025,9 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       chalk: 4.1.2
-      cjs-module-lexer: 1.3.1
+      cjs-module-lexer: 1.4.1
       collect-v8-coverage: 1.0.2
       glob: 7.2.3
       graceful-fs: 4.2.11
@@ -11980,7 +12048,7 @@ packages:
     resolution: {integrity: sha512-jZCyo6iIxO1aqUxpuBlwTDMkzOAJS4a3eYz3YzgxxVQFwLeSA7Jfq5cbqCY+JLvTDrWirgusI/0KwxKMgrdf7w==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       graceful-fs: 4.2.11
     dev: true
 
@@ -11988,16 +12056,16 @@ packages:
     resolution: {integrity: sha512-yYykXI5a0I31xX67mgeLw1DZ0bJB+gpq5IpSuCAoyDi0+BhgU/RIrL+RTzDmkNTchvDFWKP8lp+w/42Z3us5sA==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/generator': 7.24.7
-      '@babel/plugin-syntax-typescript': 7.24.7_@babel+core@7.24.7
-      '@babel/traverse': 7.24.7
-      '@babel/types': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/generator': 7.26.2
+      '@babel/plugin-syntax-typescript': 7.25.9_@babel+core@7.26.0
+      '@babel/traverse': 7.25.9
+      '@babel/types': 7.26.0
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
       '@types/babel__traverse': 7.20.6
       '@types/prettier': 2.7.3
-      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.24.7
+      babel-preset-current-node-syntax: 1.1.0_@babel+core@7.26.0
       chalk: 4.1.2
       expect: 27.5.1
       graceful-fs: 4.2.11
@@ -12009,7 +12077,7 @@ packages:
       jest-util: 27.5.1
       natural-compare: 1.4.0
       pretty-format: 27.5.1
-      semver: 7.6.2
+      semver: 7.6.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12018,15 +12086,15 @@ packages:
     resolution: {integrity: sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@babel/core': 7.24.7
-      '@babel/generator': 7.24.7
-      '@babel/plugin-syntax-jsx': 7.24.7_@babel+core@7.24.7
-      '@babel/plugin-syntax-typescript': 7.24.7_@babel+core@7.24.7
-      '@babel/types': 7.24.7
+      '@babel/core': 7.26.0
+      '@babel/generator': 7.26.2
+      '@babel/plugin-syntax-jsx': 7.25.9_@babel+core@7.26.0
+      '@babel/plugin-syntax-typescript': 7.25.9_@babel+core@7.26.0
+      '@babel/types': 7.26.0
       '@jest/expect-utils': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.24.7
+      babel-preset-current-node-syntax: 1.1.0_@babel+core@7.26.0
       chalk: 4.1.2
       expect: 29.7.0
       graceful-fs: 4.2.11
@@ -12037,7 +12105,7 @@ packages:
       jest-util: 29.7.0
       natural-compare: 1.4.0
       pretty-format: 29.7.0
-      semver: 7.6.2
+      semver: 7.6.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12047,7 +12115,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -12059,7 +12127,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.3
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -12071,7 +12139,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -12124,7 +12192,7 @@ packages:
     dependencies:
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest-util: 27.5.1
@@ -12137,7 +12205,7 @@ packages:
     dependencies:
       '@jest/test-result': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.10.2
@@ -12151,7 +12219,7 @@ packages:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -12163,7 +12231,7 @@ packages:
     resolution: {integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       merge-stream: 2.0.0
       supports-color: 7.2.0
     dev: true
@@ -12172,7 +12240,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -12181,7 +12249,7 @@ packages:
     resolution: {integrity: sha512-CqRA220YV/6jCo8VWvAt1KKx6eek1VIHMPeLEbpcfSfkEeWyBNppynM/o6q+Wmw+sOhos2ml34wZbSX3G13//g==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -12190,7 +12258,7 @@ packages:
     resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 18.19.39
+      '@types/node': 18.19.62
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -12207,7 +12275,7 @@ packages:
         optional: true
     dependencies:
       '@jest/core': 27.5.1
-      import-local: 3.1.0
+      import-local: 3.2.0
       jest-cli: 27.5.1
     transitivePeerDependencies:
       - bufferutil
@@ -12217,7 +12285,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /jest/29.7.0_@types+node@18.19.39:
+  /jest/29.7.0_@types+node@18.19.62:
     resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -12229,8 +12297,8 @@ packages:
     dependencies:
       '@jest/core': 29.7.0
       '@jest/types': 29.6.3
-      import-local: 3.1.0
-      jest-cli: 29.7.0_@types+node@18.19.39
+      import-local: 3.2.0
+      jest-cli: 29.7.0_@types+node@18.19.62
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -12247,8 +12315,8 @@ packages:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
     dev: true
 
-  /jotai/2.9.0_3vdbhqr2ncalcx7opnshezpx3q:
-    resolution: {integrity: sha512-MioTpMvR78IGfJ+W8EwQj3kwTkb+u0reGnTyg3oJZMWK9rK9v8NBSC9Rhrg9jrrFYA6bGZtzJa96zsuAYF6W3w==}
+  /jotai/2.10.1_ryhct6r6jz2fex4xfo2quarxhi:
+    resolution: {integrity: sha512-4FycO+BOTl2auLyF2Chvi6KTDqdsdDDtpaL/WHQMs8f3KS1E3loiUShQzAzFA/sMU5cJ0hz/RT1xum9YbG/zaA==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
       '@types/react': '>=17.0.0'
@@ -12259,7 +12327,7 @@ packages:
       react:
         optional: true
     dependencies:
-      '@types/react': 18.3.3
+      '@types/react': 18.3.12
       react: 18.3.1
 
   /js-base64/3.7.7:
@@ -12293,7 +12361,7 @@ packages:
         optional: true
     dependencies:
       abab: 2.0.6
-      acorn: 8.12.1
+      acorn: 8.14.0
       acorn-globals: 6.0.0
       cssom: 0.4.4
       cssstyle: 2.3.0
@@ -12301,12 +12369,12 @@ packages:
       decimal.js: 10.4.3
       domexception: 2.0.1
       escodegen: 2.1.0
-      form-data: 3.0.1
+      form-data: 3.0.2
       html-encoding-sniffer: 2.0.1
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.1
       is-potential-custom-element-name: 1.0.1
-      nwsapi: 2.2.10
+      nwsapi: 2.2.13
       parse5: 6.0.1
       saxes: 5.0.1
       symbol-tree: 3.2.4
@@ -12335,7 +12403,7 @@ packages:
         optional: true
     dependencies:
       abab: 2.0.6
-      acorn: 8.12.1
+      acorn: 8.14.0
       acorn-globals: 7.0.1
       cssom: 0.5.0
       cssstyle: 2.3.0
@@ -12343,13 +12411,13 @@ packages:
       decimal.js: 10.4.3
       domexception: 4.0.0
       escodegen: 2.1.0
-      form-data: 4.0.0
+      form-data: 4.0.1
       html-encoding-sniffer: 3.0.0
       http-proxy-agent: 5.0.0
       https-proxy-agent: 5.0.1
       is-potential-custom-element-name: 1.0.1
-      nwsapi: 2.2.10
-      parse5: 7.1.2
+      nwsapi: 2.2.13
+      parse5: 7.2.1
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 4.1.4
@@ -12366,15 +12434,11 @@ packages:
       - utf-8-validate
     dev: true
 
-  /jsesc/0.5.0:
-    resolution: {integrity: sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==}
+  /jsesc/3.0.2:
+    resolution: {integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==}
+    engines: {node: '>=6'}
     hasBin: true
     dev: true
-
-  /jsesc/2.5.2:
-    resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
-    engines: {node: '>=4'}
-    hasBin: true
 
   /json-buffer/3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -12385,6 +12449,7 @@ packages:
 
   /json-parse-even-better-errors/2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+    dev: true
 
   /json-schema-traverse/0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -12524,10 +12589,10 @@ packages:
       language-subtag-registry: 0.3.23
     dev: true
 
-  /launch-editor/2.8.0:
-    resolution: {integrity: sha512-vJranOAJrI/llyWGRQqiDM+adrw+k83fvmmx3+nV47g3+36xM15jE+zyZ6Ffel02+xSvuM0b2GDRosXZkbb6wA==}
+  /launch-editor/2.9.1:
+    resolution: {integrity: sha512-Gcnl4Bd+hRO9P9icCP/RVVT2o8SFlPXofuCxvA2SaZuH45whSvf5p8x5oih5ftLiVhEI4sp5xDY+R+b3zJBh5w==}
     dependencies:
-      picocolors: 1.0.1
+      picocolors: 1.1.1
       shell-quote: 1.8.1
     dev: true
 
@@ -12562,8 +12627,15 @@ packages:
     engines: {node: '>=14'}
     dev: true
 
+  /linebreak/1.1.0:
+    resolution: {integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==}
+    dependencies:
+      base64-js: 0.0.8
+      unicode-trie: 2.0.0
+
   /lines-and-columns/1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+    dev: true
 
   /linkify-it/2.2.0:
     resolution: {integrity: sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==}
@@ -12578,13 +12650,13 @@ packages:
       cli-truncate: 2.1.0
       commander: 6.2.1
       cosmiconfig: 7.1.0
-      debug: 4.3.5
+      debug: 4.3.7
       dedent: 0.7.0
       enquirer: 2.4.1
       execa: 4.1.0
       listr2: 3.14.0_enquirer@2.4.1
       log-symbols: 4.1.0
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       normalize-path: 3.0.0
       please-upgrade-node: 3.2.0
       string-argv: 0.3.1
@@ -12676,16 +12748,9 @@ packages:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
     dev: true
 
-  /lodash.difference/4.5.0:
-    resolution: {integrity: sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==}
-    dev: true
-
-  /lodash.get/4.4.2:
-    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
-    dev: true
-
   /lodash.isequal/4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    dev: false
 
   /lodash.memoize/4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
@@ -12701,10 +12766,6 @@ packages:
 
   /lodash.truncate/4.4.2:
     resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
-    dev: true
-
-  /lodash.union/4.6.0:
-    resolution: {integrity: sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==}
     dev: true
 
   /lodash.uniq/4.5.0:
@@ -12745,7 +12806,7 @@ packages:
   /lower-case/2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.0
     dev: true
 
   /lowercase-keys/2.0.0:
@@ -12800,7 +12861,7 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.6.2
+      semver: 7.6.3
     dev: true
 
   /make-error/1.3.6:
@@ -12881,7 +12942,7 @@ packages:
   /mdast-util-to-markdown/0.6.5:
     resolution: {integrity: sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==}
     dependencies:
-      '@types/unist': 2.0.10
+      '@types/unist': 2.0.11
       longest-streak: 2.0.4
       mdast-util-to-string: 2.0.0
       parse-entities: 2.0.0
@@ -12916,14 +12977,8 @@ packages:
       fs-monkey: 1.0.6
     dev: true
 
-  /memoize-one/4.0.3:
-    resolution: {integrity: sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw==}
-
   /memoize-one/5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
-
-  /memoize-one/6.0.0:
-    resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
 
   /memorystream/0.3.1:
     resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
@@ -12948,8 +13003,8 @@ packages:
       yargs-parser: 20.2.9
     dev: true
 
-  /merge-descriptors/1.0.1:
-    resolution: {integrity: sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==}
+  /merge-descriptors/1.0.3:
+    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
 
   /merge-options/1.0.1:
     resolution: {integrity: sha512-iuPV41VWKWBIOpBsjoxjDZw8/GbSfZ2mk7N1453bwMrfzdrIk7EzBd+8UVR6rkw67th7xnk9Dytl3J+lHPdxvg==}
@@ -12980,7 +13035,7 @@ packages:
   /micromark/2.11.4:
     resolution: {integrity: sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==}
     dependencies:
-      debug: 4.3.5
+      debug: 4.3.7
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -13005,8 +13060,8 @@ packages:
       to-regex: 3.0.2
     dev: true
 
-  /micromatch/4.0.7:
-    resolution: {integrity: sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==}
+  /micromatch/4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
     dependencies:
       braces: 3.0.3
@@ -13021,6 +13076,11 @@ packages:
   /mime-db/1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
+
+  /mime-db/1.53.0:
+    resolution: {integrity: sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==}
+    engines: {node: '>= 0.6'}
+    dev: true
 
   /mime-types/2.1.18:
     resolution: {integrity: sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==}
@@ -13061,19 +13121,25 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /mini-css-extract-plugin/2.9.0_webpack@5.92.1:
-    resolution: {integrity: sha512-Zs1YsZVfemekSZG+44vBsYTLQORkPMwnlv+aehcxK/NLKC+EGhDB39/YePYYqx/sTk6NnYpuqikhSn7+JIevTA==}
+  /mini-css-extract-plugin/2.9.1_webpack@5.95.0:
+    resolution: {integrity: sha512-+Vyi+GCCOHnrJ2VPS+6aPoXN2k2jgUzDRhTFLjjTBn23qyXJXkjUWQgTL+mXpF5/A8ixLdCc6kWsoeOjKGejKQ==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
       schema-utils: 4.2.0
       tapable: 2.2.1
-      webpack: 5.92.1
+      webpack: 5.95.0
     dev: true
 
   /minimalistic-assert/1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+    dev: true
+
+  /minimatch/3.0.8:
+    resolution: {integrity: sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==}
+    dependencies:
+      brace-expansion: 1.1.11
     dev: true
 
   /minimatch/3.1.2:
@@ -13137,30 +13203,30 @@ packages:
     hasBin: true
     dev: true
 
-  /mocha-junit-reporter/2.2.1_mocha@10.6.0:
+  /mocha-junit-reporter/2.2.1_mocha@10.8.2:
     resolution: {integrity: sha512-iDn2tlKHn8Vh8o4nCzcUVW4q7iXp7cC4EB78N0cDHIobLymyHNwe0XG8HEHHjc3hJlXm0Vy6zcrxaIhnI2fWmw==}
     peerDependencies:
       mocha: '>=2.2.5'
     dependencies:
-      debug: 4.3.5
+      debug: 4.3.7
       md5: 2.3.0
       mkdirp: 3.0.1
-      mocha: 10.6.0
+      mocha: 10.8.2
       strip-ansi: 6.0.1
       xml: 1.0.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /mocha/10.6.0:
-    resolution: {integrity: sha512-hxjt4+EEB0SA0ZDygSS015t65lJw/I2yRCS3Ae+SJ5FrbzrXgfYwJr96f0OvIXdj7h4lv/vLCrH3rkiuizFSvw==}
+  /mocha/10.8.2:
+    resolution: {integrity: sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==}
     engines: {node: '>= 14.0.0'}
     hasBin: true
     dependencies:
       ansi-colors: 4.1.3
       browser-stdout: 1.3.1
       chokidar: 3.6.0
-      debug: 4.3.5_supports-color@8.1.1
+      debug: 4.3.7_supports-color@8.1.1
       diff: 5.2.0
       escape-string-regexp: 4.0.0
       find-up: 5.0.0
@@ -13181,9 +13247,6 @@ packages:
 
   /ms/2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
-
-  /ms/2.1.2:
-    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
 
   /ms/2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -13258,7 +13321,11 @@ packages:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.6.3
+      tslib: 2.8.0
+    dev: true
+
+  /node-addon-api/7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
     dev: true
 
   /node-fetch/2.6.7:
@@ -13281,8 +13348,8 @@ packages:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
     dev: true
 
-  /node-releases/2.0.14:
-    resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
+  /node-releases/2.0.18:
+    resolution: {integrity: sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==}
     dev: true
 
   /noms/0.0.0:
@@ -13306,8 +13373,8 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       hosted-git-info: 4.1.0
-      is-core-module: 2.14.0
-      semver: 7.6.2
+      is-core-module: 2.15.1
+      semver: 7.6.3
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -13368,8 +13435,8 @@ packages:
     resolution: {integrity: sha512-Y1wZESM7VUThYY+4W+X4ySH2maqcA+p7UR+w8VWNWVAd6lwuXXWz/w/Cz43J/dI2I+PS6wD5N+bJUF+gjWvIqg==}
     dev: true
 
-  /nwsapi/2.2.10:
-    resolution: {integrity: sha512-QK0sRs7MKv0tKe1+5uZIQk/C8XGza4DAnztJG8iD+TpJIORARrCxczA738awHrZoHeTjSSoHqao2teO0dC/gFQ==}
+  /nwsapi/2.2.13:
+    resolution: {integrity: sha512-cTGB9ptp9dY9A5VbMSe7fQBcl/tt22Vcqdq8+eN93rblOuE0aCFu4aZ2vMwct/2t+lFnosm8RkQW1I0Omb1UtQ==}
     dev: true
 
   /object-assign/3.0.0:
@@ -13460,15 +13527,6 @@ packages:
       es-abstract: 1.23.3
     dev: true
 
-  /object.hasown/1.1.4:
-    resolution: {integrity: sha512-FZ9LZt9/RHzGySlBARE3VF+gE26TxR38SdmqOqliuTnl9wrKulaQs+4dee1V+Io8VfxqzAfHu6YuRgUy8OHoTg==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      define-properties: 1.2.1
-      es-abstract: 1.23.3
-      es-object-atoms: 1.0.0
-    dev: true
-
   /object.pick/1.3.0:
     resolution: {integrity: sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==}
     engines: {node: '>=0.10.0'}
@@ -13489,8 +13547,8 @@ packages:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
     dev: true
 
-  /oidc-client-ts/2.4.0:
-    resolution: {integrity: sha512-WijhkTrlXK2VvgGoakWJiBdfIsVGz6CFzgjNNqZU1hPKV2kyeEaJgLs7RwuiSp2WhLfWBQuLvr2SxVlZnk3N1w==}
+  /oidc-client-ts/2.4.1:
+    resolution: {integrity: sha512-IxlGMsbkZPsHJGCliWT3LxjUcYzmiN21656n/Zt2jDncZlBFc//cd8WqFF0Lt681UT3AImM57E6d4N53ziTCYA==}
     engines: {node: '>=12.13.0'}
     dependencies:
       crypto-js: 4.2.0
@@ -13631,15 +13689,18 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
-  /package-json-from-dist/1.0.0:
-    resolution: {integrity: sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==}
+  /package-json-from-dist/1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
     dev: true
+
+  /pako/0.2.9:
+    resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
 
   /param-case/3.0.4:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.6.3
+      tslib: 2.8.0
     dev: true
 
   /parent-module/1.0.1:
@@ -13647,6 +13708,7 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       callsites: 3.1.0
+    dev: true
 
   /parse-entities/2.0.0:
     resolution: {integrity: sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==}
@@ -13671,17 +13733,18 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/code-frame': 7.24.7
+      '@babel/code-frame': 7.26.2
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
+    dev: true
 
   /parse5/6.0.1:
     resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
     dev: true
 
-  /parse5/7.1.2:
-    resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
+  /parse5/7.2.1:
+    resolution: {integrity: sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==}
     dependencies:
       entities: 4.5.0
     dev: true
@@ -13694,7 +13757,7 @@ packages:
     resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.6.3
+      tslib: 2.8.0
     dev: true
 
   /pascalcase/0.1.1:
@@ -13731,6 +13794,7 @@ packages:
 
   /path-parse/1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+    dev: true
 
   /path-scurry/1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
@@ -13743,8 +13807,8 @@ packages:
   /path-to-regexp/0.1.10:
     resolution: {integrity: sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==}
 
-  /path-to-regexp/8.1.0:
-    resolution: {integrity: sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ==}
+  /path-to-regexp/8.2.0:
+    resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
     engines: {node: '>=16'}
     dev: true
 
@@ -13758,6 +13822,7 @@ packages:
   /path-type/4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+    dev: true
 
   /pend/1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
@@ -13770,8 +13835,9 @@ packages:
     resolution: {integrity: sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==}
     dev: true
 
-  /picocolors/1.0.1:
-    resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
+  /picocolors/1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+    dev: true
 
   /picomatch/2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
@@ -13828,302 +13894,302 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /postcss-attribute-case-insensitive/5.0.2_postcss@8.4.39:
+  /postcss-attribute-case-insensitive/5.0.2_postcss@8.4.47:
     resolution: {integrity: sha512-XIidXV8fDr0kKt28vqki84fRK8VW8eTuIa4PChv2MqKuT6C9UjmSKzen6KaWhWEoYvwxFCa7n/tC1SZ3tyq4SQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.39
-      postcss-selector-parser: 6.1.0
+      postcss: 8.4.47
+      postcss-selector-parser: 6.1.2
     dev: true
 
-  /postcss-browser-comments/4.0.0_73z3fjs2jrhgsuowbj3qmsq6yu:
+  /postcss-browser-comments/4.0.0_22bcdb3nr4qkkg7bvewmb25sri:
     resolution: {integrity: sha512-X9X9/WN3KIvY9+hNERUqX9gncsgBA25XaeR+jshHz2j8+sYyHktHw1JdKuMjeLpGktXidqDhA7b/qm1mrBDmgg==}
     engines: {node: '>=8'}
     peerDependencies:
       browserslist: '>=4'
       postcss: '>=8'
     dependencies:
-      browserslist: 4.23.2
-      postcss: 8.4.39
+      browserslist: 4.24.2
+      postcss: 8.4.47
     dev: true
 
-  /postcss-calc/8.2.4_postcss@8.4.39:
+  /postcss-calc/8.2.4_postcss@8.4.47:
     resolution: {integrity: sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==}
     peerDependencies:
       postcss: ^8.2.2
     dependencies:
-      postcss: 8.4.39
-      postcss-selector-parser: 6.1.0
+      postcss: 8.4.47
+      postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-clamp/4.1.0_postcss@8.4.39:
+  /postcss-clamp/4.1.0_postcss@8.4.47:
     resolution: {integrity: sha512-ry4b1Llo/9zz+PKC+030KUnPITTJAHeOwjfAyyB60eT0AorGLdzp52s31OsPRHRf8NchkgFoG2y6fCfn1IV1Ow==}
     engines: {node: '>=7.6.0'}
     peerDependencies:
       postcss: ^8.4.6
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-color-functional-notation/4.2.4_postcss@8.4.39:
+  /postcss-color-functional-notation/4.2.4_postcss@8.4.47:
     resolution: {integrity: sha512-2yrTAUZUab9s6CpxkxC4rVgFEVaR6/2Pipvi6qcgvnYiVqZcbDHEoBDhrXzyb7Efh2CCfHQNtcqWcIruDTIUeg==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-color-hex-alpha/8.0.4_postcss@8.4.39:
+  /postcss-color-hex-alpha/8.0.4_postcss@8.4.47:
     resolution: {integrity: sha512-nLo2DCRC9eE4w2JmuKgVA3fGL3d01kGq752pVALF68qpGLmx2Qrk91QTKkdUqqp45T1K1XV8IhQpcu1hoAQflQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.4
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-color-rebeccapurple/7.1.1_postcss@8.4.39:
+  /postcss-color-rebeccapurple/7.1.1_postcss@8.4.47:
     resolution: {integrity: sha512-pGxkuVEInwLHgkNxUc4sdg4g3py7zUeCQ9sMfwyHAT+Ezk8a4OaaVZ8lIY5+oNqA/BXXgLyXv0+5wHP68R79hg==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-colormin/5.3.1_postcss@8.4.39:
+  /postcss-colormin/5.3.1_postcss@8.4.47:
     resolution: {integrity: sha512-UsWQG0AqTFQmpBegeLLc1+c3jIqBNB0zlDGRWR+dQ3pRKJL1oeMzyqmH3o2PIfn9MBdNrVPWhDbT769LxCTLJQ==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.23.2
+      browserslist: 4.24.2
       caniuse-api: 3.0.0
       colord: 2.9.3
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-convert-values/5.1.3_postcss@8.4.39:
+  /postcss-convert-values/5.1.3_postcss@8.4.47:
     resolution: {integrity: sha512-82pC1xkJZtcJEfiLw6UXnXVXScgtBrjlO5CBmuDQc+dlb88ZYheFsjTn40+zBVi3DkfF7iezO0nJUPLcJK3pvA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.23.2
-      postcss: 8.4.39
+      browserslist: 4.24.2
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-custom-media/8.0.2_postcss@8.4.39:
+  /postcss-custom-media/8.0.2_postcss@8.4.47:
     resolution: {integrity: sha512-7yi25vDAoHAkbhAzX9dHx2yc6ntS4jQvejrNcC+csQJAXjj15e7VcWfMgLqBNAbOvqi5uIa9huOVwdHbf+sKqg==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.3
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-custom-properties/12.1.11_postcss@8.4.39:
+  /postcss-custom-properties/12.1.11_postcss@8.4.47:
     resolution: {integrity: sha512-0IDJYhgU8xDv1KY6+VgUwuQkVtmYzRwu+dMjnmdMafXYv86SWqfxkc7qdDvWS38vsjaEtv8e0vGOUQrAiMBLpQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-custom-selectors/6.0.3_postcss@8.4.39:
+  /postcss-custom-selectors/6.0.3_postcss@8.4.47:
     resolution: {integrity: sha512-fgVkmyiWDwmD3JbpCmB45SvvlCD6z9CG6Ie6Iere22W5aHea6oWa7EM2bpnv2Fj3I94L3VbtvX9KqwSi5aFzSg==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.3
     dependencies:
-      postcss: 8.4.39
-      postcss-selector-parser: 6.1.0
+      postcss: 8.4.47
+      postcss-selector-parser: 6.1.2
     dev: true
 
-  /postcss-dir-pseudo-class/6.0.5_postcss@8.4.39:
+  /postcss-dir-pseudo-class/6.0.5_postcss@8.4.47:
     resolution: {integrity: sha512-eqn4m70P031PF7ZQIvSgy9RSJ5uI2171O/OO/zcRNYpJbvaeKFUlar1aJ7rmgiQtbm0FSPsRewjpdS0Oew7MPA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.39
-      postcss-selector-parser: 6.1.0
+      postcss: 8.4.47
+      postcss-selector-parser: 6.1.2
     dev: true
 
-  /postcss-discard-comments/5.1.2_postcss@8.4.39:
+  /postcss-discard-comments/5.1.2_postcss@8.4.47:
     resolution: {integrity: sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
     dev: true
 
-  /postcss-discard-duplicates/5.1.0_postcss@8.4.39:
+  /postcss-discard-duplicates/5.1.0_postcss@8.4.47:
     resolution: {integrity: sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
     dev: true
 
-  /postcss-discard-empty/5.1.1_postcss@8.4.39:
+  /postcss-discard-empty/5.1.1_postcss@8.4.47:
     resolution: {integrity: sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
     dev: true
 
-  /postcss-discard-overridden/5.1.0_postcss@8.4.39:
+  /postcss-discard-overridden/5.1.0_postcss@8.4.47:
     resolution: {integrity: sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
     dev: true
 
-  /postcss-double-position-gradients/3.1.2_postcss@8.4.39:
+  /postcss-double-position-gradients/3.1.2_postcss@8.4.47:
     resolution: {integrity: sha512-GX+FuE/uBR6eskOK+4vkXgT6pDkexLokPaz/AbJna9s5Kzp/yl488pKPjhy0obB475ovfT1Wv8ho7U/cHNaRgQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 1.3.0_postcss@8.4.39
-      postcss: 8.4.39
+      '@csstools/postcss-progressive-custom-properties': 1.3.0_postcss@8.4.47
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-env-function/4.0.6_postcss@8.4.39:
+  /postcss-env-function/4.0.6_postcss@8.4.47:
     resolution: {integrity: sha512-kpA6FsLra+NqcFnL81TnsU+Z7orGtDTxcOhl6pwXeEq1yFPpRMkCDpHhrz8CFQDr/Wfm0jLiNQ1OsGGPjlqPwA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.4
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-flexbugs-fixes/5.0.2_postcss@8.4.39:
+  /postcss-flexbugs-fixes/5.0.2_postcss@8.4.47:
     resolution: {integrity: sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ==}
     peerDependencies:
       postcss: ^8.1.4
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
     dev: true
 
-  /postcss-focus-visible/6.0.4_postcss@8.4.39:
+  /postcss-focus-visible/6.0.4_postcss@8.4.47:
     resolution: {integrity: sha512-QcKuUU/dgNsstIK6HELFRT5Y3lbrMLEOwG+A4s5cA+fx3A3y/JTq3X9LaOj3OC3ALH0XqyrgQIgey/MIZ8Wczw==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.4
     dependencies:
-      postcss: 8.4.39
-      postcss-selector-parser: 6.1.0
+      postcss: 8.4.47
+      postcss-selector-parser: 6.1.2
     dev: true
 
-  /postcss-focus-within/5.0.4_postcss@8.4.39:
+  /postcss-focus-within/5.0.4_postcss@8.4.47:
     resolution: {integrity: sha512-vvjDN++C0mu8jz4af5d52CB184ogg/sSxAFS+oUJQq2SuCe7T5U2iIsVJtsCp2d6R4j0jr5+q3rPkBVZkXD9fQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.4
     dependencies:
-      postcss: 8.4.39
-      postcss-selector-parser: 6.1.0
+      postcss: 8.4.47
+      postcss-selector-parser: 6.1.2
     dev: true
 
-  /postcss-font-variant/5.0.0_postcss@8.4.39:
+  /postcss-font-variant/5.0.0_postcss@8.4.47:
     resolution: {integrity: sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
     dev: true
 
-  /postcss-gap-properties/3.0.5_postcss@8.4.39:
+  /postcss-gap-properties/3.0.5_postcss@8.4.47:
     resolution: {integrity: sha512-IuE6gKSdoUNcvkGIqdtjtcMtZIFyXZhmFd5RUlg97iVEvp1BZKV5ngsAjCjrVy+14uhGBQl9tzmi1Qwq4kqVOg==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
     dev: true
 
-  /postcss-html/0.36.0_lrpgrolfvll3p4c7yzuvfga3qm:
+  /postcss-html/0.36.0_7ddkth4qkj3urzklvpilix4jii:
     resolution: {integrity: sha512-HeiOxGcuwID0AFsNAL0ox3mW6MHH5cstWN1Z3Y+n6H+g12ih7LHdYxWwEA/QmrebctLjo79xz9ouK3MroHwOJw==}
     peerDependencies:
       postcss: '>=5.0.0'
       postcss-syntax: '>=0.36.0'
     dependencies:
       htmlparser2: 3.10.1
-      postcss: 8.4.39
-      postcss-syntax: 0.36.2_postcss@8.4.39
+      postcss: 8.4.47
+      postcss-syntax: 0.36.2_postcss@8.4.47
     dev: true
 
-  /postcss-image-set-function/4.0.7_postcss@8.4.39:
+  /postcss-image-set-function/4.0.7_postcss@8.4.47:
     resolution: {integrity: sha512-9T2r9rsvYzm5ndsBE8WgtrMlIT7VbtTfE7b3BQnudUqnBcBo7L758oc+o+pdj/dUV0l5wjwSdjeOH2DZtfv8qw==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-import/15.1.0_postcss@8.4.39:
+  /postcss-import/15.1.0_postcss@8.4.47:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       postcss: ^8.0.0
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.8
     dev: true
 
-  /postcss-initial/4.0.1_postcss@8.4.39:
+  /postcss-initial/4.0.1_postcss@8.4.47:
     resolution: {integrity: sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==}
     peerDependencies:
       postcss: ^8.0.0
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
     dev: true
 
-  /postcss-js/4.0.1_postcss@8.4.39:
+  /postcss-js/4.0.1_postcss@8.4.47:
     resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
       postcss: ^8.4.21
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.4.39
+      postcss: 8.4.47
     dev: true
 
-  /postcss-lab-function/4.2.1_postcss@8.4.39:
+  /postcss-lab-function/4.2.1_postcss@8.4.47:
     resolution: {integrity: sha512-xuXll4isR03CrQsmxyz92LJB2xX9n+pZJ5jE9JgcnmsCammLyKdlzrBin+25dy6wIjfhJpKBAN80gsTlCgRk2w==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 1.3.0_postcss@8.4.39
-      postcss: 8.4.39
+      '@csstools/postcss-progressive-custom-properties': 1.3.0_postcss@8.4.47
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
@@ -14131,10 +14197,10 @@ packages:
     resolution: {integrity: sha512-7TvleQWNM2QLcHqvudt3VYjULVB49uiW6XzEUFmvwHzvsOEF5MwBrIXZDJQvJNFGjJQTzSzZnDoCJ8h/ljyGXA==}
     engines: {node: '>=6.14.4'}
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
     dev: true
 
-  /postcss-load-config/4.0.2_postcss@8.4.39:
+  /postcss-load-config/4.0.2_postcss@8.4.47:
     resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
     engines: {node: '>= 14'}
     peerDependencies:
@@ -14147,11 +14213,11 @@ packages:
         optional: true
     dependencies:
       lilconfig: 3.1.2
-      postcss: 8.4.39
-      yaml: 2.4.5
+      postcss: 8.4.47
+      yaml: 2.6.0
     dev: true
 
-  /postcss-loader/6.2.1_h7ybz3vosd2sabh3expkxy422u:
+  /postcss-loader/6.2.1_ttspydkdwnlpk544tqarzu6cim:
     resolution: {integrity: sha512-WbbYpmAaKcux/P66bZ40bpWsBucjx/TTgVVzRZ9yUO8yQfVBlameJ0ZGVaPfH64hNSBh63a+ICP5nqOpBA0w+Q==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -14160,255 +14226,255 @@ packages:
     dependencies:
       cosmiconfig: 7.1.0
       klona: 2.0.6
-      postcss: 8.4.39
-      semver: 7.6.2
-      webpack: 5.92.1
+      postcss: 8.4.47
+      semver: 7.6.3
+      webpack: 5.95.0
     dev: true
 
-  /postcss-logical/5.0.4_postcss@8.4.39:
+  /postcss-logical/5.0.4_postcss@8.4.47:
     resolution: {integrity: sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.4
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
     dev: true
 
-  /postcss-media-minmax/5.0.0_postcss@8.4.39:
+  /postcss-media-minmax/5.0.0_postcss@8.4.47:
     resolution: {integrity: sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
     dev: true
 
   /postcss-media-query-parser/0.2.3:
     resolution: {integrity: sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==}
     dev: true
 
-  /postcss-merge-longhand/5.1.7_postcss@8.4.39:
+  /postcss-merge-longhand/5.1.7_postcss@8.4.47:
     resolution: {integrity: sha512-YCI9gZB+PLNskrK0BB3/2OzPnGhPkBEwmwhfYk1ilBHYVAZB7/tkTHFBAnCrvBBOmeYyMYw3DMjT55SyxMBzjQ==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
-      stylehacks: 5.1.1_postcss@8.4.39
+      stylehacks: 5.1.1_postcss@8.4.47
     dev: true
 
-  /postcss-merge-rules/5.1.4_postcss@8.4.39:
+  /postcss-merge-rules/5.1.4_postcss@8.4.47:
     resolution: {integrity: sha512-0R2IuYpgU93y9lhVbO/OylTtKMVcHb67zjWIfCiKR9rWL3GUk1677LAqD/BcHizukdZEjT8Ru3oHRoAYoJy44g==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.23.2
+      browserslist: 4.24.2
       caniuse-api: 3.0.0
-      cssnano-utils: 3.1.0_postcss@8.4.39
-      postcss: 8.4.39
-      postcss-selector-parser: 6.1.0
+      cssnano-utils: 3.1.0_postcss@8.4.47
+      postcss: 8.4.47
+      postcss-selector-parser: 6.1.2
     dev: true
 
-  /postcss-minify-font-values/5.1.0_postcss@8.4.39:
+  /postcss-minify-font-values/5.1.0_postcss@8.4.47:
     resolution: {integrity: sha512-el3mYTgx13ZAPPirSVsHqFzl+BBBDrXvbySvPGFnQcTI4iNslrPaFq4muTkLZmKlGk4gyFAYUBMH30+HurREyA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-minify-gradients/5.1.1_postcss@8.4.39:
+  /postcss-minify-gradients/5.1.1_postcss@8.4.47:
     resolution: {integrity: sha512-VGvXMTpCEo4qHTNSa9A0a3D+dxGFZCYwR6Jokk+/3oB6flu2/PnPXAh2x7x52EkY5xlIHLm+Le8tJxe/7TNhzw==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
       colord: 2.9.3
-      cssnano-utils: 3.1.0_postcss@8.4.39
-      postcss: 8.4.39
+      cssnano-utils: 3.1.0_postcss@8.4.47
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-minify-params/5.1.4_postcss@8.4.39:
+  /postcss-minify-params/5.1.4_postcss@8.4.47:
     resolution: {integrity: sha512-+mePA3MgdmVmv6g+30rn57USjOGSAyuxUmkfiWpzalZ8aiBkdPYjXWtHuwJGm1v5Ojy0Z0LaSYhHaLJQB0P8Jw==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.23.2
-      cssnano-utils: 3.1.0_postcss@8.4.39
-      postcss: 8.4.39
+      browserslist: 4.24.2
+      cssnano-utils: 3.1.0_postcss@8.4.47
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-minify-selectors/5.2.1_postcss@8.4.39:
+  /postcss-minify-selectors/5.2.1_postcss@8.4.47:
     resolution: {integrity: sha512-nPJu7OjZJTsVUmPdm2TcaiohIwxP+v8ha9NehQ2ye9szv4orirRU3SDdtUmKH+10nzn0bAyOXZ0UEr7OpvLehg==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.39
-      postcss-selector-parser: 6.1.0
+      postcss: 8.4.47
+      postcss-selector-parser: 6.1.2
     dev: true
 
-  /postcss-modules-extract-imports/3.1.0_postcss@8.4.39:
+  /postcss-modules-extract-imports/3.1.0_postcss@8.4.47:
     resolution: {integrity: sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
     dev: true
 
-  /postcss-modules-local-by-default/4.0.5_postcss@8.4.39:
+  /postcss-modules-local-by-default/4.0.5_postcss@8.4.47:
     resolution: {integrity: sha512-6MieY7sIfTK0hYfafw1OMEG+2bg8Q1ocHCpoWLqOKj3JXlKu4G7btkmM/B7lFubYkYWmRSPLZi5chid63ZaZYw==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      icss-utils: 5.1.0_postcss@8.4.39
-      postcss: 8.4.39
-      postcss-selector-parser: 6.1.0
+      icss-utils: 5.1.0_postcss@8.4.47
+      postcss: 8.4.47
+      postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-modules-scope/3.2.0_postcss@8.4.39:
+  /postcss-modules-scope/3.2.0_postcss@8.4.47:
     resolution: {integrity: sha512-oq+g1ssrsZOsx9M96c5w8laRmvEu9C3adDSjI8oTcbfkrTE8hx/zfyobUoWIxaKPO8bt6S62kxpw5GqypEw1QQ==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      postcss: 8.4.39
-      postcss-selector-parser: 6.1.0
+      postcss: 8.4.47
+      postcss-selector-parser: 6.1.2
     dev: true
 
-  /postcss-modules-values/4.0.0_postcss@8.4.39:
+  /postcss-modules-values/4.0.0_postcss@8.4.47:
     resolution: {integrity: sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      icss-utils: 5.1.0_postcss@8.4.39
-      postcss: 8.4.39
+      icss-utils: 5.1.0_postcss@8.4.47
+      postcss: 8.4.47
     dev: true
 
-  /postcss-nested/6.0.1_postcss@8.4.39:
-    resolution: {integrity: sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==}
+  /postcss-nested/6.2.0_postcss@8.4.47:
+    resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.2.14
     dependencies:
-      postcss: 8.4.39
-      postcss-selector-parser: 6.1.0
+      postcss: 8.4.47
+      postcss-selector-parser: 6.1.2
     dev: true
 
-  /postcss-nesting/10.2.0_postcss@8.4.39:
+  /postcss-nesting/10.2.0_postcss@8.4.47:
     resolution: {integrity: sha512-EwMkYchxiDiKUhlJGzWsD9b2zvq/r2SSubcRrgP+jujMXFzqvANLt16lJANC+5uZ6hjI7lpRmI6O8JIl+8l1KA==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/selector-specificity': 2.2.0_jbx4mus4njtel3ypyfykqgp6rq
-      postcss: 8.4.39
-      postcss-selector-parser: 6.1.0
+      '@csstools/selector-specificity': 2.2.0_j747yjqyvnzekvomyruvypt3ti
+      postcss: 8.4.47
+      postcss-selector-parser: 6.1.2
     dev: true
 
-  /postcss-normalize-charset/5.1.0_postcss@8.4.39:
+  /postcss-normalize-charset/5.1.0_postcss@8.4.47:
     resolution: {integrity: sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
     dev: true
 
-  /postcss-normalize-display-values/5.1.0_postcss@8.4.39:
+  /postcss-normalize-display-values/5.1.0_postcss@8.4.47:
     resolution: {integrity: sha512-WP4KIM4o2dazQXWmFaqMmcvsKmhdINFblgSeRgn8BJ6vxaMyaJkwAzpPpuvSIoG/rmX3M+IrRZEz2H0glrQNEA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-normalize-positions/5.1.1_postcss@8.4.39:
+  /postcss-normalize-positions/5.1.1_postcss@8.4.47:
     resolution: {integrity: sha512-6UpCb0G4eofTCQLFVuI3EVNZzBNPiIKcA1AKVka+31fTVySphr3VUgAIULBhxZkKgwLImhzMR2Bw1ORK+37INg==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-normalize-repeat-style/5.1.1_postcss@8.4.39:
+  /postcss-normalize-repeat-style/5.1.1_postcss@8.4.47:
     resolution: {integrity: sha512-mFpLspGWkQtBcWIRFLmewo8aC3ImN2i/J3v8YCFUwDnPu3Xz4rLohDO26lGjwNsQxB3YF0KKRwspGzE2JEuS0g==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-normalize-string/5.1.0_postcss@8.4.39:
+  /postcss-normalize-string/5.1.0_postcss@8.4.47:
     resolution: {integrity: sha512-oYiIJOf4T9T1N4i+abeIc7Vgm/xPCGih4bZz5Nm0/ARVJ7K6xrDlLwvwqOydvyL3RHNf8qZk6vo3aatiw/go3w==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-normalize-timing-functions/5.1.0_postcss@8.4.39:
+  /postcss-normalize-timing-functions/5.1.0_postcss@8.4.47:
     resolution: {integrity: sha512-DOEkzJ4SAXv5xkHl0Wa9cZLF3WCBhF3o1SKVxKQAa+0pYKlueTpCgvkFAHfk+Y64ezX9+nITGrDZeVGgITJXjg==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-normalize-unicode/5.1.1_postcss@8.4.39:
+  /postcss-normalize-unicode/5.1.1_postcss@8.4.47:
     resolution: {integrity: sha512-qnCL5jzkNUmKVhZoENp1mJiGNPcsJCs1aaRmURmeJGES23Z/ajaln+EPTD+rBeNkSryI+2WTdW+lwcVdOikrpA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.23.2
-      postcss: 8.4.39
+      browserslist: 4.24.2
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-normalize-url/5.1.0_postcss@8.4.39:
+  /postcss-normalize-url/5.1.0_postcss@8.4.47:
     resolution: {integrity: sha512-5upGeDO+PVthOxSmds43ZeMeZfKH+/DKgGRD7TElkkyS46JXAUhMzIKiCa7BabPeIy3AQcTkXwVVN7DbqsiCew==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
       normalize-url: 6.1.0
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-normalize-whitespace/5.1.1_postcss@8.4.39:
+  /postcss-normalize-whitespace/5.1.1_postcss@8.4.47:
     resolution: {integrity: sha512-83ZJ4t3NUDETIHTa3uEg6asWjSBYL5EdkVB0sDncx9ERzOKBVJIUeDO9RyA9Zwtig8El1d79HBp0JEi8wvGQnA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-normalize/10.0.1_73z3fjs2jrhgsuowbj3qmsq6yu:
+  /postcss-normalize/10.0.1_22bcdb3nr4qkkg7bvewmb25sri:
     resolution: {integrity: sha512-+5w18/rDev5mqERcG3W5GZNMJa1eoYYNGo8gB7tEwaos0ajk3ZXAI4mHGcNT47NE+ZnZD1pEpUOFLvltIwmeJA==}
     engines: {node: '>= 12'}
     peerDependencies:
@@ -14416,202 +14482,202 @@ packages:
       postcss: '>= 8'
     dependencies:
       '@csstools/normalize.css': 12.1.1
-      browserslist: 4.23.2
-      postcss: 8.4.39
-      postcss-browser-comments: 4.0.0_73z3fjs2jrhgsuowbj3qmsq6yu
+      browserslist: 4.24.2
+      postcss: 8.4.47
+      postcss-browser-comments: 4.0.0_22bcdb3nr4qkkg7bvewmb25sri
       sanitize.css: 13.0.0
     dev: true
 
-  /postcss-opacity-percentage/1.1.3_postcss@8.4.39:
+  /postcss-opacity-percentage/1.1.3_postcss@8.4.47:
     resolution: {integrity: sha512-An6Ba4pHBiDtyVpSLymUUERMo2cU7s+Obz6BTrS+gxkbnSBNKSuD0AVUc+CpBMrpVPKKfoVz0WQCX+Tnst0i4A==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
     dev: true
 
-  /postcss-ordered-values/5.1.3_postcss@8.4.39:
+  /postcss-ordered-values/5.1.3_postcss@8.4.47:
     resolution: {integrity: sha512-9UO79VUhPwEkzbb3RNpqqghc6lcYej1aveQteWY+4POIwlqkYE21HKWaLDF6lWNuqCobEAyTovVhtI32Rbv2RQ==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      cssnano-utils: 3.1.0_postcss@8.4.39
-      postcss: 8.4.39
+      cssnano-utils: 3.1.0_postcss@8.4.47
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-overflow-shorthand/3.0.4_postcss@8.4.39:
+  /postcss-overflow-shorthand/3.0.4_postcss@8.4.47:
     resolution: {integrity: sha512-otYl/ylHK8Y9bcBnPLo3foYFLL6a6Ak+3EQBPOTR7luMYCOsiVTUk1iLvNf6tVPNGXcoL9Hoz37kpfriRIFb4A==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-page-break/3.0.4_postcss@8.4.39:
+  /postcss-page-break/3.0.4_postcss@8.4.47:
     resolution: {integrity: sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==}
     peerDependencies:
       postcss: ^8
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
     dev: true
 
-  /postcss-place/7.0.5_postcss@8.4.39:
+  /postcss-place/7.0.5_postcss@8.4.47:
     resolution: {integrity: sha512-wR8igaZROA6Z4pv0d+bvVrvGY4GVHihBCBQieXFY3kuSuMyOmEnnfFzHl/tQuqHZkfkIVBEbDvYcFfHmpSet9g==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-prefix-selector/1.16.1_postcss@8.4.39:
+  /postcss-prefix-selector/1.16.1_postcss@8.4.47:
     resolution: {integrity: sha512-Umxu+FvKMwlY6TyDzGFoSUnzW+NOfMBLyC1tAkIjgX+Z/qGspJeRjVC903D7mx7TuBpJlwti2ibXtWuA7fKMeQ==}
     peerDependencies:
       postcss: '>4 <9'
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
     dev: true
 
-  /postcss-preset-env/7.8.3_postcss@8.4.39:
+  /postcss-preset-env/7.8.3_postcss@8.4.47:
     resolution: {integrity: sha512-T1LgRm5uEVFSEF83vHZJV2z19lHg4yJuZ6gXZZkqVsqv63nlr6zabMH3l4Pc01FQCyfWVrh2GaUeCVy9Po+Aag==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/postcss-cascade-layers': 1.1.1_postcss@8.4.39
-      '@csstools/postcss-color-function': 1.1.1_postcss@8.4.39
-      '@csstools/postcss-font-format-keywords': 1.0.1_postcss@8.4.39
-      '@csstools/postcss-hwb-function': 1.0.2_postcss@8.4.39
-      '@csstools/postcss-ic-unit': 1.0.1_postcss@8.4.39
-      '@csstools/postcss-is-pseudo-class': 2.0.7_postcss@8.4.39
-      '@csstools/postcss-nested-calc': 1.0.0_postcss@8.4.39
-      '@csstools/postcss-normalize-display-values': 1.0.1_postcss@8.4.39
-      '@csstools/postcss-oklab-function': 1.1.1_postcss@8.4.39
-      '@csstools/postcss-progressive-custom-properties': 1.3.0_postcss@8.4.39
-      '@csstools/postcss-stepped-value-functions': 1.0.1_postcss@8.4.39
-      '@csstools/postcss-text-decoration-shorthand': 1.0.0_postcss@8.4.39
-      '@csstools/postcss-trigonometric-functions': 1.0.2_postcss@8.4.39
-      '@csstools/postcss-unset-value': 1.0.2_postcss@8.4.39
-      autoprefixer: 10.4.19_postcss@8.4.39
-      browserslist: 4.23.2
-      css-blank-pseudo: 3.0.3_postcss@8.4.39
-      css-has-pseudo: 3.0.4_postcss@8.4.39
-      css-prefers-color-scheme: 6.0.3_postcss@8.4.39
+      '@csstools/postcss-cascade-layers': 1.1.1_postcss@8.4.47
+      '@csstools/postcss-color-function': 1.1.1_postcss@8.4.47
+      '@csstools/postcss-font-format-keywords': 1.0.1_postcss@8.4.47
+      '@csstools/postcss-hwb-function': 1.0.2_postcss@8.4.47
+      '@csstools/postcss-ic-unit': 1.0.1_postcss@8.4.47
+      '@csstools/postcss-is-pseudo-class': 2.0.7_postcss@8.4.47
+      '@csstools/postcss-nested-calc': 1.0.0_postcss@8.4.47
+      '@csstools/postcss-normalize-display-values': 1.0.1_postcss@8.4.47
+      '@csstools/postcss-oklab-function': 1.1.1_postcss@8.4.47
+      '@csstools/postcss-progressive-custom-properties': 1.3.0_postcss@8.4.47
+      '@csstools/postcss-stepped-value-functions': 1.0.1_postcss@8.4.47
+      '@csstools/postcss-text-decoration-shorthand': 1.0.0_postcss@8.4.47
+      '@csstools/postcss-trigonometric-functions': 1.0.2_postcss@8.4.47
+      '@csstools/postcss-unset-value': 1.0.2_postcss@8.4.47
+      autoprefixer: 10.4.20_postcss@8.4.47
+      browserslist: 4.24.2
+      css-blank-pseudo: 3.0.3_postcss@8.4.47
+      css-has-pseudo: 3.0.4_postcss@8.4.47
+      css-prefers-color-scheme: 6.0.3_postcss@8.4.47
       cssdb: 7.11.2
-      postcss: 8.4.39
-      postcss-attribute-case-insensitive: 5.0.2_postcss@8.4.39
-      postcss-clamp: 4.1.0_postcss@8.4.39
-      postcss-color-functional-notation: 4.2.4_postcss@8.4.39
-      postcss-color-hex-alpha: 8.0.4_postcss@8.4.39
-      postcss-color-rebeccapurple: 7.1.1_postcss@8.4.39
-      postcss-custom-media: 8.0.2_postcss@8.4.39
-      postcss-custom-properties: 12.1.11_postcss@8.4.39
-      postcss-custom-selectors: 6.0.3_postcss@8.4.39
-      postcss-dir-pseudo-class: 6.0.5_postcss@8.4.39
-      postcss-double-position-gradients: 3.1.2_postcss@8.4.39
-      postcss-env-function: 4.0.6_postcss@8.4.39
-      postcss-focus-visible: 6.0.4_postcss@8.4.39
-      postcss-focus-within: 5.0.4_postcss@8.4.39
-      postcss-font-variant: 5.0.0_postcss@8.4.39
-      postcss-gap-properties: 3.0.5_postcss@8.4.39
-      postcss-image-set-function: 4.0.7_postcss@8.4.39
-      postcss-initial: 4.0.1_postcss@8.4.39
-      postcss-lab-function: 4.2.1_postcss@8.4.39
-      postcss-logical: 5.0.4_postcss@8.4.39
-      postcss-media-minmax: 5.0.0_postcss@8.4.39
-      postcss-nesting: 10.2.0_postcss@8.4.39
-      postcss-opacity-percentage: 1.1.3_postcss@8.4.39
-      postcss-overflow-shorthand: 3.0.4_postcss@8.4.39
-      postcss-page-break: 3.0.4_postcss@8.4.39
-      postcss-place: 7.0.5_postcss@8.4.39
-      postcss-pseudo-class-any-link: 7.1.6_postcss@8.4.39
-      postcss-replace-overflow-wrap: 4.0.0_postcss@8.4.39
-      postcss-selector-not: 6.0.1_postcss@8.4.39
+      postcss: 8.4.47
+      postcss-attribute-case-insensitive: 5.0.2_postcss@8.4.47
+      postcss-clamp: 4.1.0_postcss@8.4.47
+      postcss-color-functional-notation: 4.2.4_postcss@8.4.47
+      postcss-color-hex-alpha: 8.0.4_postcss@8.4.47
+      postcss-color-rebeccapurple: 7.1.1_postcss@8.4.47
+      postcss-custom-media: 8.0.2_postcss@8.4.47
+      postcss-custom-properties: 12.1.11_postcss@8.4.47
+      postcss-custom-selectors: 6.0.3_postcss@8.4.47
+      postcss-dir-pseudo-class: 6.0.5_postcss@8.4.47
+      postcss-double-position-gradients: 3.1.2_postcss@8.4.47
+      postcss-env-function: 4.0.6_postcss@8.4.47
+      postcss-focus-visible: 6.0.4_postcss@8.4.47
+      postcss-focus-within: 5.0.4_postcss@8.4.47
+      postcss-font-variant: 5.0.0_postcss@8.4.47
+      postcss-gap-properties: 3.0.5_postcss@8.4.47
+      postcss-image-set-function: 4.0.7_postcss@8.4.47
+      postcss-initial: 4.0.1_postcss@8.4.47
+      postcss-lab-function: 4.2.1_postcss@8.4.47
+      postcss-logical: 5.0.4_postcss@8.4.47
+      postcss-media-minmax: 5.0.0_postcss@8.4.47
+      postcss-nesting: 10.2.0_postcss@8.4.47
+      postcss-opacity-percentage: 1.1.3_postcss@8.4.47
+      postcss-overflow-shorthand: 3.0.4_postcss@8.4.47
+      postcss-page-break: 3.0.4_postcss@8.4.47
+      postcss-place: 7.0.5_postcss@8.4.47
+      postcss-pseudo-class-any-link: 7.1.6_postcss@8.4.47
+      postcss-replace-overflow-wrap: 4.0.0_postcss@8.4.47
+      postcss-selector-not: 6.0.1_postcss@8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-pseudo-class-any-link/7.1.6_postcss@8.4.39:
+  /postcss-pseudo-class-any-link/7.1.6_postcss@8.4.47:
     resolution: {integrity: sha512-9sCtZkO6f/5ML9WcTLcIyV1yz9D1rf0tWc+ulKcvV30s0iZKS/ONyETvoWsr6vnrmW+X+KmuK3gV/w5EWnT37w==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.39
-      postcss-selector-parser: 6.1.0
+      postcss: 8.4.47
+      postcss-selector-parser: 6.1.2
     dev: true
 
-  /postcss-reduce-initial/5.1.2_postcss@8.4.39:
+  /postcss-reduce-initial/5.1.2_postcss@8.4.47:
     resolution: {integrity: sha512-dE/y2XRaqAi6OvjzD22pjTUQ8eOfc6m/natGHgKFBK9DxFmIm69YmaRVQrGgFlEfc1HePIurY0TmDeROK05rIg==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.23.2
+      browserslist: 4.24.2
       caniuse-api: 3.0.0
-      postcss: 8.4.39
+      postcss: 8.4.47
     dev: true
 
-  /postcss-reduce-transforms/5.1.0_postcss@8.4.39:
+  /postcss-reduce-transforms/5.1.0_postcss@8.4.47:
     resolution: {integrity: sha512-2fbdbmgir5AvpW9RLtdONx1QoYG2/EtqpNQbFASDlixBbAYuTcJ0dECwlqNqH7VbaUnEnh8SrxOe2sRIn24XyQ==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-replace-overflow-wrap/4.0.0_postcss@8.4.39:
+  /postcss-replace-overflow-wrap/4.0.0_postcss@8.4.47:
     resolution: {integrity: sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==}
     peerDependencies:
       postcss: ^8.0.3
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
     dev: true
 
-  /postcss-resolve-nested-selector/0.1.1:
-    resolution: {integrity: sha512-HvExULSwLqHLgUy1rl3ANIqCsvMS0WHss2UOsXhXnQaZ9VCc2oBvIpXrl00IUFT5ZDITME0o6oiXeiHr2SAIfw==}
+  /postcss-resolve-nested-selector/0.1.6:
+    resolution: {integrity: sha512-0sglIs9Wmkzbr8lQwEyIzlDOOC9bGmfVKcJTaxv3vMmd3uo4o4DerC3En0bnmgceeql9BfC8hRkp7cg0fjdVqw==}
     dev: true
 
   /postcss-safe-parser/4.0.2:
     resolution: {integrity: sha512-Uw6ekxSWNLCPesSv/cmqf2bY/77z11O7jZGPax3ycZMFU/oi2DMH9i89AdHc1tRwFg/arFoEwX0IS3LCUxJh1g==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
     dev: true
 
   /postcss-sass/0.4.4:
     resolution: {integrity: sha512-BYxnVYx4mQooOhr+zer0qWbSPYnarAy8ZT7hAQtbxtgVf8gy+LSLT/hHGe35h14/pZDTw1DsxdbrwxBN++H+fg==}
     dependencies:
       gonzales-pe: 4.3.0
-      postcss: 8.4.39
+      postcss: 8.4.47
     dev: true
 
   /postcss-scss/2.1.1:
     resolution: {integrity: sha512-jQmGnj0hSGLd9RscFw9LyuSVAa5Bl1/KBPqG1NQw9w8ND55nY4ZEsdlVuYJvLPpV+y0nwTV5v/4rHPzZRihQbA==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
     dev: true
 
-  /postcss-selector-not/6.0.1_postcss@8.4.39:
+  /postcss-selector-not/6.0.1_postcss@8.4.47:
     resolution: {integrity: sha512-1i9affjAe9xu/y9uqWH+tD4r6/hDaXJruk8xn2x1vzxC2U3J3LKO3zJW4CyxlNhA56pADJ/djpEwpH1RClI2rQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      postcss: 8.4.39
-      postcss-selector-parser: 6.1.0
+      postcss: 8.4.47
+      postcss-selector-parser: 6.1.2
     dev: true
 
-  /postcss-selector-parser/6.1.0:
-    resolution: {integrity: sha512-UMz42UD0UY0EApS0ZL9o1XnLhSTtvvvLe5Dc2H2O56fvRZi+KulDyf5ctDhhtYJBGKStV2FL1fy6253cmLgqVQ==}
+  /postcss-selector-parser/6.1.2:
+    resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
     engines: {node: '>=4'}
     dependencies:
       cssesc: 3.0.0
@@ -14623,49 +14689,49 @@ packages:
     engines: {node: '>=8.7.0'}
     dependencies:
       lodash: 4.17.21
-      postcss: 8.4.39
+      postcss: 8.4.47
     dev: true
 
-  /postcss-svgo/5.1.0_postcss@8.4.39:
+  /postcss-svgo/5.1.0_postcss@8.4.47:
     resolution: {integrity: sha512-D75KsH1zm5ZrHyxPakAxJWtkyXew5qwS70v56exwvw542d9CRtTo78K0WeFxZB4G7JXKKMbEZtZayTGdIky/eA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-value-parser: 4.2.0
       svgo: 2.8.0
     dev: true
 
-  /postcss-syntax/0.36.2_postcss@8.4.39:
+  /postcss-syntax/0.36.2_postcss@8.4.47:
     resolution: {integrity: sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==}
     peerDependencies:
       postcss: '>=5.0.0'
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
     dev: true
 
-  /postcss-unique-selectors/5.1.1_postcss@8.4.39:
+  /postcss-unique-selectors/5.1.1_postcss@8.4.47:
     resolution: {integrity: sha512-5JiODlELrz8L2HwxfPnhOWZYWDxVHWL83ufOv84NrcgipI7TaeRsatAhK4Tr2/ZiYldpK/wBvw5BD3qfaK96GA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.39
-      postcss-selector-parser: 6.1.0
+      postcss: 8.4.47
+      postcss-selector-parser: 6.1.2
     dev: true
 
   /postcss-value-parser/4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
     dev: true
 
-  /postcss/8.4.39:
-    resolution: {integrity: sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==}
+  /postcss/8.4.47:
+    resolution: {integrity: sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.7
-      picocolors: 1.0.1
-      source-map-js: 1.2.0
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
     dev: true
 
   /posthtml-parser/0.2.1:
@@ -14829,29 +14895,20 @@ packages:
     resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
     dev: true
 
-  /pump/3.0.0:
-    resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
+  /pump/3.0.2:
+    resolution: {integrity: sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==}
     dependencies:
       end-of-stream: 1.4.4
       once: 1.4.0
 
-  /punycode/1.4.1:
-    resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
-    dev: true
-
   /punycode/2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+    dev: true
 
   /pure-rand/6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
     dev: true
-
-  /qs/6.11.0:
-    resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
-    engines: {node: '>=0.6'}
-    dependencies:
-      side-channel: 1.0.6
 
   /qs/6.13.0:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
@@ -14932,7 +14989,7 @@ packages:
     resolution: {integrity: sha512-sZ41cxiU5llIB003yxxQBYrARBqe0repqPTTYBTmMqTz9szeBbE37BehCE891NZsmdZqqP+xWKdT3eo3vOzN8w==}
     engines: {node: '>=14'}
     dependencies:
-      core-js: 3.37.1
+      core-js: 3.39.0
       object-assign: 4.1.1
       promise: 8.3.0
       raf: 3.4.1
@@ -14952,20 +15009,20 @@ packages:
       section-iterator: 2.0.0
       shallow-equal: 1.2.1
 
-  /react-dev-utils/12.0.1_vmohbas7cixbs7dvjlkwhs5g3i:
+  /react-dev-utils/12.0.1_z6tosmbba6a4h5dofl3zomc5vu:
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
     dependencies:
-      '@babel/code-frame': 7.24.7
+      '@babel/code-frame': 7.26.2
       address: 1.2.2
-      browserslist: 4.23.2
+      browserslist: 4.24.2
       chalk: 4.1.2
       cross-spawn: 7.0.3
       detect-port-alt: 1.1.6
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3_vmohbas7cixbs7dvjlkwhs5g3i
+      fork-ts-checker-webpack-plugin: 6.5.3_z6tosmbba6a4h5dofl3zomc5vu
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -14996,35 +15053,25 @@ packages:
       react: 18.3.1
       scheduler: 0.23.2
 
-  /react-error-boundary/4.0.13_react@18.3.1:
-    resolution: {integrity: sha512-b6PwbdSv8XeOSYvjt8LpgpKrZ0yGdtZokYwkwV2wlcZbxgopHX/hgPl5VgpnoVOWd868n1hktM8Qm4b+02MiLQ==}
-    peerDependencies:
-      react: '>=16.13.1'
-    dependencies:
-      '@babel/runtime': 7.24.7
-      react: 18.3.1
-
   /react-error-boundary/4.0.3_react@18.3.1:
     resolution: {integrity: sha512-IzNKP/ViHWp2QRDgsDMirEcf0XLsLueN6Wgzm1TVwgbAH+paX8Z42VyKvZcFFRHgd+rPK2P4TLrOrHC/dommew==}
     peerDependencies:
       react: '>=16.13.1'
     dependencies:
-      '@babel/runtime': 7.24.7
+      '@babel/runtime': 7.26.0
+      react: 18.3.1
+
+  /react-error-boundary/4.1.2_react@18.3.1:
+    resolution: {integrity: sha512-GQDxZ5Jd+Aq/qUxbCm1UtzmL/s++V7zKgE8yMktJiCQXCCFZnMZh9ng+6/Ne6PjNSXH0L9CjeOEREfRnq6Duag==}
+    peerDependencies:
+      react: '>=16.13.1'
+    dependencies:
+      '@babel/runtime': 7.26.0
       react: 18.3.1
 
   /react-error-overlay/6.0.11:
     resolution: {integrity: sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==}
     dev: true
-
-  /react-highlight-words/0.20.0_react@18.3.1:
-    resolution: {integrity: sha512-asCxy+jCehDVhusNmCBoxDf2mm1AJ//D+EzDx1m5K7EqsMBIHdZ5G4LdwbSEXqZq1Ros0G0UySWmAtntSph7XA==}
-    peerDependencies:
-      react: ^0.14.0 || ^15.0.0 || ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
-    dependencies:
-      highlight-words-core: 1.2.2
-      memoize-one: 4.0.3
-      prop-types: 15.8.1
-      react: 18.3.1
 
   /react-intersection-observer/8.34.0_react@18.3.1:
     resolution: {integrity: sha512-TYKh52Zc0Uptp5/b4N91XydfSGKubEhgZRtcg1rhTKABXijc4Sdr1uTp5lJ8TN27jwUsdXxjHXtHa0kPj704sw==}
@@ -15056,8 +15103,8 @@ packages:
       react-native:
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.7
-      '@types/react-redux': 7.1.33
+      '@babel/runtime': 7.26.0
+      '@types/react-redux': 7.1.34
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -15070,62 +15117,28 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /react-router-dom/6.24.1_nnrd3gsncyragczmpvfhocinkq:
-    resolution: {integrity: sha512-U19KtXqooqw967Vw0Qcn5cOvrX5Ejo9ORmOtJMzYWtCT4/WOfFLIZGGsVLxcd9UkBO0mSTZtXqhZBsWlHr7+Sg==}
+  /react-router-dom/6.27.0_nnrd3gsncyragczmpvfhocinkq:
+    resolution: {integrity: sha512-+bvtFWMC0DgAFrfKXKG9Fc+BcXWRUO1aJIihbB79xaeq0v5UzfvnM5houGUm1Y461WVRcgAQ+Clh5rdb1eCx4g==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
     dependencies:
-      '@remix-run/router': 1.17.1
+      '@remix-run/router': 1.20.0
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
-      react-router: 6.24.1_react@18.3.1
+      react-router: 6.27.0_react@18.3.1
     dev: false
 
-  /react-router/6.24.1_react@18.3.1:
-    resolution: {integrity: sha512-PTXFXGK2pyXpHzVo3rR9H7ip4lSPZZc0bHG5CARmj65fTT6qG7sTngmb6lcYu1gf3y/8KxORoy9yn59pGpCnpg==}
+  /react-router/6.27.0_react@18.3.1:
+    resolution: {integrity: sha512-YA+HGZXz4jaAkVoYBE98VQl+nVzI+cVI2Oj/06F5ZM+0u3TgedN9Y9kmMRo2mnkSK2nCpNQn0DVob4HCsY/WLw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
     dependencies:
-      '@remix-run/router': 1.17.1
+      '@remix-run/router': 1.20.0
       react: 18.3.1
     dev: false
-
-  /react-select-async-paginate/0.7.2_kipqsbdvtmv5eumhayztwa7ftm:
-    resolution: {integrity: sha512-NlF717+Kh/OgSC7YyEYuB0ebsqF2YhyEdcETH1lX6X4INgNKpKH269MI1H5soIThZdCPZl5xz2QSldcPKlPlew==}
-    peerDependencies:
-      react: ^16.14.0 || ^17.0.0 || ^18.0.0
-      react-select: ^5.0.0
-    dependencies:
-      '@seznam/compose-react-refs': 1.0.6
-      '@vtaits/use-lazy-ref': 0.1.3_react@18.3.1
-      react: 18.3.1
-      react-select: 5.7.0_psuonouaqi5wuc37nxyknoubym
-      sleep-promise: 9.1.0
-      use-is-mounted-ref: 1.5.0_react@18.3.1
-
-  /react-select/5.7.0_psuonouaqi5wuc37nxyknoubym:
-    resolution: {integrity: sha512-lJGiMxCa3cqnUr2Jjtg9YHsaytiZqeNOKeibv6WF5zbK/fPegZ1hg3y/9P1RZVLhqBTs0PfqQLKuAACednYGhQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@emotion/cache': 11.11.0
-      '@emotion/react': 11.11.4_3vdbhqr2ncalcx7opnshezpx3q
-      '@floating-ui/dom': 1.6.7
-      '@types/react-transition-group': 4.4.10
-      memoize-one: 6.0.0
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-dom: 18.3.1_react@18.3.1
-      react-transition-group: 4.4.5_nnrd3gsncyragczmpvfhocinkq
-      use-isomorphic-layout-effect: 1.1.2_3vdbhqr2ncalcx7opnshezpx3q
-    transitivePeerDependencies:
-      - '@types/react'
-      - supports-color
 
   /react-table/7.8.0_react@18.3.1:
     resolution: {integrity: sha512-hNaz4ygkZO4bESeFfnfOft73iBUj8K5oKi1EcSHPAibEydfsX2MyU6Z8KCr3mv3C9Kqqh71U+DhZkFvibbnPbA==}
@@ -15145,7 +15158,7 @@ packages:
       react: '>=16.6.0'
       react-dom: '>=16.6.0'
     dependencies:
-      '@babel/runtime': 7.24.7
+      '@babel/runtime': 7.26.0
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -15159,7 +15172,7 @@ packages:
       react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
       react-dom: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@babel/runtime': 7.24.7
+      '@babel/runtime': 7.26.0
       memoize-one: 5.2.1
       react: 18.3.1
       react-dom: 18.3.1_react@18.3.1
@@ -15250,6 +15263,11 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /readdirp/4.0.2:
+    resolution: {integrity: sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==}
+    engines: {node: '>= 14.16.0'}
+    dev: true
+
   /recursive-readdir/2.2.3:
     resolution: {integrity: sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==}
     engines: {node: '>=6.0.0'}
@@ -15268,7 +15286,7 @@ packages:
   /redux/4.2.1:
     resolution: {integrity: sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==}
     dependencies:
-      '@babel/runtime': 7.24.7
+      '@babel/runtime': 7.26.0
 
   /reflect-metadata/0.1.14:
     resolution: {integrity: sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==}
@@ -15283,11 +15301,11 @@ packages:
       es-errors: 1.3.0
       get-intrinsic: 1.2.4
       globalthis: 1.0.4
-      which-builtin-type: 1.1.3
+      which-builtin-type: 1.1.4
     dev: true
 
-  /regenerate-unicode-properties/10.1.1:
-    resolution: {integrity: sha512-X007RyZLsCJVVrjgEFVpLUTZwyOZk3oiL75ZcuYjlIWd6rNJtOjkBwQc5AsRrpbKVkxN6sklw/k/9m2jJYOf8Q==}
+  /regenerate-unicode-properties/10.2.0:
+    resolution: {integrity: sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA==}
     engines: {node: '>=4'}
     dependencies:
       regenerate: 1.4.2
@@ -15307,7 +15325,7 @@ packages:
   /regenerator-transform/0.15.2:
     resolution: {integrity: sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==}
     dependencies:
-      '@babel/runtime': 7.24.7
+      '@babel/runtime': 7.26.0
     dev: true
 
   /regex-not/1.0.2:
@@ -15322,8 +15340,8 @@ packages:
     resolution: {integrity: sha512-TVILVSz2jY5D47F4mA4MppkBrafEaiUWJO/TcZHEIuI13AqoZMkK1WMA4Om1YkYbTx+9Ki1/tSUXbceyr9saRg==}
     dev: true
 
-  /regexp.prototype.flags/1.5.2:
-    resolution: {integrity: sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==}
+  /regexp.prototype.flags/1.5.3:
+    resolution: {integrity: sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.7
@@ -15337,16 +15355,16 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /regexpu-core/5.3.2:
-    resolution: {integrity: sha512-RAM5FlZz+Lhmo7db9L298p2vHP5ZywrVXmVXpmAD9GuL5MPH6t9ROw1iA/wfHkQ76Qe7AaPF0nGuim96/IrQMQ==}
+  /regexpu-core/6.1.1:
+    resolution: {integrity: sha512-k67Nb9jvwJcJmVpw0jPttR1/zVfnKf8Km0IPatrU/zJ5XeG3+Slx0xLXs9HByJSzXzrlz5EDvN6yLNMDc2qdnw==}
     engines: {node: '>=4'}
     dependencies:
-      '@babel/regjsgen': 0.8.0
       regenerate: 1.4.2
-      regenerate-unicode-properties: 10.1.1
-      regjsparser: 0.9.1
+      regenerate-unicode-properties: 10.2.0
+      regjsgen: 0.8.0
+      regjsparser: 0.11.2
       unicode-match-property-ecmascript: 2.0.0
-      unicode-match-property-value-ecmascript: 2.1.0
+      unicode-match-property-value-ecmascript: 2.2.0
     dev: true
 
   /registry-auth-token/3.3.2:
@@ -15363,11 +15381,15 @@ packages:
       rc: 1.2.8
     dev: true
 
-  /regjsparser/0.9.1:
-    resolution: {integrity: sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==}
+  /regjsgen/0.8.0:
+    resolution: {integrity: sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==}
+    dev: true
+
+  /regjsparser/0.11.2:
+    resolution: {integrity: sha512-3OGZZ4HoLJkkAZx/48mTXJNlmqTGOzc0o9OWQPuWpkOlXXPbyN6OafCcoXUnBqE2D3f/T5L+pWc1kdEmnfnRsA==}
     hasBin: true
     dependencies:
-      jsesc: 0.5.0
+      jsesc: 3.0.2
     dev: true
 
   /relateurl/0.2.7:
@@ -15447,6 +15469,7 @@ packages:
   /resolve-from/4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
+    dev: true
 
   /resolve-from/5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -15468,7 +15491,7 @@ packages:
       adjust-sourcemap-loader: 4.0.0
       convert-source-map: 1.9.0
       loader-utils: 2.0.4
-      postcss: 8.4.39
+      postcss: 8.4.47
       source-map: 0.6.1
     dev: true
 
@@ -15490,7 +15513,7 @@ packages:
   /resolve/1.19.0:
     resolution: {integrity: sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==}
     dependencies:
-      is-core-module: 2.14.0
+      is-core-module: 2.15.1
       path-parse: 1.0.7
     dev: true
 
@@ -15498,15 +15521,16 @@ packages:
     resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
     hasBin: true
     dependencies:
-      is-core-module: 2.14.0
+      is-core-module: 2.15.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+    dev: true
 
   /resolve/2.0.0-next.5:
     resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
     hasBin: true
     dependencies:
-      is-core-module: 2.14.0
+      is-core-module: 2.15.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
@@ -15586,17 +15610,17 @@ packages:
       rollup-plugin-inject: 3.0.2
     dev: true
 
-  /rollup-plugin-terser/7.0.2_rollup@2.79.1:
+  /rollup-plugin-terser/7.0.2_rollup@2.79.2:
     resolution: {integrity: sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==}
     deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-terser
     peerDependencies:
       rollup: ^2.0.0
     dependencies:
-      '@babel/code-frame': 7.24.7
+      '@babel/code-frame': 7.26.2
       jest-worker: 26.6.2
-      rollup: 2.79.1
+      rollup: 2.79.2
       serialize-javascript: 4.0.0
-      terser: 5.31.1
+      terser: 5.36.0
     dev: true
 
   /rollup-pluginutils/2.8.2:
@@ -15605,8 +15629,8 @@ packages:
       estree-walker: 0.6.1
     dev: true
 
-  /rollup/2.79.1:
-    resolution: {integrity: sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==}
+  /rollup/2.79.2:
+    resolution: {integrity: sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==}
     engines: {node: '>=10.0.0'}
     hasBin: true
     optionalDependencies:
@@ -15636,7 +15660,7 @@ packages:
   /rxjs/7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.0
 
   /safe-array-concat/1.1.2:
     resolution: {integrity: sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==}
@@ -15677,7 +15701,7 @@ packages:
     resolution: {integrity: sha512-ZRwKbh/eQ6w9vmTjkuG0Ioi3HBwPFce0O+v//ve+aOq1oeCy7jMV2qzzAlpsNuqpqCBjjriM1lbtZbF/Q8jVyA==}
     dev: true
 
-  /sass-loader/12.6.0_sass@1.77.7+webpack@5.92.1:
+  /sass-loader/12.6.0_sass@1.80.5+webpack@5.95.0:
     resolution: {integrity: sha512-oLTaH0YCtX4cfnJZxKSLAyglED0naiYfNG1iXfU5w1LNZ+ukoA5DtyDIN5zmKVZwYNJP4KRc5Y3hkWga+7tYfA==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -15698,18 +15722,19 @@ packages:
     dependencies:
       klona: 2.0.6
       neo-async: 2.6.2
-      sass: 1.77.7
-      webpack: 5.92.1
+      sass: 1.80.5
+      webpack: 5.95.0
     dev: true
 
-  /sass/1.77.7:
-    resolution: {integrity: sha512-9ywH75cO+rLjbrZ6en3Gp8qAMwPGBapFtlsMJoDTkcMU/bSe5a6cjKVUn5Jr4Gzg5GbP3HE8cm+02pLCgcoMow==}
+  /sass/1.80.5:
+    resolution: {integrity: sha512-TQd2aoQl/+zsxRMEDSxVdpPIqeq9UFc6pr7PzkugiTx3VYCFPUaa3P4RrBQsqok4PO200Vkz0vXQBNlg7W907g==}
     engines: {node: '>=14.0.0'}
     hasBin: true
     dependencies:
-      chokidar: 3.6.0
-      immutable: 4.3.6
-      source-map-js: 1.2.0
+      '@parcel/watcher': 2.4.1
+      chokidar: 4.0.1
+      immutable: 4.3.7
+      source-map-js: 1.2.1
     dev: true
 
   /saxes/5.0.1:
@@ -15763,9 +15788,9 @@ packages:
     engines: {node: '>= 12.13.0'}
     dependencies:
       '@types/json-schema': 7.0.15
-      ajv: 8.16.0
+      ajv: 8.17.1
       ajv-formats: 2.1.1
-      ajv-keywords: 5.1.0_ajv@8.16.0
+      ajv-keywords: 5.1.0_ajv@8.17.1
     dev: true
 
   /section-iterator/2.0.0:
@@ -15802,13 +15827,13 @@ packages:
       lru-cache: 6.0.0
     dev: true
 
-  /semver/7.6.2:
-    resolution: {integrity: sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==}
+  /semver/7.6.3:
+    resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
     engines: {node: '>=10'}
     hasBin: true
 
-  /send/0.18.0:
-    resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
+  /send/0.19.0:
+    resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
     dependencies:
       debug: 2.6.9
@@ -15844,16 +15869,15 @@ packages:
       randombytes: 2.1.0
     dev: true
 
-  /serve-handler/6.1.5:
-    resolution: {integrity: sha512-ijPFle6Hwe8zfmBxJdE+5fta53fdIY0lHISJvuikXB3VYFafRjMRpOffSPvCYsbKyBA7pvy9oYr/BT1O3EArlg==}
+  /serve-handler/6.1.6:
+    resolution: {integrity: sha512-x5RL9Y2p5+Sh3D38Fh9i/iQ5ZK+e4xuXRd/pGbM4D13tgo/MGwbttUk8emytcr1YYzBYs+apnUngBDFYfpjPuQ==}
     dependencies:
       bytes: 3.0.0
       content-disposition: 0.5.2
-      fast-url-parser: 1.1.3
       mime-types: 2.1.18
       minimatch: 3.1.2
       path-is-inside: 1.0.2
-      path-to-regexp: 8.1.0
+      path-to-regexp: 8.2.0
       range-parser: 1.2.0
     dev: true
 
@@ -15870,17 +15894,17 @@ packages:
       parseurl: 1.3.3
     dev: true
 
-  /serve-static/1.15.0:
-    resolution: {integrity: sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==}
+  /serve-static/1.16.2:
+    resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
     engines: {node: '>= 0.8.0'}
     dependencies:
-      encodeurl: 1.0.2
+      encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 0.18.0
+      send: 0.19.0
 
-  /serve/14.2.3:
-    resolution: {integrity: sha512-VqUFMC7K3LDGeGnJM9h56D3XGKb6KGgOw0cVNtA26yYXHCcpxf3xwCTUaQoWlVS7i8Jdh3GjQkOB23qsXyjoyQ==}
+  /serve/14.2.4:
+    resolution: {integrity: sha512-qy1S34PJ/fcY8gjVGszDB3EXiPSk5FKhUa7tQe0UPRddxRidc2V6cNHPNewbE1D7MAkgLuWEt3Vw56vYy73tzQ==}
     engines: {node: '>= 14'}
     hasBin: true
     dependencies:
@@ -15893,7 +15917,7 @@ packages:
       clipboardy: 3.0.0
       compression: 1.7.4
       is-port-reachable: 4.0.0
-      serve-handler: 6.1.5
+      serve-handler: 6.1.6
       update-check: 1.5.4
     dev: true
 
@@ -16008,9 +16032,6 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /sleep-promise/9.1.0:
-    resolution: {integrity: sha512-UHYzVpz9Xn8b+jikYSD6bqvf754xL2uBUzDFwiU6NcdZeifPr6UfgU43xpkPu67VMS88+TI2PSI7Eohgqf2fKA==}
-
   /slice-ansi/3.0.0:
     resolution: {integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==}
     engines: {node: '>=8'}
@@ -16055,12 +16076,12 @@ packages:
     resolution: {integrity: sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==}
     dev: true
 
-  /source-map-js/1.2.0:
-    resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
+  /source-map-js/1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /source-map-loader/3.0.2_webpack@5.92.1:
+  /source-map-loader/3.0.2_webpack@5.95.0:
     resolution: {integrity: sha512-BokxPoLjyl3iOrgkWaakaxqnelAJSS+0V+De0kKIq6lyWrXuiPgYTGp6z3iHmqljKAaLXwZa+ctD8GccRJeVvg==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -16068,19 +16089,19 @@ packages:
     dependencies:
       abab: 2.0.6
       iconv-lite: 0.6.3
-      source-map-js: 1.2.0
-      webpack: 5.92.1
+      source-map-js: 1.2.1
+      webpack: 5.95.0
     dev: true
 
-  /source-map-loader/4.0.2_webpack@5.92.1:
+  /source-map-loader/4.0.2_webpack@5.95.0:
     resolution: {integrity: sha512-oYwAqCuL0OZhBoSgmdrLa7mv9MjommVMiQIWgcztf+eS4+8BfcUee6nenFnDhKOhzAVnk5gpZdfnz1iiBv+5sg==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       webpack: ^5.72.1
     dependencies:
       iconv-lite: 0.6.3
-      source-map-js: 1.2.0
-      webpack: 5.92.1
+      source-map-js: 1.2.1
+      webpack: 5.95.0
     dev: true
 
   /source-map-resolve/0.5.3:
@@ -16116,6 +16137,7 @@ packages:
   /source-map/0.5.7:
     resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /source-map/0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
@@ -16139,15 +16161,15 @@ packages:
     deprecated: Please use @jridgewell/sourcemap-codec instead
     dev: true
 
-  /spawn-command/0.0.2-1:
-    resolution: {integrity: sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==}
+  /spawn-command/0.0.2:
+    resolution: {integrity: sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==}
     dev: true
 
   /spdx-correct/3.2.0:
     resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
     dependencies:
       spdx-expression-parse: 3.0.1
-      spdx-license-ids: 3.0.18
+      spdx-license-ids: 3.0.20
     dev: true
 
   /spdx-exceptions/2.5.0:
@@ -16158,17 +16180,17 @@ packages:
     resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
     dependencies:
       spdx-exceptions: 2.5.0
-      spdx-license-ids: 3.0.18
+      spdx-license-ids: 3.0.20
     dev: true
 
-  /spdx-license-ids/3.0.18:
-    resolution: {integrity: sha512-xxRs31BqRYHwiMzudOrpSiHtZ8i/GeionCBDSilhYRj+9gIcI8wCZTlXZKu9vZIVqViP3dcp9qE5G6AlIaD+TQ==}
+  /spdx-license-ids/3.0.20:
+    resolution: {integrity: sha512-jg25NiDV/1fLtSgEgyvVyDunvaNHbuwF9lfNV17gSmPFAlYzdfNBlLtLzXTevwkPj7DhGbmN9VnmJIgLnhvaBw==}
     dev: true
 
   /spdy-transport/3.0.0:
     resolution: {integrity: sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==}
     dependencies:
-      debug: 4.3.5
+      debug: 4.3.7
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -16182,7 +16204,7 @@ packages:
     resolution: {integrity: sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      debug: 4.3.5
+      debug: 4.3.7
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -16318,9 +16340,11 @@ packages:
       strip-ansi: 7.1.0
     dev: true
 
-  /string.prototype.includes/2.0.0:
-    resolution: {integrity: sha512-E34CkBgyeqNDcrbU76cDjL5JLcVrtSdYq0MEh/B10r17pRP4ciHLwTgnuLV8Ay6cgEMLkcBkFCKyFZ43YldYzg==}
+  /string.prototype.includes/2.0.1:
+    resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
+    engines: {node: '>= 0.4'}
     dependencies:
+      call-bind: 1.0.7
       define-properties: 1.2.1
       es-abstract: 1.23.3
     dev: true
@@ -16338,7 +16362,7 @@ packages:
       gopd: 1.0.1
       has-symbols: 1.0.3
       internal-slot: 1.0.7
-      regexp.prototype.flags: 1.5.2
+      regexp.prototype.flags: 1.5.3
       set-function-name: 2.0.2
       side-channel: 1.0.6
     dev: true
@@ -16351,6 +16375,13 @@ packages:
       define-properties: 1.2.1
       es-abstract: 1.23.3
       es-object-atoms: 1.0.0
+    dev: true
+
+  /string.prototype.repeat/1.0.0:
+    resolution: {integrity: sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==}
+    dependencies:
+      define-properties: 1.2.1
+      es-abstract: 1.23.3
     dev: true
 
   /string.prototype.trim/1.2.9:
@@ -16430,7 +16461,7 @@ packages:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
     engines: {node: '>=12'}
     dependencies:
-      ansi-regex: 6.0.1
+      ansi-regex: 6.1.0
     dev: true
 
   /strip-bom/3.0.0:
@@ -16477,28 +16508,28 @@ packages:
   /strnum/1.0.5:
     resolution: {integrity: sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==}
 
-  /style-loader/3.3.4_webpack@5.92.1:
+  /style-loader/3.3.4_webpack@5.95.0:
     resolution: {integrity: sha512-0WqXzrsMTyb8yjZJHDqwmnwRJvhALK9LfRtRc6B4UTWe8AijYLZYZ9thuJTZc2VfQWINADW/j+LiJnfy2RoC1w==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.92.1
+      webpack: 5.95.0
     dev: true
 
   /style-search/0.1.0:
     resolution: {integrity: sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==}
     dev: true
 
-  /stylehacks/5.1.1_postcss@8.4.39:
+  /stylehacks/5.1.1_postcss@8.4.47:
     resolution: {integrity: sha512-sBpcd5Hx7G6seo7b1LkpttvTz7ikD0LlH5RmdcBNb6fFR0Fl7LQwHDFr300q4cwUqi+IYrFGmsIHieMBfnN/Bw==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.23.2
-      postcss: 8.4.39
-      postcss-selector-parser: 6.1.0
+      browserslist: 4.24.2
+      postcss: 8.4.47
+      postcss-selector-parser: 6.1.2
     dev: true
 
   /stylelint-config-prettier/8.0.2_stylelint@13.13.1:
@@ -16527,7 +16558,7 @@ packages:
       stylelint: ^10.0.1 || ^11.0.0 || ^12.0.0 || ^13.0.0
     dependencies:
       lodash: 4.17.21
-      postcss: 8.4.39
+      postcss: 8.4.47
       postcss-sorting: 5.0.1
       stylelint: 13.13.1
     dev: true
@@ -16552,8 +16583,8 @@ packages:
     dependencies:
       lodash: 4.17.21
       postcss-media-query-parser: 0.2.3
-      postcss-resolve-nested-selector: 0.1.1
-      postcss-selector-parser: 6.1.0
+      postcss-resolve-nested-selector: 0.1.6
+      postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
       stylelint: 13.13.1
     dev: true
@@ -16563,13 +16594,13 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
     dependencies:
-      '@stylelint/postcss-css-in-js': 0.37.3_lrpgrolfvll3p4c7yzuvfga3qm
-      '@stylelint/postcss-markdown': 0.36.2_lrpgrolfvll3p4c7yzuvfga3qm
+      '@stylelint/postcss-css-in-js': 0.37.3_7ddkth4qkj3urzklvpilix4jii
+      '@stylelint/postcss-markdown': 0.36.2_7ddkth4qkj3urzklvpilix4jii
       autoprefixer: 9.8.8
       balanced-match: 2.0.0
       chalk: 4.1.2
       cosmiconfig: 7.1.0
-      debug: 4.3.5
+      debug: 4.3.7
       execall: 2.0.0
       fast-glob: 3.3.2
       fastest-levenshtein: 1.0.16
@@ -16579,7 +16610,7 @@ packages:
       globby: 11.1.0
       globjoin: 0.1.4
       html-tags: 3.3.1
-      ignore: 5.3.1
+      ignore: 5.3.2
       import-lazy: 4.0.0
       imurmurhash: 0.1.4
       known-css-properties: 0.21.0
@@ -16587,18 +16618,18 @@ packages:
       log-symbols: 4.1.0
       mathml-tag-names: 2.1.3
       meow: 9.0.0
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       normalize-selector: 0.2.0
-      postcss: 8.4.39
-      postcss-html: 0.36.0_lrpgrolfvll3p4c7yzuvfga3qm
+      postcss: 8.4.47
+      postcss-html: 0.36.0_7ddkth4qkj3urzklvpilix4jii
       postcss-less: 3.1.4
       postcss-media-query-parser: 0.2.3
-      postcss-resolve-nested-selector: 0.1.1
+      postcss-resolve-nested-selector: 0.1.6
       postcss-safe-parser: 4.0.2
       postcss-sass: 0.4.4
       postcss-scss: 2.1.1
-      postcss-selector-parser: 6.1.0
-      postcss-syntax: 0.36.2_postcss@8.4.39
+      postcss-selector-parser: 6.1.2
+      postcss-syntax: 0.36.2_postcss@8.4.47
       postcss-value-parser: 4.2.0
       resolve-from: 5.0.0
       slash: 3.0.0
@@ -16614,9 +16645,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-  /stylis/4.2.0:
-    resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
 
   /subarg/1.0.0:
     resolution: {integrity: sha512-RIrIdRY0X1xojthNcVtgT9sjpOGagEUKpZdgBUi054OEPFo282yg+zE+t1Rj3+RqKq2xStL7uUHhY+AjbC4BXg==}
@@ -16641,14 +16669,14 @@ packages:
   /sugarss/2.0.0:
     resolution: {integrity: sha512-WfxjozUk0UVA4jm+U1d736AUpzSrNsQcIbyOkoE364GrtWmIrFdk5lksEupgWMD4VaT/0kVx1dobpiDumSgmJQ==}
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.47
     dev: true
 
   /sumchecker/3.0.1:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
     engines: {node: '>= 8.0'}
     dependencies:
-      debug: 4.3.5
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
@@ -16662,6 +16690,7 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       has-flag: 3.0.0
+    dev: true
 
   /supports-color/6.1.0:
     resolution: {integrity: sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==}
@@ -16695,6 +16724,7 @@ packages:
   /supports-preserve-symlinks-flag/1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+    dev: true
 
   /svg-baker-runtime/1.4.7:
     resolution: {integrity: sha512-Zorfwwj5+lWjk/oxwSMsRdS2sPQQdTmmsvaSpzU+i9ZWi3zugHLt6VckWfnswphQP0LmOel3nggpF5nETbt6xw==}
@@ -16714,12 +16744,12 @@ packages:
       loader-utils: 1.4.2
       merge-options: 1.0.1
       micromatch: 3.1.0
-      postcss: 8.4.39
-      postcss-prefix-selector: 1.16.1_postcss@8.4.39
+      postcss: 8.4.47
+      postcss-prefix-selector: 1.16.1_postcss@8.4.47
       posthtml-rename-id: 1.0.12
       posthtml-svg-mode: 1.0.3
       query-string: 4.3.4
-      traverse: 0.6.9
+      traverse: 0.6.10
     dev: true
 
   /svg-parser/2.0.4:
@@ -16754,7 +16784,7 @@ packages:
       css-select: 4.3.0
       css-tree: 1.1.3
       csso: 4.2.0
-      picocolors: 1.0.1
+      picocolors: 1.1.1
       stable: 0.1.8
     dev: true
 
@@ -16769,15 +16799,15 @@ packages:
     resolution: {integrity: sha512-w2sfv80nrAh2VCbqR5AK27wswXhqcck2AhfnNW76beQXskGZ1V12GwS//yYVa3d3fcvAip2OUnbDAjW2k3v9fA==}
     engines: {node: '>=10.0.0'}
     dependencies:
-      ajv: 8.16.0
+      ajv: 8.17.1
       lodash.truncate: 4.4.2
       slice-ansi: 4.0.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
     dev: true
 
-  /tailwindcss/3.4.4:
-    resolution: {integrity: sha512-ZoyXOdJjISB7/BcLTR6SEsLgKtDStYyYZVLsUtWChO4Ps20CBad7lfJKVDiejocV4ME1hLmyY0WJE3hSDcmQ2A==}
+  /tailwindcss/3.4.14:
+    resolution: {integrity: sha512-IcSvOcTRcUtQQ7ILQL5quRDg7Xs93PdJEk1ZLbhhvJc7uj/OAhYOnruEiwnGgBvUtaUAJ8/mhSw1o8L2jCiENA==}
     engines: {node: '>=14.0.0'}
     hasBin: true
     dependencies:
@@ -16791,16 +16821,16 @@ packages:
       is-glob: 4.0.3
       jiti: 1.21.6
       lilconfig: 2.1.0
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       normalize-path: 3.0.0
       object-hash: 3.0.0
-      picocolors: 1.0.1
-      postcss: 8.4.39
-      postcss-import: 15.1.0_postcss@8.4.39
-      postcss-js: 4.0.1_postcss@8.4.39
-      postcss-load-config: 4.0.2_postcss@8.4.39
-      postcss-nested: 6.0.1_postcss@8.4.39
-      postcss-selector-parser: 6.1.0
+      picocolors: 1.1.1
+      postcss: 8.4.47
+      postcss-import: 15.1.0_postcss@8.4.47
+      postcss-js: 4.0.1_postcss@8.4.47
+      postcss-load-config: 4.0.2_postcss@8.4.47
+      postcss-nested: 6.2.0_postcss@8.4.47
+      postcss-selector-parser: 6.1.2
       resolve: 1.22.8
       sucrase: 3.35.0
     transitivePeerDependencies:
@@ -16840,7 +16870,7 @@ packages:
       supports-hyperlinks: 2.3.0
     dev: true
 
-  /terser-webpack-plugin/5.3.10_webpack@5.92.1:
+  /terser-webpack-plugin/5.3.10_webpack@5.95.0:
     resolution: {integrity: sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -16860,17 +16890,17 @@ packages:
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
-      terser: 5.31.1
-      webpack: 5.92.1
+      terser: 5.36.0
+      webpack: 5.95.0
     dev: true
 
-  /terser/5.31.1:
-    resolution: {integrity: sha512-37upzU1+viGvuFtBo9NPufCb9dwM0+l9hMxYyWfBA+fbwrPqNJAhbZ6W47bBFnZHKHTUBnMvi87434qq+qnxOg==}
+  /terser/5.36.0:
+    resolution: {integrity: sha512-IYV9eNMuFAV4THUspIRXkLakHnV6XO7FEdtKjf/mDyrnqUg9LnlOn6/RwRvM9SZjR4GUq8Nk8zj67FzVARr74w==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
       '@jridgewell/source-map': 0.3.6
-      acorn: 8.12.1
+      acorn: 8.14.0
       commander: 2.20.3
       source-map-support: 0.5.21
     dev: true
@@ -16920,6 +16950,9 @@ packages:
     resolution: {integrity: sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==}
     dev: true
 
+  /tiny-inflate/1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
+
   /tippy.js/6.3.7:
     resolution: {integrity: sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==}
     dependencies:
@@ -16928,10 +16961,6 @@ packages:
   /tmpl/1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
     dev: true
-
-  /to-fast-properties/2.0.0:
-    resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
-    engines: {node: '>=4'}
 
   /to-object-path/0.3.0:
     resolution: {integrity: sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==}
@@ -16998,8 +17027,8 @@ packages:
       punycode: 2.3.1
     dev: true
 
-  /traverse/0.6.9:
-    resolution: {integrity: sha512-7bBrcF+/LQzSgFmT0X5YclVqQxtv7TDJ1f8Wj7ibBu/U6BMLeOpUxuZjV7rMc44UtKxlnMFigdhFAIszSX1DMg==}
+  /traverse/0.6.10:
+    resolution: {integrity: sha512-hN4uFRxbK+PX56DxYiGHsTn2dME3TVr9vbNqlQGcGcPhJAn+tdP126iA+TArMpI4YSgnTkMWyoLl5bf81Hi5TA==}
     engines: {node: '>= 0.4'}
     dependencies:
       gopd: 1.0.1
@@ -17029,7 +17058,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-jest/27.1.5_ffc5qouy45v3zjlzng7flfczky:
+  /ts-jest/27.1.5_6i3m6jxo354ochmqovrdrplut4:
     resolution: {integrity: sha512-Xv6jBQPoBEvBq/5i2TeSG9tt/nqkbpcurrEG1b+2yfBrcJelOZF9Ml6dmyMh7bcW9JyFbRYpR5rxROSlBLTZHA==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     hasBin: true
@@ -17050,8 +17079,8 @@ packages:
       esbuild:
         optional: true
     dependencies:
-      '@babel/core': 7.24.7
-      babel-jest: 27.5.1_@babel+core@7.24.7
+      '@babel/core': 7.26.0
+      babel-jest: 27.5.1_@babel+core@7.26.0
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       jest: 27.5.1
@@ -17059,13 +17088,13 @@ packages:
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.6.2
+      semver: 7.6.3
       typescript: 5.0.4
       yargs-parser: 20.2.9
     dev: true
 
-  /ts-jest/29.2.0_qbbgenyc4wnry6yt7igwhfhjbm:
-    resolution: {integrity: sha512-eFmkE9MG0+oT6nqSOcUwL+2UUmK2IvhhUV8hFDsCHnc++v2WCCbQQZh5vvjsa8sgOY/g9T0325hmkEmi6rninA==}
+  /ts-jest/29.2.5_qbbgenyc4wnry6yt7igwhfhjbm:
+    resolution: {integrity: sha512-KD8zB2aAZrcKIdGk4OwpJggeLcH1FgrICqDSROWqlnJXGCXK4Mn6FcdK2B6670Xr73lHMG1kHw8R87A0ecZ+vA==}
     engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -17089,19 +17118,20 @@ packages:
         optional: true
     dependencies:
       bs-logger: 0.2.6
+      ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0_@types+node@18.19.39
+      jest: 29.7.0_@types+node@18.19.62
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.6.2
+      semver: 7.6.3
       typescript: 5.0.4
       yargs-parser: 21.1.1
     dev: true
 
-  /ts-key-enum/2.0.12:
-    resolution: {integrity: sha512-Ety4IvKMaeG34AyXMp5r11XiVZNDRL+XWxXbVVJjLvq2vxKRttEANBE7Za1bxCAZRdH2/sZT6jFyyTWxXz28hw==}
+  /ts-key-enum/2.0.13:
+    resolution: {integrity: sha512-zixs6j8+NhzazLUQ1SiFrlo1EFWG/DbqLuUGcWWZ5zhwjRT7kbi1hBlofxdqel+h28zrby2It5TrOyKp04kvqw==}
 
   /tsconfig-paths/3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
@@ -17116,8 +17146,8 @@ packages:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
 
-  /tslib/2.6.3:
-    resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
+  /tslib/2.8.0:
+    resolution: {integrity: sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==}
 
   /tsutils/3.21.0:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
@@ -17299,6 +17329,12 @@ packages:
     hasBin: true
     dev: true
 
+  /typescript/5.4.2:
+    resolution: {integrity: sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: true
+
   /uc.micro/1.0.6:
     resolution: {integrity: sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==}
 
@@ -17324,8 +17360,8 @@ packages:
   /undici-types/5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
-  /unicode-canonical-property-names-ecmascript/2.0.0:
-    resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
+  /unicode-canonical-property-names-ecmascript/2.0.1:
+    resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
     engines: {node: '>=4'}
     dev: true
 
@@ -17333,12 +17369,12 @@ packages:
     resolution: {integrity: sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==}
     engines: {node: '>=4'}
     dependencies:
-      unicode-canonical-property-names-ecmascript: 2.0.0
+      unicode-canonical-property-names-ecmascript: 2.0.1
       unicode-property-aliases-ecmascript: 2.1.0
     dev: true
 
-  /unicode-match-property-value-ecmascript/2.1.0:
-    resolution: {integrity: sha512-qxkjQt6qjg/mYscYMC0XKRn3Rh0wFPlfxB0xkt9CfyTvpX1Ra0+rAmdX2QyAobptSEvuy4RtpPRui6XkV+8wjA==}
+  /unicode-match-property-value-ecmascript/2.2.0:
+    resolution: {integrity: sha512-4IehN3V/+kkr5YeSSDDQG8QLqO26XpL2XP3GQtqwlT/QYSECAwFztxVHjlbh0+gjJ3XmNLS0zDsbgs9jWKExLg==}
     engines: {node: '>=4'}
     dev: true
 
@@ -17346,6 +17382,12 @@ packages:
     resolution: {integrity: sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==}
     engines: {node: '>=4'}
     dev: true
+
+  /unicode-trie/2.0.0:
+    resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
+    dependencies:
+      pako: 0.2.9
+      tiny-inflate: 1.0.3
 
   /unidecode/0.1.8:
     resolution: {integrity: sha512-SdoZNxCWpN2tXTCrGkPF/0rL2HEq+i2gwRG1ReBvx8/0yTzC3enHfugOf8A9JBShVwwrRIkLX0YcDUGbzjbVCA==}
@@ -17393,7 +17435,7 @@ packages:
   /unist-util-stringify-position/2.0.3:
     resolution: {integrity: sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==}
     dependencies:
-      '@types/unist': 2.0.10
+      '@types/unist': 2.0.11
     dev: true
 
   /universalify/0.1.2:
@@ -17432,15 +17474,15 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /update-browserslist-db/1.1.0_browserslist@4.23.2:
-    resolution: {integrity: sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==}
+  /update-browserslist-db/1.1.1_browserslist@4.24.2:
+    resolution: {integrity: sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
     dependencies:
-      browserslist: 4.23.2
-      escalade: 3.1.2
-      picocolors: 1.0.1
+      browserslist: 4.24.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
     dev: true
 
   /update-check/1.5.4:
@@ -17454,6 +17496,7 @@ packages:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.3.1
+    dev: true
 
   /urix/0.1.0:
     resolution: {integrity: sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==}
@@ -17472,32 +17515,6 @@ packages:
     dependencies:
       unidecode: 0.1.8
     dev: true
-
-  /use-is-mounted-ref/1.5.0_react@18.3.1:
-    resolution: {integrity: sha512-p5FksHf/ospZUr5KU9ese6u3jp9fzvZ3wuSb50i0y6fdONaHWgmOqQtxR/PUcwi6hnhQDbNxWSg3eTK3N6m+dg==}
-    peerDependencies:
-      react: '>=16.0.0'
-    dependencies:
-      react: 18.3.1
-
-  /use-isomorphic-layout-effect/1.1.2_3vdbhqr2ncalcx7opnshezpx3q:
-    resolution: {integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-    dependencies:
-      '@types/react': 18.3.3
-      react: 18.3.1
-
-  /use-sync-external-store/1.2.0_react@18.3.1:
-    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      react: 18.3.1
 
   /use-sync-external-store/1.2.2_react@18.3.1:
     resolution: {integrity: sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==}
@@ -17569,11 +17586,6 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /validator/13.12.0:
-    resolution: {integrity: sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==}
-    engines: {node: '>= 0.10'}
-    dev: true
-
   /vary/1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
@@ -17581,14 +17593,14 @@ packages:
   /vfile-message/2.0.4:
     resolution: {integrity: sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==}
     dependencies:
-      '@types/unist': 2.0.10
+      '@types/unist': 2.0.11
       unist-util-stringify-position: 2.0.3
     dev: true
 
   /vfile/4.2.1:
     resolution: {integrity: sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==}
     dependencies:
-      '@types/unist': 2.0.10
+      '@types/unist': 2.0.11
       is-buffer: 2.0.5
       unist-util-stringify-position: 2.0.3
       vfile-message: 2.0.4
@@ -17629,8 +17641,8 @@ packages:
       makeerror: 1.0.12
     dev: true
 
-  /watchpack/2.4.1:
-    resolution: {integrity: sha512-8wrBCMtVhqcXP2Sup1ctSkga6uc2Bx0IIvKyT7yTFier5AXHooSI+QyQQAtTb7+E0IUCCKyTFmXqdqgum2XWGg==}
+  /watchpack/2.4.2:
+    resolution: {integrity: sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==}
     engines: {node: '>=10.13.0'}
     dependencies:
       glob-to-regexp: 0.4.1
@@ -17665,7 +17677,7 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /webpack-dev-middleware/5.3.4_webpack@5.92.1:
+  /webpack-dev-middleware/5.3.4_webpack@5.95.0:
     resolution: {integrity: sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -17676,10 +17688,10 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.92.1
+      webpack: 5.95.0
     dev: true
 
-  /webpack-dev-server/4.15.2_webpack@5.92.1:
+  /webpack-dev-server/4.15.2_webpack@5.95.0:
     resolution: {integrity: sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==}
     engines: {node: '>= 12.13.0'}
     hasBin: true
@@ -17698,7 +17710,7 @@ packages:
       '@types/serve-index': 1.9.4
       '@types/serve-static': 1.15.7
       '@types/sockjs': 0.3.36
-      '@types/ws': 8.5.10
+      '@types/ws': 8.5.12
       ansi-html-community: 0.0.8
       bonjour-service: 1.2.1
       chokidar: 3.6.0
@@ -17706,12 +17718,12 @@ packages:
       compression: 1.7.4
       connect-history-api-fallback: 2.0.0
       default-gateway: 6.0.3
-      express: 4.19.2
+      express: 4.21.1
       graceful-fs: 4.2.11
       html-entities: 2.5.2
-      http-proxy-middleware: 2.0.6_@types+express@4.17.21
+      http-proxy-middleware: 2.0.7_@types+express@4.17.21
       ipaddr.js: 2.2.0
-      launch-editor: 2.8.0
+      launch-editor: 2.9.1
       open: 8.4.2
       p-retry: 4.6.2
       rimraf: 3.0.2
@@ -17720,8 +17732,8 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.92.1
-      webpack-dev-middleware: 5.3.4_webpack@5.92.1
+      webpack: 5.95.0
+      webpack-dev-middleware: 5.3.4_webpack@5.95.0
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
@@ -17730,14 +17742,14 @@ packages:
       - utf-8-validate
     dev: true
 
-  /webpack-manifest-plugin/4.1.1_webpack@5.92.1:
+  /webpack-manifest-plugin/4.1.1_webpack@5.95.0:
     resolution: {integrity: sha512-YXUAwxtfKIJIKkhg03MKuiFAD72PlrqCiwdwO4VEXdRO5V0ORCNwaOwAZawPZalCbmH9kBDmXnNeQOw+BIEiow==}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       webpack: ^4.44.2 || ^5.47.0
     dependencies:
       tapable: 2.2.1
-      webpack: 5.92.1
+      webpack: 5.95.0
       webpack-sources: 2.3.1
     dev: true
 
@@ -17761,8 +17773,8 @@ packages:
     engines: {node: '>=10.13.0'}
     dev: true
 
-  /webpack/5.92.1:
-    resolution: {integrity: sha512-JECQ7IwJb+7fgUFBlrJzbyu3GEuNBcdqr1LD7IbSzwkSmIevTm8PF+wej3Oxuz/JFBUZ6O1o43zsPkwm1C4TmA==}
+  /webpack/5.95.0:
+    resolution: {integrity: sha512-2t3XstrKULz41MNMBF+cJ97TyHdyQ8HCt//pqErqDvNjU9YQBnZxIHa11VXsi7F3mb5/aO2tuDxdeTPdU7xu9Q==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
@@ -17771,16 +17783,15 @@ packages:
       webpack-cli:
         optional: true
     dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       '@webassemblyjs/ast': 1.12.1
       '@webassemblyjs/wasm-edit': 1.12.1
       '@webassemblyjs/wasm-parser': 1.12.1
-      acorn: 8.12.1
-      acorn-import-attributes: 1.9.5_acorn@8.12.1
-      browserslist: 4.23.2
+      acorn: 8.14.0
+      acorn-import-attributes: 1.9.5_acorn@8.14.0
+      browserslist: 4.24.2
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.17.0
+      enhanced-resolve: 5.17.1
       es-module-lexer: 1.5.4
       eslint-scope: 5.1.1
       events: 3.3.0
@@ -17792,8 +17803,8 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10_webpack@5.92.1
-      watchpack: 2.4.1
+      terser-webpack-plugin: 5.3.10_webpack@5.95.0
+      watchpack: 2.4.2
       webpack-sources: 3.2.3
     transitivePeerDependencies:
       - '@swc/core'
@@ -17882,8 +17893,8 @@ packages:
       is-symbol: 1.0.4
     dev: true
 
-  /which-builtin-type/1.1.3:
-    resolution: {integrity: sha512-YmjsSMDBYsM1CaFiayOVT06+KJeXf0o5M/CAd4o1lTadFAtacTUM49zoYxr/oroopFDfhvN6iEcBxUyc3gvKmw==}
+  /which-builtin-type/1.1.4:
+    resolution: {integrity: sha512-bppkmBSsHFmIMSl8BO9TbsyzsvGjVoppt8xUiGzwiu/bhDCGxnpOKCxgqj6GuyHE0mINMDecBFPlOm2hzY084w==}
     engines: {node: '>= 0.4'}
     dependencies:
       function.prototype.name: 1.1.6
@@ -17974,23 +17985,23 @@ packages:
     resolution: {integrity: sha512-Tjf+gBwOTuGyZwMz2Nk/B13Fuyeo0Q84W++bebbVsfr9iLkDSo6j6PST8tET9HYA58mlRXwlMGpyWO8ETJiXdQ==}
     engines: {node: '>=10.0.0'}
     dependencies:
-      '@apideck/better-ajv-errors': 0.3.6_ajv@8.16.0
-      '@babel/core': 7.24.7
-      '@babel/preset-env': 7.24.7_@babel+core@7.24.7
-      '@babel/runtime': 7.24.7
-      '@rollup/plugin-babel': 5.3.1_je4nbmfg47mhbnn75kmajdcj7i
-      '@rollup/plugin-node-resolve': 11.2.1_rollup@2.79.1
-      '@rollup/plugin-replace': 2.4.2_rollup@2.79.1
+      '@apideck/better-ajv-errors': 0.3.6_ajv@8.17.1
+      '@babel/core': 7.26.0
+      '@babel/preset-env': 7.26.0_@babel+core@7.26.0
+      '@babel/runtime': 7.26.0
+      '@rollup/plugin-babel': 5.3.1_jv6xoz77vs757ecddpkzporema
+      '@rollup/plugin-node-resolve': 11.2.1_rollup@2.79.2
+      '@rollup/plugin-replace': 2.4.2_rollup@2.79.2
       '@surma/rollup-plugin-off-main-thread': 2.2.3
-      ajv: 8.16.0
+      ajv: 8.17.1
       common-tags: 1.8.2
       fast-json-stable-stringify: 2.1.0
       fs-extra: 9.1.0
       glob: 7.2.3
       lodash: 4.17.21
       pretty-bytes: 5.6.0
-      rollup: 2.79.1
-      rollup-plugin-terser: 7.0.2_rollup@2.79.1
+      rollup: 2.79.2
+      rollup-plugin-terser: 7.0.2_rollup@2.79.2
       source-map: 0.8.0-beta.0
       stringify-object: 3.3.0
       strip-comments: 2.0.1
@@ -18098,7 +18109,7 @@ packages:
     resolution: {integrity: sha512-R2IkwDokbtHUE4Kus8pKO5+VkPHD2oqTgl+XJwh4zbF1HyjAbgNmK/FneZHVU7p03XUt9ICfuGDYISWG9qV/CQ==}
     dev: true
 
-  /workbox-webpack-plugin/6.6.0_webpack@5.92.1:
+  /workbox-webpack-plugin/6.6.0_webpack@5.95.0:
     resolution: {integrity: sha512-xNZIZHalboZU66Wa7x1YkjIqEy1gTR+zPM+kjrYJzqN7iurYZBctBLISyScjhkJKYuRrZUP0iqViZTh8rS0+3A==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
@@ -18107,7 +18118,7 @@ packages:
       fast-json-stable-stringify: 2.1.0
       pretty-bytes: 5.6.0
       upath: 1.2.0
-      webpack: 5.92.1
+      webpack: 5.95.0
       webpack-sources: 1.4.3
       workbox-build: 6.6.0
     transitivePeerDependencies:
@@ -18254,9 +18265,10 @@ packages:
   /yaml/1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
+    dev: true
 
-  /yaml/2.4.5:
-    resolution: {integrity: sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==}
+  /yaml/2.6.0:
+    resolution: {integrity: sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==}
     engines: {node: '>= 14'}
     hasBin: true
     dev: true
@@ -18308,7 +18320,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       cliui: 7.0.4
-      escalade: 3.1.2
+      escalade: 3.2.0
       get-caller-file: 2.0.5
       require-directory: 2.1.1
       string-width: 4.2.3
@@ -18321,7 +18333,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       cliui: 8.0.1
-      escalade: 3.1.2
+      escalade: 3.2.0
       get-caller-file: 2.0.5
       require-directory: 2.1.1
       string-width: 4.2.3
@@ -18340,20 +18352,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /z-schema/5.0.5:
-    resolution: {integrity: sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==}
-    engines: {node: '>=8.0.0'}
-    hasBin: true
-    dependencies:
-      lodash.get: 4.4.2
-      lodash.isequal: 4.5.0
-      validator: 13.12.0
-    optionalDependencies:
-      commander: 9.5.0
-    dev: true
-
-  /zustand/4.5.4_djzcoonmr6xkxvxv5wbacldipi:
-    resolution: {integrity: sha512-/BPMyLKJPtFEvVL0E9E9BTUM63MNyhPGlvxk1XjrfWTUlV+BR8jufjsovHzrtR6YNcBEcL7cMHovL1n9xHawEg==}
+  /zustand/4.5.5_esssjoahjgjy6wmb4kavvr2kri:
+    resolution: {integrity: sha512-+0PALYNJNgK6hldkgDq2vLrw5f6g/jCInz52n9RTpropGgeAf/ioFUCdtsjCqu4gNhW9D01rUQBROoRjdzyn2Q==}
     engines: {node: '>=12.7.0'}
     peerDependencies:
       '@types/react': '>=16.8'
@@ -18367,10 +18367,10 @@ packages:
       react:
         optional: true
     dependencies:
-      '@types/react': 18.3.3
+      '@types/react': 18.3.12
       immer: 9.0.6
       react: 18.3.1
-      use-sync-external-store: 1.2.0_react@18.3.1
+      use-sync-external-store: 1.2.2_react@18.3.1
 
   /zwitch/1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}

--- a/packages/templates/cra-template-desktop-viewer/template/.env
+++ b/packages/templates/cra-template-desktop-viewer/template/.env
@@ -1,5 +1,5 @@
 # ---- Configuration ----
-ITWIN_VIEWER_SCOPE ="imodelaccess:read offline_access imodels:read itwins:read realitydata:read"
+ITWIN_VIEWER_SCOPE ="itwin-platform offline_access"
 ITWIN_VIEWER_CLIENT_ID=""
 ITWIN_VIEWER_REDIRECT_URI=""
 ITWIN_VIEWER_ISSUER_URL="https://ims.bentley.com"

--- a/packages/templates/cra-template-desktop-viewer/template/README.md
+++ b/packages/templates/cra-template-desktop-viewer/template/README.md
@@ -12,12 +12,7 @@ ITWIN_VIEWER_CLIENT_ID="native-xxxxxxxx"
 
 - You should generate a [client](https://developer.bentley.com/register/) to get started. The client that you generate should be for a desktop app and use the following list of apis. You can add the default redirect uri (http://localhost:3000/signin-callback).
 
-- Scopes expected by the viewer are:
-
-  - **Visualization**: `imodelaccess:read`
-  - **iModels**: `imodels:read`
-  - **Reality Data**: `realitydata:read`
-  - **Administration**: `itwins:read`
+- Viewer expects the `itwin-platform` scope to be set.
 
 ## Available Scripts
 

--- a/packages/templates/cra-template-web-viewer/template/.env
+++ b/packages/templates/cra-template-web-viewer/template/.env
@@ -2,7 +2,7 @@
 IMJS_AUTH_CLIENT_CLIENT_ID = ""
 IMJS_AUTH_CLIENT_REDIRECT_URI = ""
 IMJS_AUTH_CLIENT_LOGOUT_URI = ""
-IMJS_AUTH_CLIENT_SCOPES ="imodelaccess:read imodels:read realitydata:read"
+IMJS_AUTH_CLIENT_SCOPES ="itwin-platform"
 IMJS_AUTH_AUTHORITY="https://ims.bentley.com"
 
 # ---- Test ids ----

--- a/packages/templates/cra-template-web-viewer/template/README.md
+++ b/packages/templates/cra-template-web-viewer/template/README.md
@@ -11,16 +11,12 @@ Prior to running the app, you will need to add OIDC client configuration to the 
 IMJS_AUTH_CLIENT_CLIENT_ID=""
 IMJS_AUTH_CLIENT_REDIRECT_URI=""
 IMJS_AUTH_CLIENT_LOGOUT_URI=""
-IMJS_AUTH_CLIENT_SCOPES =""
+IMJS_AUTH_CLIENT_SCOPES=""
 ```
 
 - You can generate a [test client](https://developer.bentley.com/tutorials/web-application-quick-start/#3-register-an-application) to get started.
 
-- Scopes expected by the viewer are:
-
-  - **Visualization**: `imodelaccess:read`
-  - **iModels**: `imodels:read`
-  - **Reality Data**: `realitydata:read`
+- Viewer expects the `itwin-platform` scope to be set.
 
 - The application will use the path of the redirect URI to handle the redirection, it must simply match what is defined in your client.
 


### PR DESCRIPTION
From time to time I need a viewer app with latest and greatest version of iTwinJs. The easiest way to do that is through CRA. I sometimes test it with other packages, like [Grouping & Mapping Widget](https://www.npmjs.com/package/@itwin/grouping-mapping-widget), which require scopes that are not present in the template. Some time ago iTwin Platform consolidated all scopes into one - `itwin-platform`.

This PR changes templates to only have that scope in the .env file, requiring 1 less change to use the fresh application.