### PR TITLE
Add back view overlay support

### DIFF
--- a/common/changes/@itwin/viewer-react/fix-supply-view-overlay_2025-09-01-08-43.json
+++ b/common/changes/@itwin/viewer-react/fix-supply-view-overlay_2025-09-01-08-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/viewer-react",
+      "comment": "Fixed view overlay rendering of Viewport component.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/viewer-react"
+}

--- a/packages/apps/desktop-viewer-test/vite.config.ts
+++ b/packages/apps/desktop-viewer-test/vite.config.ts
@@ -9,7 +9,7 @@ const ENV_PREFIX = "IMJS_";
 export default defineConfig((): UserConfig => {
   return {
     build: {
-      chunkSizeWarningLimit: 7000, // Increase chunk size warning limit to avoid warnings for large chunks
+      chunkSizeWarningLimit: 9000, // Increase chunk size warning limit to avoid warnings for large chunks
     },
     server: {
       port: 3000,

--- a/packages/apps/web-viewer-test/vite.config.ts
+++ b/packages/apps/web-viewer-test/vite.config.ts
@@ -10,7 +10,7 @@ const ENV_PREFIX = "IMJS_";
 export default defineConfig(() => {
   return {
     build: {
-      chunkSizeWarningLimit: 7000, // Increase chunk size warning limit to avoid warnings for large chunks
+      chunkSizeWarningLimit: 8000, // Increase chunk size warning limit to avoid warnings for large chunks
     },
     plugins: [
       react(),

--- a/packages/modules/viewer-react/src/components/app-ui/providers/DefaultContentGroupProvider.tsx
+++ b/packages/modules/viewer-react/src/components/app-ui/providers/DefaultContentGroupProvider.tsx
@@ -10,6 +10,7 @@ import {
   StandardContentLayouts,
   UiFramework,
 } from "@itwin/appui-react";
+import type { ScreenViewport } from "@itwin/core-frontend";
 import { ViewportComponent } from "@itwin/imodel-components-react";
 import { viewWithUnifiedSelection } from "@itwin/presentation-components";
 import React from "react";
@@ -67,21 +68,58 @@ export class DefaultContentGroupProvider extends ContentGroupProvider {
             ? "iTwinViewer.UnifiedSelectionViewport"
             : "iTwinViewer.Viewport",
           classId: "",
-          content: this._isUsingDeprecatedSelectionManager ? (
-            <UnifiedSelectionViewport
+          content: (
+            <ViewportWithOverlay
               viewState={viewState}
               imodel={iModelConnection}
-              controlId={"iTwinViewer.UnifiedSelectionViewportControl"}
-            />
-          ) : (
-            <ViewportComponent
-              viewState={viewState}
-              imodel={iModelConnection}
-              controlId={"iTwinViewer.ViewportControl"}
+              deprecatedSelectionManager={
+                this._isUsingDeprecatedSelectionManager
+              }
+              supplyViewOverlay={this._viewportOptions?.supplyViewOverlay}
             />
           ),
         },
       ],
     });
   }
+}
+
+type ViewportComponentProps = React.ComponentProps<typeof ViewportComponent>;
+
+interface ViewportWithOverlayProps
+  extends Pick<ViewportComponentProps, "viewState" | "imodel">,
+    Pick<ViewerViewportControlOptions, "supplyViewOverlay"> {
+  deprecatedSelectionManager?: boolean;
+}
+
+function ViewportWithOverlay(props: ViewportWithOverlayProps) {
+  const { supplyViewOverlay } = props;
+
+  const [viewport, setViewport] = React.useState<ScreenViewport | undefined>(
+    undefined
+  );
+  const viewOverlay = React.useMemo(() => {
+    if (!viewport || !supplyViewOverlay) {return null;}
+    return supplyViewOverlay(viewport);
+  }, [viewport, supplyViewOverlay]);
+  return (
+    <>
+      {props.deprecatedSelectionManager ? (
+        <UnifiedSelectionViewport
+          viewState={props.viewState}
+          imodel={props.imodel}
+          controlId={"iTwinViewer.UnifiedSelectionViewportControl"}
+          viewportRef={setViewport}
+        />
+      ) : (
+        <ViewportComponent
+          viewState={props.viewState}
+          imodel={props.imodel}
+          controlId={"iTwinViewer.ViewportControl"}
+          viewportRef={setViewport}
+        />
+      )}
+      {viewOverlay}
+    </>
+  );
 }

--- a/packages/modules/viewer-react/src/components/app-ui/providers/DefaultContentGroupProvider.tsx
+++ b/packages/modules/viewer-react/src/components/app-ui/providers/DefaultContentGroupProvider.tsx
@@ -99,7 +99,9 @@ function ViewportWithOverlay(props: ViewportWithOverlayProps) {
     undefined
   );
   const viewOverlay = React.useMemo(() => {
-    if (!viewport || !supplyViewOverlay) {return null;}
+    if (!viewport || !supplyViewOverlay) {
+      return null;
+    }
     return supplyViewOverlay(viewport);
   }, [viewport, supplyViewOverlay]);
   return (

--- a/packages/templates/desktop/vite.config.mts
+++ b/packages/templates/desktop/vite.config.mts
@@ -8,7 +8,7 @@ const ENV_PREFIX = "IMJS_";
 export default defineConfig((): UserConfig => {
   return {
     build: {
-      chunkSizeWarningLimit: 7000, // Increase chunk size warning limit to avoid warnings for large chunks
+      chunkSizeWarningLimit: 9000, // Increase chunk size warning limit to avoid warnings for large chunks
     },
     server: {
       port: 3000,

--- a/packages/templates/web/vite.config.mts
+++ b/packages/templates/web/vite.config.mts
@@ -8,7 +8,7 @@ const ENV_PREFIX = "IMJS_";
 export default defineConfig(() => {
   return {
     build: {
-      chunkSizeWarningLimit: 7000, // Increase chunk size warning limit to avoid warnings for large chunks
+      chunkSizeWarningLimit: 8000, // Increase chunk size warning limit to avoid warnings for large chunks
     },
     plugins: [
       react(),


### PR DESCRIPTION
## Changes

This PR fixes #390 by correctly rendering a view overlay based on `viewportOptions.supplyViewOverlay` property which was supported out of the box when using now [deprecated `ConfigurableUiControl`](https://github.com/iTwin/appui/releases/tag/release%2F4.16.0) APIs (see #342).

Potential future work (we can work on these once/if a use-case is identified):
 
- [ ] Support for [default view overlays](https://www.itwinjs.org/reference/appui-react/contentview/defaultviewoverlay/)
- [ ] Conditionally render the overlay based on (now deprecated) [viewOverlayDisplay](https://www.itwinjs.org/reference/appui-react/state/configurableuistate/)

## Testing

Tested manually in `BlankConnectionHome.tsx` of `web-viewer-test`:

```tsx
// Added to `Viewer` element
viewportOptions={{
  supplyViewOverlay: () => <div style={{position: "absolute", bottom: 12, justifySelf: "center" }}>Custom view overlay</div>
}}
```

Verified, that the resulting DOM structure matches the original `ConfigurableUiControl` structure (before #342), where overlay is displayed as a sibling of a viewport.