### PR TITLE
[Fix] : Template issue

### DIFF
--- a/common/changes/@itwin/cra-template-web-viewer/pankhur94-template-bug-fix_2025-05-16-22-06.json
+++ b/common/changes/@itwin/cra-template-web-viewer/pankhur94-template-bug-fix_2025-05-16-22-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/cra-template-web-viewer",
+      "comment": "remove direct dep @itwin/presentation-core-interop and add override for metadependencies to 1.3.1",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/cra-template-web-viewer"
+}

--- a/packages/templates/cra-template-web-viewer/template.json
+++ b/packages/templates/cra-template-web-viewer/template.json
@@ -27,7 +27,6 @@
       "@itwin/presentation-common": "^4.7.3",
       "@itwin/presentation-components": "^5.0.0",
       "@itwin/presentation-frontend": "^4.7.3",
-      "@itwin/presentation-core-interop": "^1.3.0",
       "@itwin/presentation-shared": "^1.2.0",
       "@itwin/unified-selection": "~1.1.2",
       "@itwin/unified-selection-react": "^1.0.0",
@@ -68,6 +67,9 @@
       "last 4 edge version",
       "not dead",
       "not <0.2%"
-    ]
+    ],
+    "overrides": {
+      "@itwin/presentation-core-interop": "1.3.1"
+    }
   }
 }


### PR DESCRIPTION
 Removes `@itwin/presentation-core-interop` as direct dep and override for metadependencies to 1.3.1.