### PR TITLE
Remove StrictMode Wrapper

### DIFF
--- a/common/changes/@itwin/cra-template-web-viewer/mike-remove-strict-mode_2024-11-18-21-41.json
+++ b/common/changes/@itwin/cra-template-web-viewer/mike-remove-strict-mode_2024-11-18-21-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/cra-template-web-viewer",
+      "comment": "Remove React.StrictMode Wrapper",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/cra-template-web-viewer"
+}

--- a/packages/apps/desktop-viewer-test/.env
+++ b/packages/apps/desktop-viewer-test/.env
@@ -1,5 +1,5 @@
 # ---- Configuration ----
-ITWIN_VIEWER_SCOPE ="imodelaccess:read offline_access imodels:read realitydata:read itwins:read"
+ITWIN_VIEWER_SCOPE ="itwin-platform"
 ITWIN_VIEWER_CLIENT_ID=""
 ITWIN_VIEWER_REDIRECT_URI=""
 ITWIN_VIEWER_ISSUER_URL="https://ims.bentley.com"

--- a/packages/apps/desktop-viewer-test/.env
+++ b/packages/apps/desktop-viewer-test/.env
@@ -1,5 +1,5 @@
 # ---- Configuration ----
-ITWIN_VIEWER_SCOPE ="itwin-platform"
+ITWIN_VIEWER_SCOPE ="itwin-platform offline_access"
 ITWIN_VIEWER_CLIENT_ID=""
 ITWIN_VIEWER_REDIRECT_URI=""
 ITWIN_VIEWER_ISSUER_URL="https://ims.bentley.com"

--- a/packages/apps/desktop-viewer-test/src/frontend/index.tsx
+++ b/packages/apps/desktop-viewer-test/src/frontend/index.tsx
@@ -27,11 +27,7 @@ const viewerFrontendMain = async () => {
 
   document.documentElement.classList.add(`iui-theme-dark`);
 
-  root.render(
-    <React.StrictMode>
-      <App />
-    </React.StrictMode>
-  );
+  root.render(<App />);
 };
 
 viewerFrontendMain(); // eslint-disable-line @typescript-eslint/no-floating-promises

--- a/packages/templates/cra-template-web-viewer/template/src/index.tsx
+++ b/packages/templates/cra-template-web-viewer/template/src/index.tsx
@@ -44,11 +44,7 @@ const redirectUrl = new URL(process.env.IMJS_AUTH_CLIENT_REDIRECT_URI);
 if (redirectUrl.pathname === window.location.pathname) {
   Auth.handleSigninCallback().catch(console.error);
 } else {
-  root.render(
-    <React.StrictMode>
-      <App />
-    </React.StrictMode>
-  );
+  root.render(<App />);
 }
 
 // If you want your app to work offline and load faster, you can change


### PR DESCRIPTION
Removes the <React.StrictMode> wrapper from the desktop-viewer-test app, and the [Create React App template](https://www.npmjs.com/package/@itwin/cra-template-desktop-viewer).

The StrictMode Wrapper causes iModels API calls to stall, resulting in endless loading of iModels. 

Also, Updates the scopes in the Desktop-viewer-test env Template.

Related Issues:
https://github.com/iTwin/viewer/issues/336
https://github.com/iTwin/admin-components-react/issues/128