### PR TITLE
mitigate audit GHSA-rhx6-c78j-4q9w

### DIFF
--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -5,7 +5,7 @@
       "body-parser@<1.20.3": "^1.20.3",
       "braces": "^3.0.3",
       "path-to-regexp@>=0.2.0": "^8.0.0",
-      "path-to-regexp@<0.1.10": "^0.1.10",
+      "path-to-regexp@<0.1.12": "^0.1.12",
       "postcss": "^8.4.31",
       "http-proxy-middleware": "^2.0.7",
       "rollup": "^2.79.2",

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -4,7 +4,7 @@ overrides:
   body-parser@<1.20.3: ^1.20.3
   braces: ^3.0.3
   path-to-regexp@>=0.2.0: ^8.0.0
-  path-to-regexp@<0.1.10: ^0.1.10
+  path-to-regexp@<0.1.12: ^0.1.12
   postcss: ^8.4.31
   http-proxy-middleware: ^2.0.7
   rollup: ^2.79.2
@@ -9477,7 +9477,7 @@ packages:
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
-      path-to-regexp: 0.1.10
+      path-to-regexp: 0.1.12
       proxy-addr: 2.0.7
       qs: 6.11.0
       range-parser: 1.2.1
@@ -13462,8 +13462,8 @@ packages:
       minipass: 7.1.2
     dev: true
 
-  /path-to-regexp/0.1.10:
-    resolution: {integrity: sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==}
+  /path-to-regexp/0.1.12:
+    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
 
   /path-to-regexp/8.1.0:
     resolution: {integrity: sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ==}


### PR DESCRIPTION
We're stuck overriding vulnerable dependency versions until we move off CRA.