### PR TITLE
[ Fix ]: Desktop viewer template fix

### DIFF
--- a/common/changes/@itwin/cra-template-desktop-viewer/pankhur94-desktop-viewer-template-fix_2025-05-26-15-10.json
+++ b/common/changes/@itwin/cra-template-desktop-viewer/pankhur94-desktop-viewer-template-fix_2025-05-26-15-10.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/cra-template-desktop-viewer",
-      "comment": "remove direct dep @itwin/presentation-core-interop and add override for metadependencies to 1.3.1",
+      "comment": "remove direct dep @itwin/presentation-core-interop and add override for transient dependencies to 1.3.1",
       "type": "patch"
     }
   ],

--- a/common/changes/@itwin/cra-template-desktop-viewer/pankhur94-desktop-viewer-template-fix_2025-05-26-15-10.json
+++ b/common/changes/@itwin/cra-template-desktop-viewer/pankhur94-desktop-viewer-template-fix_2025-05-26-15-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/cra-template-desktop-viewer",
+      "comment": "remove direct dep @itwin/presentation-core-interop and add override for metadependencies to 1.3.1",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/cra-template-desktop-viewer"
+}

--- a/packages/templates/cra-template-desktop-viewer/template.json
+++ b/packages/templates/cra-template-desktop-viewer/template.json
@@ -42,7 +42,6 @@
       "@itwin/presentation-common": "^4.7.3",
       "@itwin/presentation-components": "^5.0.0",
       "@itwin/presentation-frontend": "^4.7.3",
-      "@itwin/presentation-core-interop": "^1.3.0",
       "@itwin/presentation-shared": "^1.2.0",
       "@itwin/unified-selection": "~1.1.2",
       "@itwin/unified-selection-react": "^1.0.0",
@@ -80,6 +79,9 @@
     },
     "browserslist": [
       "last 1 electron version"
-    ]
+    ],
+    "overrides": {
+      "@itwin/presentation-core-interop":"1.3.1"
+    }
   }
 }


### PR DESCRIPTION
- Fixed in web-viewer in [this](https://github.com/iTwin/viewer/pull/361).
- Removes @itwin/presentation-core-interop as dependency and overrides with version 1.3.1.